### PR TITLE
Add mongodb docker image for ms-output

### DIFF
--- a/docker/ms-output-mongo/Dockerfile
+++ b/docker/ms-output-mongo/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:latest as go-builder
+MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
+ENV WDIR=/data
+WORKDIR $WDIR
+
+# fetch mongo DB
+ENV MONGODBVER=4.4.2
+ENV MONGOTOOLS=100.2.1
+RUN curl -ksLO https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-debian10-${MONGODBVER}.tgz && curl -ksLO https://fastdl.mongodb.org/tools/db/mongodb-database-tools-debian10-x86_64-${MONGOTOOLS}.tgz
+RUN tar xfz mongodb-linux-x86_64-debian10-${MONGODBVER}.tgz && cp mongodb-linux-x86_64-debian10-${MONGODBVER}/bin/[a-z]* /data && rm -rf mongodb-linux-x86_64-debian10-${MONGODBVER}*
+RUN tar xfz mongodb-database-tools-debian10-x86_64-${MONGOTOOLS}.tgz && cp mongodb-database-tools-debian10-x86_64-${MONGOTOOLS}/bin/[a-z]* /data && rm -rf mongodb-database-tools-debian10-x86_64-${MONGOTOOLS}*
+
+# setup environment
+ENV PATH="/data:${PATH}"
+ADD mongodb.conf $WDIR/mongodb.conf
+ADD run.sh $WDIR/run.sh
+CMD ["./run.sh"]

--- a/docker/ms-output-mongo/mongodb.conf
+++ b/docker/ms-output-mongo/mongodb.conf
@@ -1,0 +1,15 @@
+systemLog:
+   destination: file
+   path: "/data/mongodb/logs/mongod.log"
+   logAppend: true
+   logRotate: rename
+storage:
+   dbPath: "/data/mongodb/wtdb"
+   #engine: "mmapv1"
+   journal:
+      enabled: false
+processManagement:
+   fork: true
+net:
+   bindIp: 0.0.0.0
+   port: 8230

--- a/docker/ms-output-mongo/run.sh
+++ b/docker/ms-output-mongo/run.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# start mongo
+mkdir -p /data/mongodb/{wtdb,logs}
+if [ -f /etc/secrets/mongodb.conf ]; then
+    mongod --config /etc/secrets/mongodb.conf
+else
+    mongod --config /data/mongodb.conf
+fi
+
+# mongostat daemon
+mongostat --port 8230 --quiet --json 60


### PR DESCRIPTION
This PR adds a mongodb image for ms-output and is based off of the das-mongo image. This image will be required when migrating ms-output to the k8s testbed (Jan 2021).