### PR TITLE
Bug fix for deploy-secrets.sh ha argument

### DIFF
--- a/kubernetes/monitoring/deploy-secrets.sh
+++ b/kubernetes/monitoring/deploy-secrets.sh
@@ -56,7 +56,7 @@ literals=""
 
 if [ "$secret" == "prometheus-secrets" ]; then
     prom="$cdir/prometheus/prometheus.yaml"
-    if [ $ha -ne "" ]; then
+    if [ $ha != "" ]; then
         prom="$cdir/prometheus/ha/prometheus.yaml"
     fi
     files=`ls $cdir/prometheus/*.rules $cdir/prometheus/*.json $prom | awk '{ORS=" " ; print "--from-file="$1""}' | sed "s, $,,g"`


### PR DESCRIPTION
@vkuznet 
deploy-secrets.sh script produce `deploy-secrets.sh: line 59: [: ha: integer expression expected` error when giving "ha" param.
It's because of using `-ne` to compare with string. When you checked the output, it gets `--from-file="$cmsmon-configs/prometheus/prometheus.yaml"` instead of `--from-file="$cmsmon-configs/prometheus/ha/prometheus.yaml"`.
This commit fixes the problem. 