### PR TITLE
Change condition to trigger down service alert for reqmgr2

### DIFF
--- a/kubernetes/cmsweb/monitoring/prometheus/rules/reqmgr2.rules
+++ b/kubernetes/cmsweb/monitoring/prometheus/rules/reqmgr2.rules
@@ -3,7 +3,7 @@ groups:
   rules:
 
   - alert: ReqMgr2 service is down
-    expr: reqmgr2_num_cpus == 0 or rate(reqmgr2_process_cpu_seconds_total[5m]) == 0
+    expr: avg_over_time(reqmgr2_process_cpu_seconds_total[5m]) == 0
     for: 5m
     labels:
       severity: high

--- a/kubernetes/cmsweb/monitoring/prometheus/rules/reqmgr2.rules
+++ b/kubernetes/cmsweb/monitoring/prometheus/rules/reqmgr2.rules
@@ -1,9 +1,11 @@
 groups:
 - name: reqmgr2
   rules:
+  - record: avg_process_cpu_over_time_5m
+    expr: avg_over_time(reqmgr2_process_cpu_seconds_total[5m])
 
   - alert: ReqMgr2 service is down
-    expr: avg_over_time(reqmgr2_process_cpu_seconds_total[5m]) == 0
+    expr: avg_process_cpu_over_time_5m == 0
     for: 5m
     labels:
       severity: high
@@ -11,10 +13,10 @@ groups:
       service: reqmgr2
       host: "{{ $labels.host }}"
       kind: dmwm
-      action: Please restart ReqMgr2 service on {{ $labels.instance }}
+      action: Please check ReqMgr2 service on {{ $labels.instance }} and restart it if needed
     annotations:
       summary: "reqmgr2 {{ $labels.env }} is down"
-      description: "{{ $labels.env }} has been down for more than 5m"
+      description: "{{ $labels.env }} has been down - zero CPU load over time - for more than 5m"
 
   - alert: ReqMgr2 high memory usage
     expr: reqmgr2_proc_mem > 70

--- a/kubernetes/cmsweb/monitoring/prometheus/rules/reqmgr2.test
+++ b/kubernetes/cmsweb/monitoring/prometheus/rules/reqmgr2.test
@@ -6,7 +6,7 @@ evaluation_interval: 1m
 tests:
 - interval: 1m
   input_series:
-  - series: 'reqmgr2_num_cpus{env="prod",host="k8s-test",instance="test-instance"}'
+  - series: 'avg_process_cpu_over_time_5m{env="prod",host="k8s-test",instance="test-instance"}'
     values: '0+0x100'
   alert_rule_test:
       - eval_time: 10m
@@ -18,12 +18,12 @@ tests:
                  service: reqmgr2
                  host: k8s-test
                  kind: dmwm
-                 action: Please restart ReqMgr2 service on test-instance
+                 action: Please check ReqMgr2 service on test-instance and restart it if needed
                  instance: test-instance
                  env: prod
               exp_annotations:
                  summary: "reqmgr2 prod is down"
-                 description: "prod has been down for more than 5m"
+                 description: "prod has been down - zero CPU load over time - for more than 5m"
 
 - interval: 1m
   input_series:


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/10667

From the discussion in this JIRA ticket: https://its.cern.ch/jira/browse/CMSMONIT-408
the provided condition seems to be more meaningful and will avoid false alarms.

Thanks to Valentin and Ceyhun for investigating this and providing this alternative.