### PR TITLE
Update reqmgr2ms container and service configs for ms-output mongodb

### DIFF
--- a/docker/reqmgr2ms/run.sh
+++ b/docker/reqmgr2ms/run.sh
@@ -86,10 +86,6 @@ for fname in $files; do
 done
 
 # start the service
-# if it is ms-output, then we also need to start mongodb
-if [ -f $cdir/config-output.py ]; then
-    /data/srv/current/config/mongodb/manage start 'I did read documentation'
-fi
 /data/srv/current/config/$srv/manage start 'I did read documentation'
 
 # run monitoring script

--- a/kubernetes/cmsweb/services/reqmgr2ms-output.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-output.yaml
@@ -115,10 +115,10 @@ spec:
 #PROD#    mountPath: /data/srv/logs/reqmgr2ms
         securityContext:
           privileged: true
-#      initContainers:
-#      - name: checkcouchdb
-#        image: busybox:1.28
-#        command: ['sh', '-c', 'until nslookup couchdb.couchdb; do echo "Waiting for couchdb"; sleep 10; done;']
+      initContainers:
+      - name: checkmongodb
+        image: busybox:1.28
+        command: ['sh', '-c', 'until nslookup ms-output-mongo.dmwm; do echo "Waiting for ms-output-mongo"; sleep 10; done;']
       volumes:
       - name: proxy-secrets
         secret:


### PR DESCRIPTION
This PR updates the reqmgr2ms docker image to not start mongodb when used for the ms-output microservice. It also adds a check for the ms-output-mongodb service at reqmgr2ms-output initialization.

