### PR TITLE
Fix Rucio urls in workqueue/reqmgr2ms just before running the service

### DIFF
--- a/docker/reqmgr2ms/run.sh
+++ b/docker/reqmgr2ms/run.sh
@@ -85,6 +85,15 @@ for fname in $files; do
     fi
 done
 
+# before running the service, we need to make sure rucio.cfg has the correct URLs
+SERVICE_CONFIG=${cdir}/config-*.py
+RUCIO_CONFIG=${cdir}/etc/rucio.cfg
+MATCH_RUCIO_URL=`cat ${SERVICE_CONFIG} | egrep '^RUCIO_URL =' | awk -F'=' '{print $2}' | sed 's/"//g'`
+MATCH_RUCIO_AUTH_URL=`cat ${SERVICE_CONFIG} | egrep '^RUCIO_AUTH_URL =' | awk -F'=' '{print $2}' | sed 's/"//g'`
+# now replace it in the rucio.cfg file
+sed -i -e "s,rucio_host.*,rucio_host =${MATCH_RUCIO_URL},g" ${RUCIO_CONFIG}
+sed -i -e "s,auth_host.*,auth_host =${MATCH_RUCIO_AUTH_URL},g" ${RUCIO_CONFIG}
+
 # start the service
 sudo chmod 755 /data/srv/current/config/$srv/manage
 /data/srv/current/config/$srv/manage start 'I did read documentation'

--- a/docker/workqueue/run.sh
+++ b/docker/workqueue/run.sh
@@ -68,6 +68,15 @@ for fname in $files; do
     fi
 done
 
+# before running the service, we need to make sure rucio.cfg has the correct URLs
+SERVICE_CONFIG=${cdir}/config.py
+RUCIO_CONFIG=${cdir}/etc/rucio.cfg
+MATCH_RUCIO_URL=`cat ${SERVICE_CONFIG} | egrep '^RUCIO_URL =' | awk -F'=' '{print $2}' | sed 's/"//g'`
+MATCH_RUCIO_AUTH_URL=`cat ${SERVICE_CONFIG} | egrep '^RUCIO_AUTH_URL =' | awk -F'=' '{print $2}' | sed 's/"//g'`
+# now replace it in the rucio.cfg file
+sed -i -e "s,rucio_host.*,rucio_host =${MATCH_RUCIO_URL},g" ${RUCIO_CONFIG}
+sed -i -e "s,auth_host.*,auth_host =${MATCH_RUCIO_AUTH_URL},g" ${RUCIO_CONFIG}
+
 # start the service
 /data/srv/current/config/$srv/manage start 'I did read documentation'
 


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/10600

Just before we start the service via `run.sh` script, fixup the `rucio.cfg` file to make sure the correct default values are in place.
I took advantage and made the same fix for the `reqmgr2ms` service, which could potentially have the same faith (even though we do not initialize Rucio over there with default values...)

@muhammadimranfarooqi @vkuznet could you please review this? I have done some interactive tests and it seems to be working fine.