### PR TITLE
[cmsmon][alert-int] Using specific image tag on k8s deployment

### DIFF
--- a/kubernetes/monitoring/services/cmsmon-intelligence.yaml
+++ b/kubernetes/monitoring/services/cmsmon-intelligence.yaml
@@ -20,7 +20,7 @@ spec:
           - /data/intelligence
           - -config
           - /etc/secrets/config.json
-          image: cmssw/cmsmon-intelligence:latest
+          image: cmssw/cmsmon-intelligence:20200814
           name: intelligence
           imagePullPolicy: Always
           volumeMounts:


### PR DESCRIPTION
Using a specific tag (instead of latest) will allow to upgrade the service easily and to revert to a previous state if needed.