### PR TITLE
Change the max size of HTTP POST sent to the GUI

### DIFF
--- a/kubernetes/cmsweb/ingress/ing-dqm.yaml
+++ b/kubernetes/cmsweb/ingress/ing-dqm.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: dqm
   annotations:
     kubernetes.io/ingress.class: nginx
+    # Allow HTTP POST of 10GB (to allow root file uploads)
+    nginx.ingress.kubernetes.io/proxy-body-size: 10000m
     # restrict access to this ingress controller from specific IPs
     # https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#whitelist-source-range
     nginx.ingress.kubernetes.io/whitelist-source-range: 137.138.31.19,137.138.158.91,137.138.33.200,137.138.54.48


### PR DESCRIPTION
We are trying to upload files to the DQM GUI for testing, however getting error: ERROR HTTP Error 413: Request Entity Too Large

After changing this parameter on the test cluster https://cmsweb-test2.cern.ch/dqm/dev/  we confirmed it now works. Therefore we would like to have this configuration to allow the upload of Root files which can be up to 1 GB but just to be safe 10GB would make the trick.