### PR TITLE
Set more realistic resource requirements for WMCore services

### DIFF
--- a/kubernetes/cmsweb/services/couchdb.yaml
+++ b/kubernetes/cmsweb/services/couchdb.yaml
@@ -68,11 +68,11 @@ spec:
               - sudo chmod 0777 /data/srv/state/couchdb/database; sudo chown _couchdb:_couchdb /data/srv/state/couchdb/database
         resources:
           requests:
-            memory: "256Mi"
-            cpu: "500m"
+            memory: "512Mi"
+            cpu: "1000m"
           limits:
             memory: "3Gi"
-            cpu: "2000m"
+            cpu: "4000m"
         ports:
         - containerPort: 5984
           protocol: TCP

--- a/kubernetes/cmsweb/services/reqmgr2-tasks.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2-tasks.yaml
@@ -52,8 +52,8 @@ spec:
           initialDelaySeconds: 300
         resources:
           requests:
-            memory: "256Mi"
-            cpu: "300m"
+            memory: "512Mi"
+            cpu: "500m"
           limits:
             memory: "3Gi"
             cpu: "1000m"

--- a/kubernetes/cmsweb/services/reqmgr2.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2.yaml
@@ -79,7 +79,7 @@ spec:
           periodSeconds: 10
         resources:
           requests:
-            memory: "256Mi"
+            memory: "512Mi"
             cpu: "300m"
           limits:
             memory: "3Gi"

--- a/kubernetes/cmsweb/services/reqmon-tasks.yaml
+++ b/kubernetes/cmsweb/services/reqmon-tasks.yaml
@@ -48,7 +48,7 @@ spec:
           periodSeconds: 10
         resources:
           requests:
-            memory: "256Mi"
+            memory: "5Gi"
             cpu: "300m"
           limits:
             memory: "8Gi"

--- a/kubernetes/cmsweb/services/reqmon.yaml
+++ b/kubernetes/cmsweb/services/reqmon.yaml
@@ -67,6 +67,8 @@ spec:
           initialDelaySeconds: 300
           periodSeconds: 10
         resources:
+          # This service also relies on the DataCache thread, so the
+          # memory footprint can be very high
           requests:
             memory: "5Gi"
             cpu: "1"

--- a/kubernetes/cmsweb/services/t0_reqmon-tasks.yaml
+++ b/kubernetes/cmsweb/services/t0_reqmon-tasks.yaml
@@ -57,7 +57,7 @@ spec:
           periodSeconds: 10
         resources:
           requests:
-            memory: "256Mi"
+            memory: "512Mi"
             cpu: "300m"
           limits:
             memory: "3Gi"

--- a/kubernetes/cmsweb/services/t0_reqmon.yaml
+++ b/kubernetes/cmsweb/services/t0_reqmon.yaml
@@ -72,7 +72,7 @@ spec:
           periodSeconds: 10
         resources:
           requests:
-            memory: "256Mi"
+            memory: "512Mi"
             cpu: "300m"
           limits:
             memory: "3Gi"

--- a/kubernetes/cmsweb/services/workqueue.yaml
+++ b/kubernetes/cmsweb/services/workqueue.yaml
@@ -68,8 +68,8 @@ spec:
           periodSeconds: 10
         resources:
           requests:
-            memory: "256Mi"
-            cpu: "300m"
+            memory: "512Mi"
+            cpu: "500m"
           limits:
             memory: "3Gi"
             cpu: "1000m"


### PR DESCRIPTION
I compared the resource requirements from this yaml files with what is actually used in the CMSWEB backends, and I came up with these numbers (for a some cases, I added a safe margin).

I also think that alertscollector is no longer used: https://github.com/dmwm/CMSKubernetes/blob/master/kubernetes/cmsweb/services/alertscollector.yaml
and workqueue-tasks (AFAIR we put it all under workqueue, right Imran?): https://github.com/dmwm/CMSKubernetes/blob/master/kubernetes/cmsweb/services/workqueue-tasks.yaml

Please let me know if you want me to delete them as well in this PR.

@muhammadimranfarooqi @vkuznet please review
FYI @todor-ivanov @khurtado  