### PR TITLE
Increase Memory requirements for reqmon and reqmon-tasks PODs

### DIFF
--- a/kubernetes/cmsweb/services/reqmon-tasks.yaml
+++ b/kubernetes/cmsweb/services/reqmon-tasks.yaml
@@ -41,7 +41,7 @@ spec:
             memory: "256Mi"
             cpu: "300m"
           limits:
-            memory: "3Gi"
+            memory: "8Gi"
             cpu: "1000m"
         command:
         - /bin/bash

--- a/kubernetes/cmsweb/services/reqmon.yaml
+++ b/kubernetes/cmsweb/services/reqmon.yaml
@@ -61,7 +61,7 @@ spec:
             memory: "256Mi"
             cpu: "300m"
           limits:
-            memory: "3Gi"
+            memory: "8Gi"
             cpu: "1000m"
         ports:
         - containerPort: 8249


### PR DESCRIPTION
Increase memory limit to 8GB.

I was going to increase the minimum required memory from `256Mi` to `1Gi`, but I'm not sure about the impact it will have on the test clusters...

@muhammadimranfarooqi @vkuznet is kubernetes smart enough to only schedule such PODs in minions providing up to `            memory: "8Gi"` memory? Otherwise, POD recreation will be more common than we expected.