### PR TITLE
Redefine the same port number and mount point for all replicas of ms-unmerged

### DIFF
--- a/kubernetes/cmsweb/services/reqmgr2ms-unmerged-t1.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-unmerged-t1.yaml
@@ -7,11 +7,11 @@ spec:
   selector:
     app: ms-unmerged-t1
   ports:
-    - port: 8360
-      targetPort: 8360
+    - port: 8242
+      targetPort: 8242
       name: ms-unmerged-t1
-    - port: 18360
-      targetPort: 18360
+    - port: 18242
+      targetPort: 18242
       name: unmerged-mon
 ---
 kind: ConfigMap
@@ -48,7 +48,7 @@ spec:
         env: k8s #k8s#
       annotations:
         prometheus.io/scrape: 'true'
-        prometheus.io/port: "18360"
+        prometheus.io/port: "18242"
     spec:
       # use hostNetwork to allow communication between reqmgr2ms/reqmon/workqueue and couch
 #       hostNetwork: true
@@ -70,7 +70,7 @@ spec:
 #          exec:
 #            command:
 #            - cmsweb-ping
-#            - "--url=http://localhost:8360/ms-unmerged-t1/data/status"
+#            - "--url=http://localhost:8242/ms-unmerged/data/status"
 #            - "--authz=/etc/hmac/hmac"
 #            - -verbose
 #            - "0"
@@ -84,10 +84,10 @@ spec:
             memory: "3Gi"
             cpu: "1000m"
         ports:
-        - containerPort: 8360
+        - containerPort: 8242
           protocol: TCP
           name: ms-um-t1
-        - containerPort: 18360
+        - containerPort: 18242
           protocol: TCP
           name: unmerged-mon
         command:

--- a/kubernetes/cmsweb/services/reqmgr2ms-unmerged-t2-t3-us.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-unmerged-t2-t3-us.yaml
@@ -7,11 +7,11 @@ spec:
   selector:
     app: ms-unmerged-t2-t3-us
   ports:
-    - port: 8361
-      targetPort: 8361
+    - port: 8242
+      targetPort: 8242
       name: ms-unmerged-t2-t3-us
-    - port: 18361
-      targetPort: 18361
+    - port: 18242
+      targetPort: 18242
       name: unmerged-mon
 ---
 kind: ConfigMap
@@ -48,7 +48,7 @@ spec:
         env: k8s #k8s#
       annotations:
         prometheus.io/scrape: 'true'
-        prometheus.io/port: "18361"
+        prometheus.io/port: "18242"
     spec:
       # use hostNetwork to allow communication between reqmgr2ms/reqmon/workqueue and couch
 #       hostNetwork: true
@@ -70,7 +70,7 @@ spec:
 #          exec:
 #            command:
 #            - cmsweb-ping
-#            - "--url=http://localhost:8361/ms-unmerged-t2-t3-us/data/status"
+#            - "--url=http://localhost:8242/ms-unmerged/data/status"
 #            - "--authz=/etc/hmac/hmac"
 #            - -verbose
 #            - "0"
@@ -84,10 +84,10 @@ spec:
             memory: "3Gi"
             cpu: "1000m"
         ports:
-        - containerPort: 8361
+        - containerPort: 8242
           protocol: TCP
           name: ms-um-t2-t3-us
-        - containerPort: 18361
+        - containerPort: 18242
           protocol: TCP
           name: unmerged-mon
         command:

--- a/kubernetes/cmsweb/services/reqmgr2ms-unmerged-t2-t3.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-unmerged-t2-t3.yaml
@@ -7,11 +7,11 @@ spec:
   selector:
     app: ms-unmerged-t2-t3
   ports:
-    - port: 8362
-      targetPort: 8362
+    - port: 8242
+      targetPort: 8242
       name: ms-unmerged-t2-t3
-    - port: 18362
-      targetPort: 18362
+    - port: 18242
+      targetPort: 18242
       name: unmerged-mon
 ---
 kind: ConfigMap
@@ -48,7 +48,7 @@ spec:
         env: k8s #k8s#
       annotations:
         prometheus.io/scrape: 'true'
-        prometheus.io/port: "18362"
+        prometheus.io/port: "18242"
     spec:
       # use hostNetwork to allow communication between reqmgr2ms/reqmon/workqueue and couch
 #       hostNetwork: true
@@ -70,7 +70,7 @@ spec:
 #          exec:
 #            command:
 #            - cmsweb-ping
-#            - "--url=http://localhost:8362/ms-unmerged-t2-t3/data/status"
+#            - "--url=http://localhost:8242/ms-unmerged/data/status"
 #            - "--authz=/etc/hmac/hmac"
 #            - -verbose
 #            - "0"
@@ -84,10 +84,10 @@ spec:
             memory: "3Gi"
             cpu: "1000m"
         ports:
-        - containerPort: 8362
+        - containerPort: 8242
           protocol: TCP
           name: ms-um-t2-t3
-        - containerPort: 18362
+        - containerPort: 18242
           protocol: TCP
           name: unmerged-mon
         command:


### PR DESCRIPTION
As discussed this morning over mattermost, this PR brings in the following changes:
* set the same port number for all the 3 replicas of MSUnmerged
* updated the cmsweb-ping url to a common mount point.

FYI @todor-ivanov @muhammadimranfarooqi 