### PR TITLE
Update sqoop image tags

### DIFF
--- a/kubernetes/monitoring/services/hdfs-exporter-eos.yaml
+++ b/kubernetes/monitoring/services/hdfs-exporter-eos.yaml
@@ -45,7 +45,8 @@ spec:
       spec:
         containers:
         - name: hdfs-exporter-eos
-          image: cmssw/sqoop:20210323-v2
+          image: cmssw/sqoop:20210715
+          #image: cmssw/sqoop:20210323-v2
           #image: cmssw/sqoop:20210212-v2
           command:
           - /bin/sh

--- a/kubernetes/monitoring/services/sqoop.yaml
+++ b/kubernetes/monitoring/services/sqoop.yaml
@@ -21,7 +21,8 @@ spec:
           - /data/sqoop/log
           - "7"
           - "7200"
-          image: cmssw/sqoop:20210323-v2
+          image: cmssw/sqoop:20210715
+          #image: cmssw/sqoop:20210323-v2
           #image: cmssw/sqoop:20210212
           #image: cmssw/sqoop:20210208
           #image: cmssw/sqoop:20201214

--- a/kubernetes/spider/cronjobs/spider-cron-affiliation.yaml
+++ b/kubernetes/spider/cronjobs/spider-cron-affiliation.yaml
@@ -12,7 +12,7 @@
             serviceAccountName: spider-account
             containers:
             - name: cms-htcondor-es
-              image: cmssw/cms-htcondor-es:00.00.02
+              image: cmssw/cms-htcondor-es:d1dfe4d
               args:
               - /bin/sh
               - -c

--- a/kubernetes/spider/cronjobs/spider-cron-queues.yaml
+++ b/kubernetes/spider/cronjobs/spider-cron-queues.yaml
@@ -19,7 +19,7 @@ spec:
           serviceAccountName: spider-account
           containers:
           - name: cms-htcondor-es
-            image: cmssw/cms-htcondor-es:00.00.02
+            image: cmssw/cms-htcondor-es:d1dfe4d
             imagePullPolicy: Always
             args:
             - python

--- a/kubernetes/spider/deployments/spider-flower.yaml
+++ b/kubernetes/spider/deployments/spider-flower.yaml
@@ -27,7 +27,7 @@ spec:
         - --persistent=True
         - --max_tasks=1000000000
         - --db=/cms_shared/flower.db
-        image: cmssw/cms-htcondor-es:00.00.02
+        image: cmssw/cms-htcondor-es:d1dfe4d
         name: spider-flower
         ports:
         - containerPort: 5555

--- a/kubernetes/spider/deployments/spider-worker.yaml
+++ b/kubernetes/spider/deployments/spider-worker.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: spider-worker
-        image: cmssw/cms-htcondor-es:00.00.02
+        image: cmssw/cms-htcondor-es:d1dfe4d
         imagePullPolicy: Always
         args:
         - celery


### PR DESCRIPTION
@vkuznet @leggerf 
New sqoop image and it's new secret deployed to cms-monitoring cluster.
To be compatible, I also deployed new image for "hdfs-exporter-eos" in all 3 monitoring clusters. 

Related with hdfs size issue in CMSMONIT-398 ticket.