### PR TITLE
Add sqoop job of rucio contents table and refactor scripts&cronjobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ tmp
 log
 hmac
 
+# PyCharm IDE
+.idea
+
 # 3rd party packages
 kubernetes-prometheus
 

--- a/docker/condor-cpu-eff/cronjobs.txt
+++ b/docker/condor-cpu-eff/cronjobs.txt
@@ -2,7 +2,5 @@
 # Gets CMSMONIT_WWW from k8s conf
 
 # Condor cpu efficiency, last_n_days is 30
-00 03 * * 1 source $VIRTUAL_ENV/bin/activate && /bin/bash $WDIR/CMSSpark/bin/k8s_condor_cpu_efficiency.sh $CMSMONIT_WWW 30 > /proc/1/fd/1 2>&1
-
 # StepChain cpu efficiency, last_n_days is 15
-00 03 * * 2 source $VIRTUAL_ENV/bin/activate && /bin/bash $WDIR/CMSSpark/bin/k8s_stepchain_cpu_eff.sh $CMSMONIT_WWW 15 > /proc/1/fd/1 2>&1
+00 03 * * * source $VIRTUAL_ENV/bin/activate && /bin/bash $WDIR/CMSSpark/bin/k8s_condor_cpu_efficiency.sh $CMSMONIT_WWW 30 > /proc/1/fd/1 2>&1 && /bin/bash $WDIR/CMSSpark/bin/k8s_stepchain_cpu_eff.sh $CMSMONIT_WWW 15 > /proc/1/fd/1 2>&1

--- a/docker/sqoop/cronjobs.txt
+++ b/docker/sqoop/cronjobs.txt
@@ -18,8 +18,10 @@
 
 # Rucio dumps
 30 06 * * * cd /data/sqoop; ./run.sh ./rucio_replicas.sh
+
 # Rucio DIDS table dump
-30 01 * * 1 cd /data/sqoop; ./run.sh ./rucio_dids.sh
+# 30 01 * * 1 cd /data/sqoop; ./run.sh ./rucio_dids.sh
+# 30 02 * * 1 cd /data/sqoop; ./run.sh ./rucio_contents.sh
 
 # DBS dumps
 27 03 * * *   cd /data/sqoop; ./run.sh ./cms-dbs3-datasets.sh

--- a/docker/sqoop/scripts/rucio_contents.sh
+++ b/docker/sqoop/scripts/rucio_contents.sh
@@ -1,5 +1,5 @@
-# Imports CMS_RUCIO_PROD.DIDS table for access time of datasets
-BASE_PATH=/project/awg/cms/rucio_dids/
+# Imports CMS_RUCIO_PROD.CONTENTS table for access time of datasets
+BASE_PATH=/project/awg/cms/rucio_contents/
 JDBC_URL=jdbc:oracle:thin:@cms-nrac-scan.cern.ch:10121/CMSR_CMS_NRAC.cern.ch
 if [ -f /etc/secrets/rucio ]; then
   USERNAME=$(grep username </etc/secrets/rucio | awk '{print $2}')
@@ -9,21 +9,21 @@ else
   exit 1
 fi
 LOG_FILE=log/$(date +'%F_%H%m%S')_$(basename "$0")
-TABLE=CMS_RUCIO_PROD.DIDS
+TABLE=CMS_RUCIO_PROD.CONTENTS
 TZ=UTC
 
 /usr/hdp/sqoop/bin/sqoop import \
   -Dmapreduce.job.user.classpath.first=true \
   -Ddfs.client.socket-timeout=120000 \
   --username "$USERNAME" --password "$PASSWORD" \
-  -m 10 \
+  -m 1 \
   -z \
   --direct \
   --connect $JDBC_URL \
   --fetch-size 10000 \
   --as-avrodatafile \
   --target-dir "$BASE_PATH""$(date +%Y-%m-%d)" \
-  --query "SELECT * FROM ${TABLE} WHERE scope='cms' AND did_type='F' AND deleted_at IS NULL AND hidden=0 AND \$CONDITIONS" \
+  --query "SELECT * FROM ${TABLE} WHERE did_type='D' AND child_type='F' AND \$CONDITIONS" \
   1>"$LOG_FILE".stdout 2>"$LOG_FILE".stderr
 
 # change permission of HDFS area

--- a/docker/sqoop/scripts/rucio_contents.sh
+++ b/docker/sqoop/scripts/rucio_contents.sh
@@ -15,7 +15,13 @@ LOG_FILE=log/$(date +'%F_%H%m%S')_$(basename "$0")
 TABLE=CMS_RUCIO_PROD.CONTENTS
 TZ=UTC
 
-/usr/hdp/sqoop/bin/sqoop import \
+# Check sqoop and hadoop executables exist
+if ! [ -x "$(command -v hadoop)" ] || ! [ -x "$(command -v sqoop)" ]; then
+  echo "It seems 'sqoop' or 'hadoop' is not exist in PATH! Exiting..."
+  exit 1
+fi
+
+sqoop import \
   -Dmapreduce.job.user.classpath.first=true \
   -Ddfs.client.socket-timeout=120000 \
   --username "$USERNAME" --password "$PASSWORD" \
@@ -34,3 +40,4 @@ hadoop fs -chmod -R o+rx $BASE_PATH"$(date +%Y-%m-%d)"
 
 # Delete previous folder
 hadoop fs -rmdir --ignore-fail-on-non-empty "$PREVIOUS_FOLDER"
+echo "$PREVIOUS_FOLDER is deleted"

--- a/docker/sqoop/scripts/rucio_contents.sh
+++ b/docker/sqoop/scripts/rucio_contents.sh
@@ -8,6 +8,9 @@ else
   echo "Unable to read Rucio credentials"
   exit 1
 fi
+
+# There should be always one folder
+PREVIOUS_FOLDER=$(hadoop fs -ls $BASE_PATH | awk '{ORS=""; print $8}')
 LOG_FILE=log/$(date +'%F_%H%m%S')_$(basename "$0")
 TABLE=CMS_RUCIO_PROD.CONTENTS
 TZ=UTC
@@ -28,3 +31,6 @@ TZ=UTC
 
 # change permission of HDFS area
 hadoop fs -chmod -R o+rx $BASE_PATH"$(date +%Y-%m-%d)"
+
+# Delete previous folder
+hadoop fs -rmdir --ignore-fail-on-non-empty "$PREVIOUS_FOLDER"

--- a/docker/sqoop/scripts/rucio_dids.sh
+++ b/docker/sqoop/scripts/rucio_dids.sh
@@ -8,6 +8,9 @@ else
   echo "Unable to read Rucio credentials"
   exit 1
 fi
+
+# There should be always one folder
+PREVIOUS_FOLDER=$(hadoop fs -ls $BASE_PATH | awk '{ORS=""; print $8}')
 LOG_FILE=log/$(date +'%F_%H%m%S')_$(basename "$0")
 TABLE=CMS_RUCIO_PROD.DIDS
 TZ=UTC
@@ -28,3 +31,6 @@ TZ=UTC
 
 # change permission of HDFS area
 hadoop fs -chmod -R o+rx $BASE_PATH"$(date +%Y-%m-%d)"
+
+# Delete previous folder
+hadoop fs -rmdir --ignore-fail-on-non-empty "$PREVIOUS_FOLDER"


### PR DESCRIPTION
@vkuznet @leggerf 

I already run sqoop job for DIDS and CONTENTS tables(forget to open PR yesterday), so I used them in Spark job. I commented out their cronjobs in sqoop pod for now. After improvements and approval of [PR](https://github.com/dmwm/CMSSpark/pull/66), I'll edit them.

Also, condor and stepchain cpu efficiency cron jobs are edited. They started to be used more than usual these days, so let's run them daily.