### PR TITLE
crabserver alert if high numbr of fds

### DIFF
--- a/kubernetes/cmsweb/monitoring/prometheus/rules/crabserver.rules
+++ b/kubernetes/cmsweb/monitoring/prometheus/rules/crabserver.rules
@@ -1,7 +1,8 @@
 groups:
 - name: crabserver
   rules:
-
+  - record: avg_open_fds
+    expr: avg_over_time(crabserver_process_open_fds[15m])
   - alert: CRAB server is down
     expr: crabserver_num_cpus == 0
     for: 5m
@@ -14,3 +15,14 @@ groups:
     annotations:
       summary: "crabserver {{ $labels.env }} is down"
       description: "{{ $labels.env }} has been down for more than 5m"
+  - alert: CRAB server service has high number of fds
+    expr: avg_open_fds > 5
+    for: 1m
+    labels:
+      severity: high
+      tag: cmsweb
+      service: crab
+      action: Please check CRAB server {{ $labels.instance }} and possibly restart it
+    annotations:
+      summary: "CRAB {{ $labels.env }} environment"
+      description: "{{ $labels.env }} has high level of fds {{ $value }} for more than 1m"

--- a/kubernetes/cmsweb/monitoring/prometheus/rules/crabserver.test
+++ b/kubernetes/cmsweb/monitoring/prometheus/rules/crabserver.test
@@ -23,3 +23,22 @@ tests:
               exp_annotations:
                  summary: "crabserver prod is down"
                  description: "prod has been down for more than 5m"
+- interval: 1m
+  input_series:
+  - series: 'avg_open_fds{env="prod",instance="test-instance",host="k8s-test"}'
+    values: '6+1x100'
+  alert_rule_test:
+      - eval_time: 10m
+        alertname: CRAB server service has high number of fds
+        exp_alerts:
+            - exp_labels:
+                 severity: high
+                 tag: cmsweb
+                 service: crab
+                 host: k8s-test
+                 action: Please check CRAB server test-instance and possibly restart it
+                 instance: test-instance
+                 env: prod
+              exp_annotations:
+                 summary: "CRAB prod environment"
+                 description: "prod has high level of fds 16 for more than 1m"


### PR DESCRIPTION
As part of the efforts addressing https://github.com/dmwm/CRABServer/issues/6708, we would like to restart a crabserver pod if the number of open fds gets too high.

Implementing the restarting procedure requires creating an alert in AlertManager and then making PodManager react to this alert. This PR takes care of the first step. 

This is only a first test for us: at this moment, we only want to make sure we understand the machinery and try to restart a pod. This is why
- we are creating the alert as soon as `expr: avg_open_fds > 5`
- we would like to ask @muhammadimranfarooqi if it is possible to deploy PodManager so that it reacts to this alert only in the `test2` cluster. We checked the metrics and the pod in test2 has 9 open fds since at least 30min, so we should be able to trigger the alert.

After having made sure that we properly restart the test2 cluster, we plan to
- create a new PR with proper real-world metrics for `prod` (or only `testbed` first?)
- ask Imran to deploy PodManager so that it reacts to this alert in `prod` (or `testbed` cluster first?)

I order to implement our changes here, we took inspiration from [dbs.rules](https://github.com/dmwm/CMSKubernetes/blob/master/kubernetes/cmsweb/monitoring/prometheus/rules/dbs.rules) and [dbs.test](https://github.com/dmwm/CMSKubernetes/blob/master/kubernetes/cmsweb/monitoring/prometheus/rules/dbs.test). We have two question on this:
- since we want to trigger the alert when the average of open fds is over a certaing threshold for a somewhat long time, we are averaging over 15m. Is is ok to test this alert with `- eval_time: 15m` in `crabserver.test`?
- if we want to test the alert works, and having set the alert as `avg_open_fds > 5`, it is ok to set the input series as `    values: '1+5x1000'`, having set the eval time to 15min? We noticed that in `dbs.rules` every time that there is `values: M+Nx100`, then the eval time is 10m and value reported in the alert description is `M+10*N`, while when `values: M+Nx10` the eval time is 5min and the value in the description is `M+5*N`. We also noted that a 15min eval time is correlated to an input series containing `x1000`, but i could not find any example to copy how to set M and N in `M+Nx1000` from.


Every comment and correction is very much appreciated! :)

fyi: @ddaina @belforte 