### PR TITLE
Edit sqoop to get hdfs.json from cmsmon-configs

### DIFF
--- a/docker/sqoop/cronjobs.txt
+++ b/docker/sqoop/cronjobs.txt
@@ -31,4 +31,4 @@
 # ASO dump
 42 03 * * * cd /data/sqoop; ./run.sh ./cms-aso.sh
 
-40 14 * * * cd /data; /data/sqoop/run.sh /data/monit -query="stats" -token /etc/cmsdb/token -hdfs /data/CMSMonitoring/doc/hdfs/hdfs.json -creds=/etc/cmsdb/cms-es-size.json -verbose 1 -inject 2>&1 1>& monit.log
+40 14 * * * cd /data; /data/sqoop/run.sh /data/monit -query="stats" -token /etc/cmsdb/token -hdfs=/etc/cmsdb/hdfs.json -creds=/etc/cmsdb/cms-es-size.json -verbose 1 -inject 2>&1 1>& monit.log

--- a/kubernetes/monitoring/deploy-secrets.sh
+++ b/kubernetes/monitoring/deploy-secrets.sh
@@ -119,7 +119,9 @@ elif [ "$secret" == "rumble-secrets" ]; then
 elif [ "$secret" == "rucio-secrets" ]; then
     files=`ls $sdir/rucio/ | awk '{ORS=" " ; print "--from-file="D"/"$1""}' D=$sdir/rucio | sed "s, $,,g"`
 elif [ "$secret" == "sqoop-secrets" ]; then
-    files=`ls $sdir/sqoop/ | awk '{ORS=" " ; print "--from-file="D"/"$1""}' D=$sdir/sqoop | sed "s, $,,g"`
+    s_files=`ls $sdir/sqoop/ | awk '{ORS=" " ; print "--from-file="D"/"$1""}' D=$sdir/sqoop | sed "s, $,,g"`
+    c_files=`ls $cdir/sqoop/ | awk '{ORS=" " ; print "--from-file="D"/"$1""}' D=$cdir/sqoop | sed "s, $,,g"`
+    files="${s_files} ${c_files}"
 fi
 echo "files: \"$files\""
 #echo "literals: $literals"


### PR DESCRIPTION
@vkuznet @leggerf 

"hdfs.json" is added to [configs](https://gitlab.cern.ch/cmsmonitoring/cmsmon-configs/-/merge_requests/7)
I arranged sqoop cronjob to get hdfs.json from "sqoop-secrets". Also edited "deploy-secrets.sh" to include the json in "sqoop-secrets".
I did not edit "deploy.sh" because I guess we're not using "deploy.sh" to deploy secrets?

@vkuznet I'm not sure but it seems we're not using this Dockerfile to build sqoop image according to [cmssw/sqoop:20210323-v2](https://hub.docker.com/layers/cmssw/sqoop/20210323-v2/images/sha256-ad32eb153c96c8c946a184cf16eefdd667db435fcf2c525354a5f23b8077d6a5?context=explore) image

@muhammadimranfarooqi do you know which Dockerfile we're using to build sqoop image?