### PR TITLE
crabserver alert if high numbr of fds: production-ready thresholds.

### DIFF
--- a/kubernetes/cmsweb/monitoring/prometheus/rules/crabserver.rules
+++ b/kubernetes/cmsweb/monitoring/prometheus/rules/crabserver.rules
@@ -1,8 +1,10 @@
 groups:
 - name: crabserver
   rules:
-  - record: avg_open_fds
-    expr: avg_over_time(crabserver_process_open_fds[15m])
+  - record: avg_open_fds_10m
+    expr: avg_over_time(crabserver_process_open_fds[10m])
+  - record: avg_open_fds_30m
+    expr: avg_over_time(crabserver_process_open_fds[30m])
   - alert: CRAB server is down
     expr: crabserver_num_cpus == 0
     for: 5m
@@ -15,14 +17,27 @@ groups:
     annotations:
       summary: "crabserver {{ $labels.env }} is down"
       description: "{{ $labels.env }} has been down for more than 5m"
+  - alert: CRAB server service has large number of fds
+    expr: avg_open_fds_10m > 75
+    for: 1m
+    labels:
+      severity: warning
+      tag: cmsweb
+      service: crab
+      host: "{{ $labels.host }}"
+      action: Please check CRAB server on {{ $labels.instance }} and possibly restart it
+    annotations:
+      summary: "CRAB {{ $labels.env }} environment"
+      description: "{{ $labels.env }} has large level of fds {{ $value }} (avg 10m) for more than 1m"
   - alert: CRAB server service has high number of fds
-    expr: avg_open_fds > 5
+    expr: avg_open_fds_30m > 100
     for: 1m
     labels:
       severity: high
       tag: cmsweb
       service: crab
-      action: Please check CRAB server {{ $labels.instance }} and possibly restart it
+      host: "{{ $labels.host }}"
+      action: Please restart CRAB server on {{ $labels.instance }}
     annotations:
       summary: "CRAB {{ $labels.env }} environment"
-      description: "{{ $labels.env }} has high level of fds {{ $value }} for more than 1m"
+      description: "{{ $labels.env }} has high level of fds {{ $value }} (avg 30m) for more than 1m"

--- a/kubernetes/cmsweb/monitoring/prometheus/rules/crabserver.test
+++ b/kubernetes/cmsweb/monitoring/prometheus/rules/crabserver.test
@@ -25,8 +25,27 @@ tests:
                  description: "prod has been down for more than 5m"
 - interval: 1m
   input_series:
-  - series: 'avg_open_fds{env="prod",instance="test-instance",host="k8s-test"}'
-    values: '6+1x100'
+  - series: 'avg_open_fds_10m{env="prod",instance="test-instance",host="k8s-test"}'
+    values: '76+1x100'
+  alert_rule_test:
+      - eval_time: 10m
+        alertname: CRAB server service has large number of fds
+        exp_alerts:
+            - exp_labels:
+                 severity: warning
+                 tag: cmsweb
+                 service: crab
+                 host: k8s-test
+                 action: Please check CRAB server on test-instance and possibly restart it
+                 instance: test-instance
+                 env: prod
+              exp_annotations:
+                 summary: "CRAB prod environment"
+                 description: "prod has large level of fds 86 (avg 10m) for more than 1m"
+- interval: 1m
+  input_series:
+  - series: 'avg_open_fds_30m{env="prod",instance="test-instance",host="k8s-test"}'
+    values: '101+1x100'
   alert_rule_test:
       - eval_time: 10m
         alertname: CRAB server service has high number of fds
@@ -36,9 +55,9 @@ tests:
                  tag: cmsweb
                  service: crab
                  host: k8s-test
-                 action: Please check CRAB server test-instance and possibly restart it
+                 action: Please restart CRAB server on test-instance
                  instance: test-instance
                  env: prod
               exp_annotations:
                  summary: "CRAB prod environment"
-                 description: "prod has high level of fds 16 for more than 1m"
+                 description: "prod has high level of fds 111 (avg 30m) for more than 1m"


### PR DESCRIPTION
As part of the efforts addressing https://github.com/dmwm/CRABServer/issues/6708, we would like to restart a crabserver pod if the number of open fds gets too high.

After having tested on `test2` that we receive email notifications from AlertManager thanks to #814, we are ready to change the thresholds to production-ready ones. I created two alerts:

1. `CRAB server service has large number of fds`: this should only trigger a notification
2. `CRAB server service has high number of fds`: this should trigger a notification AND restart the crabserver pod in production.

I am not sure if PodManager checks the alert name or the alert action: 
- If it checks the action, then this PR should be enough, since the alert `CRAB server service has high number of fds` has the same action as `CRAB server is down`
- If it checks the alert name, then I ask you to deploy PodManager so that in production it restarts a pod that fires the alert `CRAB server service has high number of fds`.

These new rules and their test pass `promtool` checks:

```plaintext
> /cvmfs/cms.cern.ch/cmsmon/promtool check rules kubernetes/cmsweb/monitoring/prometheus/rules/crabserver.rules
Checking kubernetes/cmsweb/monitoring/prometheus/rules/crabserver.rules
  SUCCESS: 5 rules found
> /cvmfs/cms.cern.ch/cmsmon/promtool test rules kubernetes/cmsweb/monitoring/prometheus/rules/crabserver.test
Unit Testing:  kubernetes/cmsweb/monitoring/prometheus/rules/crabserver.test
  SUCCESS
```

PS: I would ask to merge also
- [ ] https://gitlab.cern.ch/cmsmonitoring/cmsmon-configs/-/merge_requests/12
- [ ] https://gitlab.cern.ch/cmsmonitoring/cmsmon-configs/-/merge_requests/13