### PR TITLE
Add runregistry service

### DIFF
--- a/kubernetes/cmsweb/services/runregistry.yaml
+++ b/kubernetes/cmsweb/services/runregistry.yaml
@@ -1,0 +1,347 @@
+# There are four components of runregistry:
+#   1. The server required to serve the front end (server rendered html using next.js)
+#   2. The API server
+#   3. The Workers (in charge of processing jsons, and fetching new runs, and interacting with the GUI) (not exposed to the outer world)
+#   4. A redis client in charge of providing a queue system for the workers to know when to operate and where to publish results
+
+# There are two environments for runregistry
+#   1. Production environment
+#   2. Staging environmnent
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: rr-prod-fe
+  namespace: runregistry
+spec:
+  selector:
+    app: rr-prod-fe
+  ports:
+    - port: 8350
+      targetPort: 7001
+      name: rr-prod-fe
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  labels:
+    app: rr-prod-fe
+  name: rr-prod-fe
+  namespace: runregistry
+spec:
+  selector:
+    matchLabels:
+      app: rr-prod-fe
+  replicas: 1 #PROD# 1
+  template:
+    metadata:
+      labels:
+        app: rr-prod-fe
+    spec:
+      containers:
+        - image: cmssw/runregistry-frontend:0.1-cmsweb
+          name: rr-prod-fe
+          tty: true
+          stdin: true
+          env:
+            - name: NODE_ENV
+              value: production
+            - name: ENV
+              value: kubernetes
+          resources:
+            requests:
+              memory: '256Mi'
+              cpu: '300m'
+            limits:
+              memory: '3Gi'
+              cpu: '1000m'
+          ports:
+            - containerPort: 7001
+              protocol: TCP
+              name: rr-prod-fe
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: rr-prod-api
+  namespace: runregistry
+spec:
+  selector:
+    app: rr-prod-api
+  ports:
+    - port: 8351
+      targetPort: 9500
+      name: rr-prod-api
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  labels:
+    app: rr-prod-api
+  name: rr-prod-api
+  namespace: runregistry
+spec:
+  selector:
+    matchLabels:
+      app: rr-prod-api
+  replicas: 1 #PROD# 1
+  template:
+    metadata:
+      labels:
+        app: rr-prod-api
+    spec:
+      containers:
+        - image: cmssw/runregistry-backend:0.1-cmsweb
+          name: rr-prod-api
+          tty: true # Not sure
+          stdin: true # Not sure
+          env:
+            - name: NODE_ENV
+              value: production
+            - name: ENV
+              value: prod_kubernetes
+          resources:
+            requests:
+              memory: '256Mi'
+              cpu: '300m'
+            limits:
+              memory: '3Gi'
+              cpu: '1000m'
+          ports:
+            - containerPort: 9500
+              protocol: TCP
+              name: rr-prod-api
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: rr-prod-redis
+  namespace: runregistry
+spec:
+  selector:
+    app: rr-prod-redis
+  ports:
+    - port: 8352
+      targetPort: 6379
+      name: rr-prod-redis
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  labels:
+    app: rr-prod-redis
+  name: rr-prod-redis
+  namespace: runregistry
+spec:
+  selector:
+    matchLabels:
+      app: rr-prod-redis
+  replicas: 1 #PROD# 1
+  template:
+    metadata:
+      labels:
+        app: rr-prod-redis
+    spec:
+      containers:
+        - image: redis:5.0.7-alpine
+          name: rr-prod-redis
+          tty: true # Not sure
+          stdin: true # Not sure
+          resources:
+            requests:
+              memory: '256Mi'
+              cpu: '30m'
+            limits:
+              memory: '3Gi'
+              cpu: '1000m'
+          ports:
+            - containerPort: 6379
+              protocol: TCP
+              name: rr-prod-redis
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  labels:
+    app: dqmgui-pinging
+  name: dqmgui-pinging
+  namespace: runregistry
+spec:
+  selector:
+    matchLabels:
+      app: dqmgui-pinging
+  replicas: 1 #PROD# 1
+  template:
+    metadata:
+      labels:
+        app: dqmgui-pinging
+    spec:
+      containers:
+        - image: cmssw/runregistry-workers-dqm-gui-pinging:0.1-cmsweb
+          name: dqmgui-pinging
+          tty: true # Not sure
+          stdin: true # Not sure
+          resources:
+            requests:
+              memory: '256Mi'
+              cpu: '50m'
+            limits:
+              memory: '3Gi'
+              cpu: '1000m'
+          ports:
+            - containerPort: 6379
+              protocol: TCP
+              name: dqmgui-pinging
+---
+# DEVELOPMENT
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: rr-dev-fe
+  namespace: runregistry
+spec:
+  selector:
+    app: rr-dev-fe
+  ports:
+    - port: 8357
+      targetPort: 7001
+      name: rr-dev-fe
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  labels:
+    app: rr-dev-fe
+  name: rr-dev-fe
+  namespace: runregistry
+spec:
+  selector:
+    matchLabels:
+      app: rr-dev-fe
+  replicas: 1 #PROD# 1
+  template:
+    metadata:
+      labels:
+        app: rr-dev-fe
+    spec:
+      containers:
+        - image: cmssw/runregistry-frontend:0.1-cmsweb
+          name: rr-dev-fe
+          tty: true # Not sure
+          stdin: true # Not sure
+          env:
+            - name: NODE_ENV
+              value: production
+            - name: ENV
+              value: staging
+          resources:
+            requests:
+              memory: '256Mi'
+              cpu: '100m'
+            limits:
+              memory: '3Gi'
+              cpu: '1000m'
+          ports:
+            - containerPort: 9600
+              protocol: TCP
+              name: rr-dev-fe
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: rr-dev-api
+  namespace: runregistry
+spec:
+  selector:
+    app: rr-dev-api
+  ports:
+    - port: 8354
+      targetPort: 9500
+      name: rr-dev-api
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  labels:
+    app: rr-dev-api
+  name: rr-dev-api
+  namespace: runregistry
+spec:
+  selector:
+    matchLabels:
+      app: rr-dev-api
+  replicas: 1 #PROD# 1
+  template:
+    metadata:
+      labels:
+        app: rr-dev-api
+    spec:
+      containers:
+        - image: cmssw/runregistry-backend:0.1-cmsweb
+          name: rr-dev-api
+          tty: true # Not sure
+          stdin: true # Not sure
+          env:
+            - name: NODE_ENV
+              value: production
+            - name: ENV
+              value: dev_kubernetes
+          resources:
+            requests:
+              memory: '256Mi'
+              cpu: '100m'
+            limits:
+              memory: '3Gi'
+              cpu: '1000m'
+          ports:
+            - containerPort: 9500
+              protocol: TCP
+              name: rr-dev-api
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: rr-dev-redis
+  namespace: runregistry
+spec:
+  selector:
+    app: rr-dev-redis
+  ports:
+    - port: 8356
+      targetPort: 6379
+      name: rr-dev-redis
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  labels:
+    app: rr-dev-redis
+  name: rr-dev-redis
+  namespace: runregistry
+spec:
+  selector:
+    matchLabels:
+      app: rr-dev-redis
+  replicas: 1 #PROD# 1
+  template:
+    metadata:
+      labels:
+        app: rr-dev-redis
+    spec:
+      containers:
+        - image: redis:5.0.7-alpine
+          name: rr-dev-redis
+          tty: true # Not sure
+          stdin: true # Not sure
+          resources:
+            requests:
+              memory: '256Mi'
+              cpu: '100m'
+            limits:
+              memory: '3Gi'
+              cpu: '1000m'
+          ports:
+            - containerPort: 6379
+              protocol: TCP
+              name: rr-dev-redis


### PR DESCRIPTION
This PR attempts to add runregistry services (both development and staging) to the cmsweb-k8s-testbedsrv.cern.ch cluster in order to test it with the new CERN SSO.