### PR TITLE
add start.sh, stop.sh and addGH.sh

### DIFF
--- a/docker/crabserver/Dockerfile
+++ b/docker/crabserver/Dockerfile
@@ -23,9 +23,10 @@ ENV CMSK8S=$CMSK8S
 # install
 RUN $WDIR/install.sh
 
+COPY addGH.sh monitor.sh run.sh start.sh stop.sh $WDIR/
+RUN ./addGH.sh
+
 # run the service
-ADD run.sh $WDIR/run.sh
-ADD monitor.sh $WDIR/monitor.sh
 USER $USER
 WORKDIR $WDIR
 CMD ["./run.sh"]

--- a/docker/crabserver/addGH.sh
+++ b/docker/crabserver/addGH.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# add GitHub repositories for CRABServer and WMCore
+
+# 0. find the crabserver directory
+CRABServerDir=`realpath /data/srv/current/sw/*/cms/crabserver`
+
+# 1. find which tags were installed
+CRABServerTag=`ls $CRABServerDir`
+export PYTHONPATH=$CRABServerDir/$CRABServerTag/lib/python2.7/site-packages
+WMCoreTag=`python -c "from WMCore import __version__; print __version__"`
+
+# 2. create directories for repositories and clone
+mkdir /data/repos
+pushd /data/repos
+git clone https://github.com/dmwm/CRABServer.git
+git clone https://github.com/dmwm/WMCore.git
+
+# 3. checkout the installed tags
+cd CRABServer
+git checkout $CRABServerTag
+cd ..
+cd WMCore
+git checkout $WMCoreTag
+
+# 4. hack init.sh to point PYTHONPATH to the GH repos when $RUN_FROM_GH is True
+CRABServerInitDir=${CRABServerDir}/${CRABServerTag}/etc/profile.d/
+cd ${CRABServerInitDir}
+cat init.sh | grep -v PYTHONPATH > new-init.sh
+cat << EOF >> new-init.sh
+if [ "\$RUN_FROM_GH" = "True" ]; then
+  export PYTHONPATH=/data/repos/CRABServer/src/python:/data/repos/WMCore/src/python/:\$PYTHONPATH
+else
+EOF
+cat init.sh | grep PYTHONPATH | sed "s/\[/  \[/" >> new-init.sh
+echo "fi" >> new-init.sh
+mv new-init.sh init.sh
+
+# 5. all done, reset cwd and exit
+popd

--- a/docker/crabserver/start.sh
+++ b/docker/crabserver/start.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# run crabserver service
+
+#==== PARSE ARGUMENTS
+helpFunction(){
+  echo -e "\nUsage example: ./start.sh -c | -g [-d]"
+  echo -e "\t-c start current crabserver instance"
+  echo -e "\t-g start crabserver instance from GitHub repo"
+  echo -e "\t-d start crabserver in debug mode. Option can be combined with -c or -g"
+  exit 1
+  }
+
+while getopts ":dDcCgGhH" opt
+do
+    case "$opt" in
+      h|H) helpFunction ;;
+      g|G) MODE="fromGH" ;;
+      c|C) MODE="current" ;;
+      d|D) debug=true ;;
+      * ) echo "Unimplemented option: -$OPTARG"; helpFunction ;;
+    esac
+done
+
+if ! [ -v MODE ]; then
+  echo "Please set how you want to start crabserver (add -c or -g option)." && helpFunction
+fi
+
+#==== SETUP ENVIRONMENT
+if [ "$debug" = true ]; then
+  # this will direct WMCore/REST/Main.py to run in the foreground rather than as a demon
+  # allowing among other things to insert pdb calls in the crabserver code and debug interactively
+  export DONT_DEMONIZE_REST=True
+fi
+
+if [ "$MODE" = fromGH ]; then
+  export RUN_FROM_GH=True
+fi
+
+#==== START THE SERVICE
+/data/srv/current/config/crabserver/manage start 'I did read documentation'

--- a/docker/crabserver/stop.sh
+++ b/docker/crabserver/stop.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# stop crabserver service
+/data/srv/current/config/crabserver/manage stop 'I did read documentation'


### PR DESCRIPTION
Hi @muhammadimranfarooqi please merge this (tested) PR which adds to crabserver image a few things to make our debugging easier:
- a `start.sh` and `stop.sh` to start and stop the service when logged inside the container
- an `addGH.sh` which adds directories with needed GH repos for crabserver and wmcore to test things quickly
- options to use `start.sh` to run from the GH repos and/or in python debug mode

Of course we will test again before deploying in production.
