### PR TITLE
WIP: Cert manager

### DIFF
--- a/docker/cert-manager/run.sh
+++ b/docker/cert-manager/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-cert=$1
+cert_path=$1
 if [ -n  "${AMURL}" ] ; then
     amurl=$AMURL
 else
@@ -8,22 +8,25 @@ fi
 
 while :
 do
-    certTime=`openssl x509 -enddate -noout -in $cert | sed -e "s,notAfter=,,g"`
-    tstamp=`date --date="$certTime" +"%s"`
-    now=`date +"%s"`
-    if [ $tstamp -lt $now ] ; then
-        msg="Certificate $cert expired on $certTime"
-        echo $msg
-        expire=`date -d '+5 min' --rfc-3339=ns | tr ' ' 'T'`
-        if [ -f /data/amtool ] ; then
-            /data/amtool alert add cert_alert \
-                alertname=cert_alert severity=high tag=test alert=amtool \
-                --end=$expire \
-                --annotation=date="`date`" \
-                --annotation=hostname="`hostname`" \
-                --annotation=message="$msg" \
-                --alertmanager.url=$amurl
+    for cert in "$cert_path"/*; do
+        certTime=`openssl x509 -enddate -noout -in $cert | sed -e "s,notAfter=,,g"`
+        tstamp=`date --date="$certTime" +"%s"`
+        now=`date +"%s"`
+        echo "Checking $cert with expiration $certTime"
+        if [ $tstamp -lt $now ] ; then
+            msg="Certificate $cert expired on $certTime"
+            echo $msg
+            expire=`date -d '+5 min' --rfc-3339=ns | tr ' ' 'T'`
+            if [ -f /data/amtool ] ; then
+                /data/amtool alert add cert_alert \
+                    alertname=cert_alert severity=high tag=test alert=amtool \
+                    --end=$expire \
+                    --annotation=date="`date`" \
+                    --annotation=hostname="`hostname`" \
+                    --annotation=message="$msg" \
+                    --alertmanager.url=$amurl
+            fi
         fi
-    fi
+    done
     sleep 10
 done

--- a/docker/cert-manager/run.sh
+++ b/docker/cert-manager/run.sh
@@ -13,7 +13,7 @@ do
         tstamp=`date --date="$certTime" +"%s"`
         alertDate=`date -d "+15 days" +"%s"`
         if [  ! -z  "$certTime" ] && [ $tstamp -lt $alertDate ] ; then
-            msg="Certificate $cert on pod $POD_NAME running on node $NODE_NAME will expire on $certTime"
+            msg="Certificate $cert will expire on $certTime"
             expire=`date -d '+15 days' --rfc-3339=ns | tr ' ' 'T'`
             if [ -f /data/amtool ] ; then
                 /data/amtool alert add cert_alert \

--- a/docker/cert-manager/run.sh
+++ b/docker/cert-manager/run.sh
@@ -11,15 +11,13 @@ do
     for cert in "$cert_path"/*; do
         certTime=`openssl x509 -enddate -noout -in $cert | sed -e "s,notAfter=,,g"`
         tstamp=`date --date="$certTime" +"%s"`
-        now=`date +"%s"`
-        echo "Checking $cert with expiration $certTime"
-        if [ $tstamp -lt $now ] ; then
-            msg="Certificate $cert expired on $certTime"
-            echo $msg
-            expire=`date -d '+5 min' --rfc-3339=ns | tr ' ' 'T'`
+        alertDate=`date -d "+15 days" +"%s"`
+        if [  ! -z  "$certTime" ] && [ $tstamp -lt $alertDate ] ; then
+            msg="Certificate $cert on pod $POD_NAME running on node $NODE_NAME will expire on $certTime"
+            expire=`date -d '+15 days' --rfc-3339=ns | tr ' ' 'T'`
             if [ -f /data/amtool ] ; then
                 /data/amtool alert add cert_alert \
-                    alertname=cert_alert severity=high tag=test alert=amtool \
+                    alertname=cert_alert severity=high tag=cmsweb alert=amtool \
                     --end=$expire \
                     --annotation=date="`date`" \
                     --annotation=hostname="`hostname`" \

--- a/kubernetes/cmsweb/services/cert-manager.yaml
+++ b/kubernetes/cmsweb/services/cert-manager.yaml
@@ -28,11 +28,17 @@ spec:
         command:
         - /bin/sh
         - -c
-        - /data/run.sh /etc/grid-security/hostcert.pem
+        - /data/run.sh /etc/certs
         volumeMounts:
+        - name: robot-secrets
+          mountPath: /etc/certs/robot.cert
+          subPath: robotcert.pem
         - name: hostcert
-          mountPath: /etc/grid-security/hostcert.pem
+          mountPath: /etc/certs/host.cert
       volumes:
+      - name: robot-secrets
+        secret:
+          secretName: robot-secrets
       - name: hostcert
         hostPath:
             path: /etc/grid-security/hostcert.pem

--- a/kubernetes/cmsweb/services/frontend-ds.yaml
+++ b/kubernetes/cmsweb/services/frontend-ds.yaml
@@ -56,7 +56,6 @@ spec:
       containers:
       - image: registry.cern.ch/cmsweb/frontend #imagetag
         name: frontend
-#         imagePullPolicy: Always
         livenessProbe:
           httpGet:
             path: /
@@ -102,40 +101,6 @@ spec:
           mountPath: /etc/grid-security/hostcert.pem
         - name: hostkey
           mountPath: /etc/grid-security/hostkey.pem
-#PROD#  - name: logs
-#PROD#    mountPath: /data/srv/logs/frontend
-#PROD#  - name: filebeat-cephfs
-#PROD#    mountPath: /data/filebeat
-#PROD#- name: frontend-filebeat
-#PROD#  image: docker.elastic.co/beats/filebeat:7.12.0
-#PROD#  args: [
-#PROD#    "-c", "/etc/filebeat.yml",
-#PROD#    "-e",
-#PROD#  ]
-#PROD#  env:
-#PROD#  - name: MY_POD_NAME
-#PROD#    valueFrom:
-#PROD#      fieldRef:
-#PROD#        apiVersion: v1
-#PROD#        fieldPath: metadata.name
-#PROD#  resources:
-#PROD#    requests:
-#PROD#      memory: "50Mi"
-#PROD#      cpu: "50m"
-#PROD#  volumeMounts:
-#PROD#  - name: logs
-#PROD#    mountPath: /data/srv/logs/frontend
-#PROD#  - name: config
-#PROD#    mountPath: /etc/filebeat.yml
-#PROD#    readOnly: true
-#PROD#    subPath: filebeat.yml
-#PROD#  - name: data
-#PROD#    mountPath: /usr/share/filebeat/data
-#PROD#  - name: varlog
-#PROD#    mountPath: /var/log
-#PROD#  - name: varlibdockercontainers
-#PROD#    mountPath: /var/lib/docker/containers
-#PROD#    readOnly: true
       - image: registry.cern.ch/cmsweb/exporters:20210706-static
         name: frontend-exporter
         imagePullPolicy: Always
@@ -156,6 +121,24 @@ spec:
         - name: proxy-secrets
           mountPath: /etc/proxy
           readOnly: true
+      - image: registry.cern.ch/cmsweb/cert-manager-sidecar:latest
+        name: cert-manager
+        resources: 
+          requests:
+            memory: "256Mi"
+            cpu: "100m"
+          limits:
+            memory: "512Mi"
+            cpu: "300m"
+        command:
+        - /bin/sh
+        - -c
+        - /data/run.sh /etc/certs
+        volumeMounts:
+        - name: robot-secrets
+          mountPath: /etc/certs/robot.cert
+        - name: hostcert
+          mountPath: /etc/certs/host.cert
       volumes:
       - name: proxy-secrets
         secret:
@@ -195,6 +178,7 @@ spec:
 #PROD#      claimName: logs-cephfs-claim-default
       nodeSelector:
         role: auth
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/kubernetes/cmsweb/services/frontend-ds.yaml
+++ b/kubernetes/cmsweb/services/frontend-ds.yaml
@@ -156,34 +156,6 @@ spec:
         - name: proxy-secrets
           mountPath: /etc/proxy
           readOnly: true
-      - image: registry.cern.ch/cmsweb/cert-manager-sidecar:latest
-        name: cert-manager
-        resources: 
-          requests:
-            memory: "256Mi"
-            cpu: "100m"
-          limits:
-            memory: "512Mi"
-            cpu: "300m"
-        env:
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        command:
-        - /bin/sh
-        - -c
-        - /data/run.sh /etc/certs
-        volumeMounts:
-        - name: robot-secrets
-          mountPath: /etc/certs/robot.cert
-          subPath: robotcert.pem
-        - name: hostcert
-          mountPath: /etc/certs/host.cert
       volumes:
       - name: proxy-secrets
         secret:

--- a/kubernetes/cmsweb/services/frontend-ds.yaml
+++ b/kubernetes/cmsweb/services/frontend-ds.yaml
@@ -56,6 +56,7 @@ spec:
       containers:
       - image: registry.cern.ch/cmsweb/frontend #imagetag
         name: frontend
+#         imagePullPolicy: Always
         livenessProbe:
           httpGet:
             path: /
@@ -101,6 +102,40 @@ spec:
           mountPath: /etc/grid-security/hostcert.pem
         - name: hostkey
           mountPath: /etc/grid-security/hostkey.pem
+#PROD#  - name: logs
+#PROD#    mountPath: /data/srv/logs/frontend
+#PROD#  - name: filebeat-cephfs
+#PROD#    mountPath: /data/filebeat
+#PROD#- name: frontend-filebeat
+#PROD#  image: docker.elastic.co/beats/filebeat:7.12.0
+#PROD#  args: [
+#PROD#    "-c", "/etc/filebeat.yml",
+#PROD#    "-e",
+#PROD#  ]
+#PROD#  env:
+#PROD#  - name: MY_POD_NAME
+#PROD#    valueFrom:
+#PROD#      fieldRef:
+#PROD#        apiVersion: v1
+#PROD#        fieldPath: metadata.name
+#PROD#  resources:
+#PROD#    requests:
+#PROD#      memory: "50Mi"
+#PROD#      cpu: "50m"
+#PROD#  volumeMounts:
+#PROD#  - name: logs
+#PROD#    mountPath: /data/srv/logs/frontend
+#PROD#  - name: config
+#PROD#    mountPath: /etc/filebeat.yml
+#PROD#    readOnly: true
+#PROD#    subPath: filebeat.yml
+#PROD#  - name: data
+#PROD#    mountPath: /usr/share/filebeat/data
+#PROD#  - name: varlog
+#PROD#    mountPath: /var/log
+#PROD#  - name: varlibdockercontainers
+#PROD#    mountPath: /var/lib/docker/containers
+#PROD#    readOnly: true
       - image: registry.cern.ch/cmsweb/exporters:20210706-static
         name: frontend-exporter
         imagePullPolicy: Always
@@ -130,6 +165,15 @@ spec:
           limits:
             memory: "512Mi"
             cpu: "300m"
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         command:
         - /bin/sh
         - -c
@@ -137,6 +181,7 @@ spec:
         volumeMounts:
         - name: robot-secrets
           mountPath: /etc/certs/robot.cert
+          subPath: robotcert.pem
         - name: hostcert
           mountPath: /etc/certs/host.cert
       volumes:
@@ -178,7 +223,6 @@ spec:
 #PROD#      claimName: logs-cephfs-claim-default
       nodeSelector:
         role: auth
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
I made a few changes but this is still not ready to be merged. 

The run.sh script now takes a directory as the argument and checks all the certs in this directory one by one.
The alert message includes the dn of the certificate and the expiration date.
I made it so that it pushes an alert if the certificate will expire in the next 15 days. This should give us enough time to react. 
The alert expiration is also set 15 days in the future.
The cmsweb tag is used in the alert to notify the correct set of people (TODO: Check if it actually works ) 

I experimented with deploying the container as a sidecar in the frontend pods but I think it's not a good strategy. Too many containers are deployed and even if we managed to renew certificates automatically we could do it from one central place. 

I have also managed to automatically renew cern host certificates but there are still a few things I need to figure out.

0. How to make this more configurable. Right now we need to specify the secrets to be mounted one by one in the yaml file. This means that we would need a different manifest file for each cluster, which should be maintained by the cluster operator. 
1. How to update the k8s secrets from within the pod, once I get the renewed certificate (this should be easy by passing the cluster config and installing kubectl)
2. How to restart the pods that are using a certificate when we renew it (This I don't know yet).