### PR TITLE
Run StepChain cpu efficiency in k8s and fix spark issues

### DIFF
--- a/docker/condor-cpu-eff/Dockerfile
+++ b/docker/condor-cpu-eff/Dockerfile
@@ -11,6 +11,9 @@ ENV PATH="${PATH}:${WDIR}"
 # set required env vars
 ENV VIRTUAL_ENV "/venv"
 ENV HADOOP_CONF_DIR=/etc/hadoop/conf
+ENV PATH "$VIRTUAL_ENV/bin:/usr/hdp/hadoop-2.7.5/bin:/usr/hdp/spark-2.4/bin:$PATH"
+ENV PYSPARK_PYTHON=/usr/bin/python3
+ENV PYSPARK_DRIVER_PYTHON=$VIRTUAL_ENV/bin/python
 
 # add required files
 ADD hadoop.repo /etc/yum.repos.d/hadoop.repo
@@ -18,7 +21,7 @@ ADD hadoop-mapreduce-client-core-2.6.0-cdh5.7.6.jar $WDIR
 ADD cronjobs.txt $WDIR
 
 # oracle java is included as spark dependency
-RUN yum install -y cern-hadoop-config spark-bin-2.3.0 hadoop-bin-2.7.5 git python3 && \
+RUN yum install -y cern-hadoop-config spark-bin-2.4 hadoop-bin-2.7.5 git python3 && \
     yum clean all && \
     rm -rf /var/cache/yum && \
     hadoop-set-default-conf.sh analytix && \
@@ -27,9 +30,6 @@ RUN yum install -y cern-hadoop-config spark-bin-2.3.0 hadoop-bin-2.7.5 git pytho
     source $VIRTUAL_ENV/bin/activate && \
     pip install pandas pyspark click && \
     git clone https://github.com/dmwm/CMSSpark.git
-
-# set PATH
-ENV PATH "$VIRTUAL_ENV/bin:/usr/hdp/hadoop-2.7.5/bin:/usr/hdp/spark/bin:$PATH"
 
 # Setup cron
 CMD ["crond", "-n", "-s", "&"]

--- a/docker/condor-cpu-eff/cronjobs.txt
+++ b/docker/condor-cpu-eff/cronjobs.txt
@@ -1,8 +1,8 @@
 # Do not run cronjobs at the same time!
 # Gets CMSMONIT_WWW from k8s conf
 
-# Condor cpu efficiency
-00 03 * * 1 source $VIRTUAL_ENV/bin/activate && /bin/bash $WDIR/CMSSpark/bin/k8s_condor_cpu_efficiency.sh $CMSMONIT_WWW > /proc/1/fd/1 2>&1
+# Condor cpu efficiency, last_n_days is 30
+00 03 * * 1 source $VIRTUAL_ENV/bin/activate && /bin/bash $WDIR/CMSSpark/bin/k8s_condor_cpu_efficiency.sh $CMSMONIT_WWW 30 > /proc/1/fd/1 2>&1
 
-# StepChain cpu efficiency
-00 03 * * 2 source $VIRTUAL_ENV/bin/activate && /bin/bash $WDIR/CMSSpark/bin/k8s_stepchain_cpu_eff.sh $CMSMONIT_WWW > /proc/1/fd/1 2>&1
+# StepChain cpu efficiency, last_n_days is 15
+00 03 * * 2 source $VIRTUAL_ENV/bin/activate && /bin/bash $WDIR/CMSSpark/bin/k8s_stepchain_cpu_eff.sh $CMSMONIT_WWW 15 > /proc/1/fd/1 2>&1

--- a/docker/condor-cpu-eff/cronjobs.txt
+++ b/docker/condor-cpu-eff/cronjobs.txt
@@ -1,7 +1,8 @@
 # Do not run cronjobs at the same time!
-
 # Gets CMSMONIT_WWW from k8s conf
+
 # Condor cpu efficiency
 00 03 * * 1 source $VIRTUAL_ENV/bin/activate && /bin/bash $WDIR/CMSSpark/bin/k8s_condor_cpu_efficiency.sh $CMSMONIT_WWW > /proc/1/fd/1 2>&1
+
 # StepChain cpu efficiency
 00 03 * * 2 source $VIRTUAL_ENV/bin/activate && /bin/bash $WDIR/CMSSpark/bin/k8s_stepchain_cpu_eff.sh $CMSMONIT_WWW > /proc/1/fd/1 2>&1

--- a/docker/condor-cpu-eff/cronjobs.txt
+++ b/docker/condor-cpu-eff/cronjobs.txt
@@ -1,2 +1,7 @@
-# Gets CPU_EFF_OUTPUT from k8s conf
-00 03 * * 1 source $VIRTUAL_ENV/bin/activate && /bin/bash $WDIR/CMSSpark/bin/k8s_condor_cpu_efficiency.sh $CPU_EFF_OUTPUT > /proc/1/fd/1 2>&1
+# Do not run cronjobs at the same time!
+
+# Gets CMSMONIT_WWW from k8s conf
+# Condor cpu efficiency
+00 03 * * 1 source $VIRTUAL_ENV/bin/activate && /bin/bash $WDIR/CMSSpark/bin/k8s_condor_cpu_efficiency.sh $CMSMONIT_WWW > /proc/1/fd/1 2>&1
+# StepChain cpu efficiency
+00 03 * * 2 source $VIRTUAL_ENV/bin/activate && /bin/bash $WDIR/CMSSpark/bin/k8s_stepchain_cpu_eff.sh $CMSMONIT_WWW > /proc/1/fd/1 2>&1

--- a/kubernetes/monitoring/services/condor-cpu-eff.yaml
+++ b/kubernetes/monitoring/services/condor-cpu-eff.yaml
@@ -47,8 +47,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        - name: CPU_EFF_OUTPUT # Define output path here
-          value: /eos/user/c/cmsmonit/www/cpu_eff
+        - name: CMSMONIT_WWW # Define output path here
+          value: /eos/user/c/cmsmonit/www
         resources:
           limits:
             cpu: 2000m

--- a/kubernetes/monitoring/services/condor-cpu-eff.yaml
+++ b/kubernetes/monitoring/services/condor-cpu-eff.yaml
@@ -40,6 +40,7 @@ spec:
       containers:
       - name: condor-cpu-eff
         image: mrceyhun/condor_cpu_eff:latest
+        imagePullPolicy: Always
         tty: true
         stdin: true
         env:


### PR DESCRIPTION
fyi @vkuznet @leggerf 

StepChain cpu efficiency cronjob will run in k8s in same pod with condor_cpu_eff.
Spark version 2.4 is used.
Spark worker and driver version conflict error is solved with env parameters.