### PR TITLE
Write cron logs to stdout

### DIFF
--- a/docker/condor-cpu-eff/Dockerfile
+++ b/docker/condor-cpu-eff/Dockerfile
@@ -1,6 +1,8 @@
 FROM cern/cc7-base:20210201-1.x86_64
 MAINTAINER Ceyhun Uzunoglu ceyhunuzngl@gmail.com
 
+ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
+
 # set working directory
 ENV WDIR=/data
 WORKDIR $WDIR

--- a/docker/condor-cpu-eff/cronjobs.txt
+++ b/docker/condor-cpu-eff/cronjobs.txt
@@ -1,2 +1,2 @@
 # Gets CPU_EFF_OUTPUT from k8s conf
-02 16 * * 4 source $VIRTUAL_ENV/bin/activate && /bin/bash $WDIR/CMSSpark/bin/k8s_condor_cpu_efficiency.sh $CPU_EFF_OUTPUT >> /data/cron.log 2>&1
+00 03 * * 1 source $VIRTUAL_ENV/bin/activate && /bin/bash $WDIR/CMSSpark/bin/k8s_condor_cpu_efficiency.sh $CPU_EFF_OUTPUT > /proc/1/fd/1 2>&1


### PR DESCRIPTION
Write cronjob logs to stdout, so logs can be red from k8s pod logs.