### PR TITLE
Monitor ReqMgr2 up status based on the # of fds

### DIFF
--- a/kubernetes/cmsweb/monitoring/prometheus/rules/reqmgr2.rules
+++ b/kubernetes/cmsweb/monitoring/prometheus/rules/reqmgr2.rules
@@ -1,12 +1,12 @@
 groups:
 - name: reqmgr2
   rules:
-  - record: avg_process_cpu_over_time_5m
-    expr: avg_over_time(reqmgr2_process_cpu_seconds_total[5m])
+  - record: avg_open_fds_2m
+    expr: avg_over_time(reqmgr2_process_open_fds[2m])
 
   - alert: ReqMgr2 service is down
-    expr: avg_process_cpu_over_time_5m == 0
-    for: 5m
+    expr: avg_open_fds_2m < 1
+    for: 2m
     labels:
       severity: high
       tag: cmsweb
@@ -16,7 +16,7 @@ groups:
       action: Please check ReqMgr2 service on {{ $labels.instance }} and restart it if needed
     annotations:
       summary: "reqmgr2 {{ $labels.env }} is down"
-      description: "{{ $labels.env }} has been down - zero CPU load over time - for more than 5m"
+      description: "{{ $labels.env }} has been down - zero file descriptors - for more than 2m"
 
   - alert: ReqMgr2 high memory usage
     expr: reqmgr2_proc_mem > 70

--- a/kubernetes/cmsweb/monitoring/prometheus/rules/reqmgr2.test
+++ b/kubernetes/cmsweb/monitoring/prometheus/rules/reqmgr2.test
@@ -6,10 +6,10 @@ evaluation_interval: 1m
 tests:
 - interval: 1m
   input_series:
-  - series: 'avg_process_cpu_over_time_5m{env="prod",host="k8s-test",instance="test-instance"}'
+  - series: 'avg_open_fds_2m{env="prod",host="k8s-test",instance="test-instance"}'
     values: '0+0x100'
   alert_rule_test:
-      - eval_time: 10m
+      - eval_time: 5m
         alertname: ReqMgr2 service is down
         exp_alerts:
             - exp_labels:
@@ -23,7 +23,7 @@ tests:
                  env: prod
               exp_annotations:
                  summary: "reqmgr2 prod is down"
-                 description: "prod has been down - zero CPU load over time - for more than 5m"
+                 description: "prod has been down - zero file descriptors - for more than 2m"
 
 - interval: 1m
   input_series:


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/10667

Second attempt trying to fix the "ReqMgr2 service is down" alert. This time, based on the amount of open file descriptors opened for the reqmgr2 process, which has a standard value of 3 fds.
If the service ever goes below 1 fds, that means the service is not running.

Rule and unit test are looking okay:
```
amaltaro@lxplus751:~/CMSKubernetes $ /cvmfs/cms.cern.ch/cmsmon/promtool check rules kubernetes/cmsweb/monitoring/prometheus/rules/reqmgr2.rules 
Checking kubernetes/cmsweb/monitoring/prometheus/rules/reqmgr2.rules
  SUCCESS: 4 rules found

amaltaro@lxplus751:~/CMSKubernetes $ /cvmfs/cms.cern.ch/cmsmon/promtool test rules kubernetes/cmsweb/monitoring/prometheus/rules/reqmgr2.test 
Unit Testing:  kubernetes/cmsweb/monitoring/prometheus/rules/reqmgr2.test
  SUCCESS
  ```
  
  @muhammadimranfarooqi @vkuznet if this rule looks good to you, can you please merge and push it to CMSWEB? Thanks