### PR TITLE
Update reqmgr2ms run/monitor scripts for ms-ruleCleaner

### DIFF
--- a/docker/reqmgr2ms/monitor.sh
+++ b/docker/reqmgr2ms/monitor.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # start process exporter
-for p in "config-monitor" "config-output" "config-transferor"; do
+for p in "config-monitor" "config-output" "config-transferor" "config-ruleCleaner"; do
     pat="wmc-httpd.*$p"
     pid=`ps axjfwww | grep "$pat" | grep -v grep | grep -v process_monitor | grep -v " 1 " | awk '{print $1}'`
     if [ -n "$pid" ]; then
@@ -15,6 +15,9 @@ for p in "config-monitor" "config-output" "config-transferor"; do
         fi
         if [ "$p" == "config-transferor" ]; then
             address=":18247"
+        fi
+        if [ "$p" == "config-ruleCleaner" ]; then
+            address=":18244"
         fi
         nohup process_exporter -pid $pid -prefix $prefix -address "$address" 2>&1 1>& ${prefix}.log < /dev/null &
     fi

--- a/docker/reqmgr2ms/run.sh
+++ b/docker/reqmgr2ms/run.sh
@@ -50,7 +50,7 @@ fi
 # In case there is at least one configuration file under /etc/secrets, remove
 # the default config files from the image and copy over those from the secrets area
 cdir=/data/srv/current/config/$srv
-cfiles="config-monitor.py config-output.py config-transferor.py"
+cfiles="config-monitor.py config-output.py config-transferor.py config-ruleCleaner.py"
 for fname in $cfiles; do
     if [ -f /etc/secrets/$fname ]; then
         pushd $cdir


### PR DESCRIPTION
While preparing for migrating microservices to the k8s tesbed, I found a couple missing pieces for the ruleCleaner microservice. This would need merged and new Docker images built before we can migrate ruleCleaner to the k8s testbed.

@todor-ivanov since you worked on ruleCleaner can you take a look at these changes to see if they make sense?

Thanks!

Discussion on this started here with @amaltaro: https://github.com/dmwm/deployment/pull/1006