### PR TITLE
Disable crabcache storage for developers

### DIFF
--- a/kubernetes/cmsweb/services/crabcache.yaml
+++ b/kubernetes/cmsweb/services/crabcache.yaml
@@ -73,8 +73,8 @@ spec:
           mountPath: /etc/grid-security/hostcert.pem
           readOnly: true 
         # TMP: use cinder storage for time being
-#        - name: crabcache-storage
-#          mountPath: /data/srv/state/crabcache/files
+#PROD#        - name: crabcache-storage
+#PROD#          mountPath: /data/srv/state/crabcache/files
 #PROD#  - name: crabcache-storage
 #PROD#    mountPath: /data/srv/state/crabcache/files
 #PROD#  - name: logs-cephfs
@@ -95,9 +95,9 @@ spec:
             path: /etc/grid-security/hostcert.pem
             type: File
       # TMP: use ciner storage for time being
-#      - name: crabcache-storage
-#        persistentVolumeClaim:
-#            claimName: crabcache-claim
+#PROD#      - name: crabcache-storage
+#PROD#        persistentVolumeClaim:
+#PROD#            claimName: crabcache-claim
 #PROD#- name: crabcache-storage-cephfs
 #PROD#  persistentVolumeClaim:
 #PROD#      claimName: crabcache-cephfs-claim

--- a/kubernetes/cmsweb/services/crabcache.yaml
+++ b/kubernetes/cmsweb/services/crabcache.yaml
@@ -73,8 +73,8 @@ spec:
           mountPath: /etc/grid-security/hostcert.pem
           readOnly: true 
         # TMP: use cinder storage for time being
-#PROD#        - name: crabcache-storage
-#PROD#          mountPath: /data/srv/state/crabcache/files
+#PROD#  - name: crabcache-storage
+#PROD#    mountPath: /data/srv/state/crabcache/files
 #PROD#  - name: crabcache-storage
 #PROD#    mountPath: /data/srv/state/crabcache/files
 #PROD#  - name: logs-cephfs
@@ -95,9 +95,9 @@ spec:
             path: /etc/grid-security/hostcert.pem
             type: File
       # TMP: use ciner storage for time being
-#PROD#      - name: crabcache-storage
-#PROD#        persistentVolumeClaim:
-#PROD#            claimName: crabcache-claim
+#PROD#- name: crabcache-storage
+#PROD#      persistentVolumeClaim:
+#PROD#      claimName: crabcache-claim
 #PROD#- name: crabcache-storage-cephfs
 #PROD#  persistentVolumeClaim:
 #PROD#      claimName: crabcache-cephfs-claim

--- a/kubernetes/cmsweb/services/crabcache.yaml
+++ b/kubernetes/cmsweb/services/crabcache.yaml
@@ -73,8 +73,8 @@ spec:
           mountPath: /etc/grid-security/hostcert.pem
           readOnly: true 
         # TMP: use cinder storage for time being
-        - name: crabcache-storage
-          mountPath: /data/srv/state/crabcache/files
+#        - name: crabcache-storage
+#          mountPath: /data/srv/state/crabcache/files
 #PROD#  - name: crabcache-storage
 #PROD#    mountPath: /data/srv/state/crabcache/files
 #PROD#  - name: logs-cephfs
@@ -95,9 +95,9 @@ spec:
             path: /etc/grid-security/hostcert.pem
             type: File
       # TMP: use ciner storage for time being
-      - name: crabcache-storage
-        persistentVolumeClaim:
-            claimName: crabcache-claim
+#      - name: crabcache-storage
+#        persistentVolumeClaim:
+#            claimName: crabcache-claim
 #PROD#- name: crabcache-storage-cephfs
 #PROD#  persistentVolumeClaim:
 #PROD#      claimName: crabcache-cephfs-claim


### PR DESCRIPTION
@vkuznet 

As per request of @belforte , I have disabled crabcache storage parameters in crabcache.yaml file. So that developers don't find errors during their deployment of their services.