### PR TITLE
Add another rucio probe

### DIFF
--- a/docker/rucio-probes/Dockerfile
+++ b/docker/rucio-probes/Dockerfile
@@ -27,6 +27,7 @@ ADD https://raw.githubusercontent.com/ericvaandering/probes/more_sqlalchemy/comm
 # Until Fernando ports to SQLAlchemy and/or merged
 
 ADD https://raw.githubusercontent.com/ericvaandering/probes/hack_obsolete_replicas/common/check_obsolete_replicas /probes/common
+ADD https://raw.githubusercontent.com/nsmith-/probes/hack_replicas/common/check_deletable_replicas /probes/common
 
 
 # TODO: Merge Donata's probes somewhere

--- a/kubernetes/rucio/cms-rucio-probes.yaml
+++ b/kubernetes/rucio/cms-rucio-probes.yaml
@@ -40,6 +40,8 @@ probes:
     interval: 1
   check_obsolete_replicas:
     interval: 10
+  check_deletable_replicas:
+    interval: 10
   check_report_free_space:
     interval: 120
   check_report_used_space:


### PR DESCRIPTION
I installed this probe directly in the running pod, but when @ericvaandering is available he can re-create the docker container and upload (unless someone else has permission to generate and push the containers specified in this repo?)