### PR TITLE
Bug fix rumble

### DIFF
--- a/kubernetes/rumble/rumble.yaml
+++ b/kubernetes/rumble/rumble.yaml
@@ -62,6 +62,10 @@ spec:
         - name: rumble-secrets
           mountPath: /etc/rumble
           readOnly: true
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/sh", "-c", "export > /etc/environment"]
       volumes:
       - name: rumble-secrets
         secret:


### PR DESCRIPTION
@vkuznet  
The problem is that run_rumble.sh script could not get/inherit environment variable $MY_NODE_NAME .
And when I look server.log, spark.driver.host set to empty string. I added postStart lifecycle to write env vars to /etc/environment and now run_rumble.sh can use all defined env vars. I really don't know why I did not get this error before.
New version of rumble.yaml already deployed to cms-monitoring cluster.