### PR TITLE
[CMSMONIT-429] Add timestamp field

### DIFF
--- a/kubernetes/cmsweb/monitoring/logstash.conf
+++ b/kubernetes/cmsweb/monitoring/logstash.conf
@@ -46,6 +46,7 @@ filter {
       ruby {
          code => "event.set('rec_timestamp',event.get('date_object').to_i)
                   event.set('rec_date',event.get('date_object'))
+                  event.set('timestamp',(event.get('rec_timestamp').to_f * 1000).to_i)
                  "
       }
       mutate { gsub =>  [ "dn","/CN=\d+","" ] }
@@ -174,7 +175,7 @@ output {
           format => "json_batch"
           # for message please use double quotes for string type and no-double
           # quotes for objects, e.g. %{agent} is an object, while "%{dn}" is a string
-          message => '{"producer": "cmswebk8s", "type": "frontend", "hostname": "%{hostname}", "agent_id": "%{agent_id}", "ephemeral_id": "%{ephemeral_id}", "cmsweb_log": "%{cmsweb_log}", "message": "%{message}", "api": "%{api}", "client": "%{client}", "clientip": "%{clientip}", "code": %{code}, "crypto": "%{crypto}", "date_object": "%{date_object}", "dn": "%{dn}", "frontend": "%{frontend}", "httpversion": "%{httpversion}", "method": "%{method}", "rec_date": "%{rec_date}", "rec_timestamp": %{rec_timestamp}, "request": "%{request}", "system": "%{system}", "tls": "%{tls}", "tstamp": "%{tstamp}", "uri_params": "%{uri_params}", "uri_path": "%{uri_path}", "bytes_sent": "%{bytes_sent}", "bytes_received": "%{bytes_received}", "body_size": "%{body_size}", "time_spent_ms": "%{time_spent_ms}", "cmsweb_env":"%{cmsweb_env}", "cmsweb_cluster":"%{cmsweb_cluster}", "fe_port": "%{fe_port}"}'
+          message => '{"producer": "cmswebk8s", "type": "frontend", "hostname": "%{hostname}", "agent_id": "%{agent_id}", "ephemeral_id": "%{ephemeral_id}", "cmsweb_log": "%{cmsweb_log}", "message": "%{message}", "api": "%{api}", "client": "%{client}", "clientip": "%{clientip}", "code": %{code}, "crypto": "%{crypto}", "date_object": "%{date_object}", "dn": "%{dn}", "frontend": "%{frontend}", "httpversion": "%{httpversion}", "method": "%{method}", "rec_date": "%{rec_date}", "rec_timestamp": %{rec_timestamp}, "request": "%{request}", "system": "%{system}", "tls": "%{tls}", "tstamp": "%{tstamp}", "uri_params": "%{uri_params}", "uri_path": "%{uri_path}", "bytes_sent": "%{bytes_sent}", "bytes_received": "%{bytes_received}", "body_size": "%{body_size}", "time_spent_ms": "%{time_spent_ms}", "cmsweb_env":"%{cmsweb_env}", "cmsweb_cluster":"%{cmsweb_cluster}", "fe_port": "%{fe_port}", "timestamp": "%{timestamp}"}'
       }
   }
   if [type] == "couchdb" {
@@ -183,7 +184,7 @@ output {
           url => "http://monit-logs.cern.ch:10012/"
           content_type => "application/json; charset=UTF-8"
           format => "json_batch"
-          message => '{"producer": "cmswebk8s", "type": "couchdb", "hostname": "%{hostname}", "agent_id": "%{agent_id}", "ephemeral_id": "%{ephemeral_id}", "cmsweb_log": "%{cmsweb_log}", "message": "%{message}", "clientip":"%{clientip}", "method":"%{method}", "request":"%{request}", "rec_timestamp":"%{rec_timestamp}", "rec_date":"%{rec_date}", "log_level":"%{log_level}", "code":%{code}, "system":"%{system}", "uri_path":"%{uri_path}", "uri_params":"%{uri_params}", "uri_path":"%{uri_path}", "api":"%{api}", "cmsweb_env":"%{cmsweb_env}", "cmsweb_cluster":"%{cmsweb_cluster}"}'
+          message => '{"producer": "cmswebk8s", "type": "couchdb", "hostname": "%{hostname}", "agent_id": "%{agent_id}", "ephemeral_id": "%{ephemeral_id}", "cmsweb_log": "%{cmsweb_log}", "message": "%{message}", "clientip":"%{clientip}", "method":"%{method}", "request":"%{request}", "rec_timestamp":"%{rec_timestamp}", "rec_date":"%{rec_date}", "log_level":"%{log_level}", "code":%{code}, "system":"%{system}", "uri_path":"%{uri_path}", "uri_params":"%{uri_params}", "uri_path":"%{uri_path}", "api":"%{api}", "cmsweb_env":"%{cmsweb_env}", "cmsweb_cluster":"%{cmsweb_cluster}", "timestamp": "%{timestamp}"}'
       }
   }
   if [type] == "dbs" {
@@ -192,7 +193,7 @@ output {
           url => "http://monit-logs.cern.ch:10012/"
           content_type => "application/json; charset=UTF-8"
           format => "json_batch"
-          message => '{"producer": "cmswebk8s", "type": "dbs", "hostname": "%{hostname}", "agent_id": "%{agent_id}", "ephemeral_id": "%{ephemeral_id}", "cmsweb_log": "%{cmsweb_log}", "message": "%{message}", "tstamp": "%{tstamp}", "backend": "%{backend}", "clientip": "%{clientip}", "method":"%{method}", "httpversion":"%{httpversion}", "code":%{code}, "status":"%{status}", "auth":"%{auth}", "dn":"%{dn}", "client_agent":"%{client_agent}", "instance":"%{instance}", "instance_type":"%{instance_type}", "instance_kind":"%{instance_kind}", "api":"%{api}", "params":"%{params}", "request":"%{request}", "rec_timestamp":"%{rec_timestamp}", "rec_date":"%{rec_date}", "cmsweb_env":"%{cmsweb_env}", "cmsweb_cluster":"%{cmsweb_cluster}"}'
+          message => '{"producer": "cmswebk8s", "type": "dbs", "hostname": "%{hostname}", "agent_id": "%{agent_id}", "ephemeral_id": "%{ephemeral_id}", "cmsweb_log": "%{cmsweb_log}", "message": "%{message}", "tstamp": "%{tstamp}", "backend": "%{backend}", "clientip": "%{clientip}", "method":"%{method}", "httpversion":"%{httpversion}", "code":%{code}, "status":"%{status}", "auth":"%{auth}", "dn":"%{dn}", "client_agent":"%{client_agent}", "instance":"%{instance}", "instance_type":"%{instance_type}", "instance_kind":"%{instance_kind}", "api":"%{api}", "params":"%{params}", "request":"%{request}", "rec_timestamp":"%{rec_timestamp}", "rec_date":"%{rec_date}", "cmsweb_env":"%{cmsweb_env}", "cmsweb_cluster":"%{cmsweb_cluster}", "timestamp": "%{timestamp}"}'
       }
   }
   if [type] == "reqmgr2" {
@@ -201,7 +202,7 @@ output {
           url => "http://monit-logs.cern.ch:10012/"
           content_type => "application/json; charset=UTF-8"
           format => "json_batch"
-          message => '{"producer": "cmswebk8s", "type": "reqmgr2", "hostname": "%{hostname}", "agent_id": "%{agent_id}", "ephemeral_id": "%{ephemeral_id}", "cmsweb_log": "%{cmsweb_log}", "message": "%{message}", "tstamp": "%{tstamp}", "backend": "%{backend}", "clientip": "%{clientip}", "method":"%{method}", "httpversion":"%{httpversion}", "code":%{code}, "status":"%{status}", "auth":"%{auth}", "dn":"%{dn}", "client_agent":"%{client_agent}", "request":"%{request}", "rec_timestamp":"%{rec_timestamp}", "rec_date":"%{rec_date}", "cmsweb_env":"%{cmsweb_env}", "cmsweb_cluster":"%{cmsweb_cluster}"}'
+          message => '{"producer": "cmswebk8s", "type": "reqmgr2", "hostname": "%{hostname}", "agent_id": "%{agent_id}", "ephemeral_id": "%{ephemeral_id}", "cmsweb_log": "%{cmsweb_log}", "message": "%{message}", "tstamp": "%{tstamp}", "backend": "%{backend}", "clientip": "%{clientip}", "method":"%{method}", "httpversion":"%{httpversion}", "code":%{code}, "status":"%{status}", "auth":"%{auth}", "dn":"%{dn}", "client_agent":"%{client_agent}", "request":"%{request}", "rec_timestamp":"%{rec_timestamp}", "rec_date":"%{rec_date}", "cmsweb_env":"%{cmsweb_env}", "cmsweb_cluster":"%{cmsweb_cluster}", "timestamp": "%{timestamp}"}'
       }
   }
 


### PR DESCRIPTION
fyi @vkuznet 

Related with [CMSMONIT-429](https://its.cern.ch/jira/browse/CMSMONIT-429) and [INC2963624](https://cern.service-now.com/service-portal?id=ticket&table=incident&n=INC2963624). 

Formula is `timestamp`(millisec) = `rec_timestamp`(sec in UTC) * 1000 . Tested and it's working fine. @muhammadimranfarooqi we can deploy it together, in case of unexpected problem.