### PR TITLE
Update sqoop docker image

### DIFF
--- a/docker/sqoop/Dockerfile
+++ b/docker/sqoop/Dockerfile
@@ -1,8 +1,10 @@
-FROM cmssw/cmsweb
+FROM registry.cern.ch/cmsweb/cmsweb:20211103-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 
+RUN yum -y update
 RUN yum install -y cern-hadoop-config spark-bin-2.3.0 hadoop-bin-2.7.5 hbase-bin-1.2.6 sqoop-bin-1.4
 RUN yum install -y java-1.8.0-openjdk-devel
+RUN yum clean all && rm -rf /var/cache/yum
 
 ENV WDIR=/data
 ADD scripts $WDIR/sqoop

--- a/kubernetes/monitoring/services/sqoop.yaml
+++ b/kubernetes/monitoring/services/sqoop.yaml
@@ -21,7 +21,8 @@ spec:
           - /data/sqoop/log
           - "7"
           - "7200"
-          image: cmssw/sqoop:20210715
+          image: registry.cern.ch/cmsmonitoring/sqoop:20211123
+          # image: cmssw/sqoop:20210715
           #image: cmssw/sqoop:20210323-v2
           #image: cmssw/sqoop:20210212
           #image: cmssw/sqoop:20210208


### PR DESCRIPTION
fyi @vkuznet @muhammadimranfarooqi 
I used base cmsweb image of `registry.cern.ch/cmsweb/cmsweb:20211103-stable`. There is also another one in cmsmonitoring:  `registry.cern.ch/cmsmonitoring/cmsweb:20211103 ` Which one should we use in sqoop image?

I pushed this version to `registry.cern.ch/cmsmonitoring/sqoop:20211123`