### PR TITLE
CMSMONIT-261 Edit logstash conf to parse apache log data part

### DIFF
--- a/kubernetes/cmsweb/monitoring/logstash.conf
+++ b/kubernetes/cmsweb/monitoring/logstash.conf
@@ -13,7 +13,7 @@ filter {
   if "frontend" in [tags] {
       mutate { replace => { "type" => "frontend" } }
       grok {
-        match => { "message" => '\[%{HTTPDATE:tstamp}\] %{DATA:frontend} %{IPORHOST:clientip} "%{WORD:method} %{NOTSPACE:request} %{DATA:httpversion}" %{NUMBER:code:int} \[data:.*\] \[auth: %{DATA:tls} %{DATA:crypto} "%{DATA:dn}".*\] \[ref: "%{DATA}.*" "%{DATA:client}" \]' }
+        match => { "message" => '\[%{HTTPDATE:tstamp}\] %{DATA:frontend} %{IPORHOST:clientip} "%{WORD:method} %{NOTSPACE:request} %{DATA:httpversion}" %{NUMBER:code:int} \[data: %{NUMBER:bytes_sent:int} in %{NUMBER:bytes_received:int} out %{NUMBER:body_size:int} body %{NUMBER:time_spent_ms:int} us \] \[auth: %{DATA:tls} %{DATA:crypto} "%{DATA:dn}".*\] \[ref: "%{DATA}.*" "%{DATA:client}" \]' }
       }
       grok { match => { "request" => '/%{WORD:system}%{UNIXPATH:uri_path}%{URIPARAM:uri_params}?' } }
       if [uri_params] {
@@ -166,7 +166,7 @@ output {
           format => "message"
           # for message please use double quotes for string type and no-double
           # quotes for objects, e.g. %{agent} is an object, while "%{dn}" is a string
-          message => '[{"producer": "cmswebk8s", "type": "frontend", "hostname": "%{hostname}", "agent_id": "%{agent_id}", "ephemeral_id": "%{ephemeral_id}", "cmsweb_log": "%{cmsweb_log}", "message": "%{message}", "api": "%{api}", "client": "%{client}", "clientip": "%{clientip}", "code": %{code}, "crypto": "%{crypto}", "date_object": "%{date_object}", "dn": "%{dn}", "frontend": "%{frontend}", "httpversion": "%{httpversion}", "method": "%{method}", "rec_date": "%{rec_date}", "rec_timestamp": %{rec_timestamp}, "request": "%{request}", "system": "%{system}", "tls": "%{tls}", "tstamp": "%{tstamp}", "uri_params": "%{uri_params}", "uri_path": "%{uri_path}"}]'
+          message => '[{"producer": "cmswebk8s", "type": "frontend", "hostname": "%{hostname}", "agent_id": "%{agent_id}", "ephemeral_id": "%{ephemeral_id}", "cmsweb_log": "%{cmsweb_log}", "message": "%{message}", "api": "%{api}", "client": "%{client}", "clientip": "%{clientip}", "code": %{code}, "crypto": "%{crypto}", "date_object": "%{date_object}", "dn": "%{dn}", "frontend": "%{frontend}", "httpversion": "%{httpversion}", "method": "%{method}", "rec_date": "%{rec_date}", "rec_timestamp": %{rec_timestamp}, "request": "%{request}", "system": "%{system}", "tls": "%{tls}", "tstamp": "%{tstamp}", "uri_params": "%{uri_params}", "uri_path": "%{uri_path}", "bytes_sent": "%{bytes_sent}", "bytes_received": "%{bytes_received}", "body_size": "%{body_size}", "time_spent_ms": "%{time_spent_ms}"}]'
       }
   }
   if [type] == "couchdb" {
@@ -204,7 +204,7 @@ output {
   #file {
   #    path => "/tmp/logstash-output.log"
   #}
-  
+
   # example how to enable debugging
   #stdout { codec => rubydebug }
 }


### PR DESCRIPTION
Fields added:
- bytes_sent [int]
- bytes_received [int]
- body_size [int]
- time_spent_ms [int]

I did not use nested field, such as:
```message -> [{ ..., data: {bytes_sent: 11, bytes_received:22, body_size:33, time_spent_ms:44}, ...}]```

Since it is recommended to use flat fields.