### PR TITLE
crabserver docker image: change scripts for new py3 env

### DIFF
--- a/docker/crabserver/addGH.sh
+++ b/docker/crabserver/addGH.sh
@@ -13,9 +13,8 @@ CRABServerDir=`realpath /data/srv/current/sw*/*/cms/crabserver/*`
 # 1. find which GitHub tags were installed
 # beware that directory name in $CRABServerDir may not be the GH tag but rather
 # name assigned at build time like v3.230303-comp4
-export PYTHONPATH=${CRABServerDir}/lib/python2.7/site-packages
-CRABServerGHTag=`python -c "from CRABInterface import __version__; print __version__"`
-WMCoreGHTag=`python -c "from WMCore import __version__; print __version__"`
+CRABServerGHTag=$(grep __version__ $CRABServerDir/lib/python*/site-packages/CRABInterface/__init__.py | tail -n 1 | cut -f1 -d"#" | cut -f2 -d"=" |  tr -d " '\"")
+WMCoreGHTag=$(grep __version__ $CRABServerDir/lib/python*/site-packages/WMCore/__init__.py | cut -f2 -d"=" |  tr -d " '\"")
 
 # 2. create directories for repositories and clone
 mkdir /data/repos

--- a/docker/crabserver/run.sh
+++ b/docker/crabserver/run.sh
@@ -65,6 +65,7 @@ done
 sleep 5
 
 # start the service
+export CRYPTOGRAPHY_ALLOW_OPENSSL_102=true
 /data/srv/current/config/$srv/manage start 'I did read documentation'
 
 # run monitoring script

--- a/docker/crabserver/start.sh
+++ b/docker/crabserver/start.sh
@@ -39,4 +39,5 @@ if [ "$MODE" = fromGH ]; then
 fi
 
 #==== START THE SERVICE
+export CRYPTOGRAPHY_ALLOW_OPENSSL_102=true
 /data/srv/current/config/crabserver/manage start 'I did read documentation'


### PR DESCRIPTION
With the migration of the CRAB REST interface to the py3 environment, we need to adapt the scripts that ends up in the container.

I tested the changes when building both a py2 [1] and a py3 [2] docker image.

I attach here the file where we get the version of WMCore [3] and of CRABInterface [4] from.

fyi: @belforte

[1]:

```plaintext
Step 15/17 : RUN ./addGH.sh
 ---> Running in 248b3cf9106b
/data/repos /data
Cloning into 'CRABServer'...
Cloning into 'WMCore'...
Note: checking out 'v3.210701'.
[...]
HEAD is now at e02a437... fix #6686 (#6687)
Note: checking out '1.4.6.crab1'.
[...]
HEAD is now at aaeabc2... 1.4.6.crab1
/data
```

[2]:
```plaintext
Step 15/17 : RUN ./addGH.sh
 ---> Running in dbb31cc24351
python3 is /data/srv/HG2111d-comp16/sw.dmapelli/slc7_amd64_gcc630/external/python3/3.8.2-comp/bin/python3
/data/repos /data
Cloning into 'CRABServer'...
Cloning into 'WMCore'...
Note: checking out 'py3.211104patch1'.
[...]
HEAD is now at 4ff1cc8... complete removal of unused taskbuffer
Note: checking out '1.5.5'.
[...]
HEAD is now at 80c63c9... 1.5.5
/data
```


[3]

```python
[_crabserver@d9b9df5b5010 data]$ cat $CRABServerDir/lib/python*/site-packages/WMCore/__init__.py
#!/usr/bin/env python3
"""
_WMCore_

Core libraries for Workload Management Packages

"""

__version__ = '1.5.5'
__all__ = []

```

[4]

```python
[_crabserver@d9b9df5b5010 data]$ cat $CRABServerDir/lib/python*/site-packages/CRABInterface/__init__.py
#!/usr/bin/env python3
"""
_RestInterface_

RestInterface component
"""

#the __version__ will be automatically changed when building RPMs
__version__ = 'development'


__version__ = "py3.211104patch1"#Automatically added during RPM build process

```