### PR TITLE
Use COMP gfal2-python package in MSUnmerged image

### DIFF
--- a/docker/reqmgr2ms-unmerged/Dockerfile
+++ b/docker/reqmgr2ms-unmerged/Dockerfile
@@ -9,19 +9,19 @@ USER ${USER}
 RUN mkdir -p $WDIR
 WORKDIR ${WDIR}
 
-# Install gfal2-python3 dependecies
-RUN sudo yum install -y \
-    gfal2-python3 \
+# Install and enable the CERN DMC EL7 repository to get up-to-date gfal2 packages
+ADD https://dmc-repo.web.cern.ch/dmc-repo/dmc-el7.repo /etc/yum.repos.d/dmc-el7.repo
+# Install the gfal2 base libraries (from the production DMC repo)
+# Also install the external plugins required for full gfal2 functionality
+RUN sudo yum install -y gfal2 gfal2-devel \
     gfal2-plugin-file \
     gfal2-plugin-gridftp \
     gfal2-plugin-http \
     gfal2-plugin-srm \
     gfal2-plugin-xrootd \
     xrootd-client \
-    && sudo yum clean all && \
-    sudo rm -rf /var/cache/yum
+    && sudo yum clean all && sudo rm -rf /var/cache/yum
 
-ENV PYTHONPATH="$PYTHONPATH:/usr/lib64/python3.6/site-packages/"
 # switch to user
 ARG CMSK8S
 ENV CMSK8S=$CMSK8S


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/10828
Depends on https://github.com/cms-sw/cmsdist/pull/7326

This PR provides the following changes for the reqmgr2ms-unmerged dockerfile:
* add the EL7 DMC repository (required for up-to-date gfal2 packages)
* no longer install `gfal2-python3` (and juggle with PYTHONPATH). We will use the COMP package
* install the latest production `gfal2` and `gfal2-devel` packages (from DMC repo).

I successfully built this docker image. Just for the record, here is a list of RPMs and their versions, installed with the changes.
```
================================================================================
 Package                     Arch       Version               Repository   Size
================================================================================
Installing:
 gfal2                       x86_64     2.20.0-1.el7.cern     dmc-el7      82 k
 gfal2-devel                 x86_64     2.20.0-1.el7.cern     dmc-el7      39 k
 gfal2-plugin-file           x86_64     2.20.0-1.el7.cern     dmc-el7      20 k
 gfal2-plugin-gridftp        x86_64     2.20.0-1.el7.cern     dmc-el7      73 k
 gfal2-plugin-http           x86_64     2.20.0-1.el7.cern     dmc-el7      65 k
 gfal2-plugin-srm            x86_64     2.20.0-1.el7.cern     dmc-el7      46 k
 gfal2-plugin-xrootd         x86_64     2.20.0-1.el7.cern     dmc-el7      62 k
Installing for dependencies:
...
```

PS.: the `xrootd-client` package is already available in the image. I kept it here for completeness.