### PR TITLE
crabserver - test env - sidecar container for persistent logging

### DIFF
--- a/kubernetes/cmsweb/scripts/deploy-srv.sh
+++ b/kubernetes/cmsweb/scripts/deploy-srv.sh
@@ -147,8 +147,8 @@ elif  [ "$cmsweb_env" == "k8s-preprod" ] ; then
 	fi
 
 elif [ "$srv" == "crabserver" ]; then
-            cat $srv.yaml | sed -e "s, #imagetag,$cmsweb_image_tag,g" |  sed -e 's+crabserver/prod+crabserver/preprod+g' | sed -e "s,k8s #k8s#,$cmsweb_env,g"  >  $srv.yaml.new
-            cat $srv.yaml | sed -e "s, #imagetag,$cmsweb_image_tag,g" |  sed -e 's+crabserver/prod+crabserver/preprod+g' | sed -e "s,k8s #k8s#,$cmsweb_env,g" | kubectl apply -f -
+            cat $srv.yaml | sed -e "s,1 #TEST#,,g" | sed -e "s,#TEST#,      ,g" | sed -e "s, #imagetag,$cmsweb_image_tag,g" |  sed -e 's+crabserver/prod+crabserver/preprod+g' | sed -e "s,k8s #k8s#,$cmsweb_env,g"  >  $srv.yaml.new
+            cat $srv.yaml | sed -e "s,1 #TEST#,,g" | sed -e "s,#TEST#,      ,g" | sed -e "s, #imagetag,$cmsweb_image_tag,g" |  sed -e 's+crabserver/prod+crabserver/preprod+g' | sed -e "s,k8s #k8s#,$cmsweb_env,g" | kubectl apply -f -
 
 elif [[ "$srv" == "dbs-global-r"  || "$srv" == "dbs-global-w"  ||  "$srv" == "dbs-migrate"  ||  "$srv" == "dbs-phys03-r" || "$srv" == "dbs-phys03-w" ]] ; then
         cat $srv.yaml | sed -e "s, #imagetag,$cmsweb_image_tag,g" |  sed -e 's+dbs/prod+dbs/dev+g' | sed -e "s,k8s #k8s#,$cmsweb_env,g"  >  $srv.yaml.new

--- a/kubernetes/cmsweb/services/crabserver.yaml
+++ b/kubernetes/cmsweb/services/crabserver.yaml
@@ -142,10 +142,24 @@ spec:
           readOnly: true
         - name: setup-certs-and-run
           mountPath: /opt/setup-certs-and-run
+#TEST#  - name: logs
+#TEST#    mountPath: /data/srv/logs/crabserver
 #PROD#  - name: logs
 #PROD#    mountPath: /data/srv/logs/crabserver
         securityContext:
           privileged: true
+#TEST#- name: crabserver-sidecar
+#TEST#  image: busybox
+#TEST#  args: [/bin/sh, -c, 'sleep 60 && tail -n+1 -f /data/srv/logs/crabserver/crabserver-$(date +%Y%m%d)-$(hostname).log']
+#TEST#  resources:
+#TEST#    requests:
+#TEST#      memory: "50Mi"
+#TEST#      cpu: "50m"
+#TEST#  volumeMounts:
+#TEST#  - name: logs
+#TEST#    mountPath: /data/srv/logs/crabserver
+#TEST#  securityContext:
+#TEST#    allowPrivilegeEscalation: false
 #PROD#- name: crabserver-filebeat
 #PROD#  image: docker.elastic.co/beats/filebeat:7.12.0
 #PROD#  args: [
@@ -197,6 +211,8 @@ spec:
       - name: setup-certs-and-run
         configMap:
           name: crabserver
+#TEST#- name: logs
+#TEST#  emptyDir: {}
 #PROD#- name: logs
 #PROD#  persistentVolumeClaim:
 #PROD#      claimName: logs-cephfs-claim-crab

--- a/kubernetes/cmsweb/services/crabserver.yaml
+++ b/kubernetes/cmsweb/services/crabserver.yaml
@@ -142,56 +142,42 @@ spec:
           readOnly: true
         - name: setup-certs-and-run
           mountPath: /opt/setup-certs-and-run
-#TEST#  - name: logs
-#TEST#    mountPath: /data/srv/logs/crabserver
-#PROD#  - name: logs
-#PROD#    mountPath: /data/srv/logs/crabserver
+        - name: logs
+          mountPath: /data/srv/logs/crabserver
         securityContext:
           privileged: true
-#TEST#- name: crabserver-sidecar
-#TEST#  image: busybox
-#TEST#  args: [/bin/sh, -c, 'sleep 60 && tail -n+1 -f /data/srv/logs/crabserver/crabserver-$(date +%Y%m%d)-$(hostname).log']
-#TEST#  resources:
-#TEST#    requests:
-#TEST#      memory: "50Mi"
-#TEST#      cpu: "50m"
-#TEST#  volumeMounts:
-#TEST#  - name: logs
-#TEST#    mountPath: /data/srv/logs/crabserver
-#TEST#  securityContext:
-#TEST#    allowPrivilegeEscalation: false
-#PROD#- name: crabserver-filebeat
-#PROD#  image: docker.elastic.co/beats/filebeat:7.12.0
-#PROD#  args: [
-#PROD#    "-c", "/etc/filebeat.yml",
-#PROD#    "-e",
-#PROD#  ]
-#PROD#  env:
-#PROD#  - name: MY_POD_NAME
-#PROD#    valueFrom:
-#PROD#      fieldRef:
-#PROD#        apiVersion: v1
-#PROD#        fieldPath: metadata.name
-#PROD#  resources:
-#PROD#    requests:
-#PROD#      memory: "50Mi"
-#PROD#      cpu: "50m"
-#PROD#  volumeMounts:
-#PROD#  - name: logs
-#PROD#    mountPath: /data/srv/logs/crabserver
-#PROD#  - name: config
-#PROD#    mountPath: /etc/filebeat.yml
-#PROD#    readOnly: true
-#PROD#    subPath: filebeat.yml
-#PROD#  - name: data
-#PROD#    mountPath: /usr/share/filebeat/data
-#PROD#  - name: varlog
-#PROD#    mountPath: /var/log
-#PROD#  - name: varlibdockercontainers
-#PROD#    mountPath: /var/lib/docker/containers
-#PROD#    readOnly: true
-#PROD#  securityContext:
-#PROD#    allowPrivilegeEscalation: false
+      - name: crabserver-filebeat
+        image: docker.elastic.co/beats/filebeat:7.12.0
+        args: [
+          "-c", "/etc/filebeat.yml",
+          "-e",
+        ]
+        env:
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        resources:
+          requests:
+            memory: "50Mi"
+            cpu: "50m"
+        volumeMounts:
+        - name: logs
+          mountPath: /data/srv/logs/crabserver
+        - name: config
+          mountPath: /etc/filebeat.yml
+          readOnly: true
+          subPath: filebeat.yml
+        - name: data
+          mountPath: /usr/share/filebeat/data
+        - name: varlog
+          mountPath: /var/log
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+        securityContext:
+          allowPrivilegeEscalation: false
       volumes:
       - name: proxy-secrets
         secret:
@@ -211,20 +197,20 @@ spec:
       - name: setup-certs-and-run
         configMap:
           name: crabserver
-#TEST#- name: logs
-#TEST#  emptyDir: {}
-#PROD#- name: logs
-#PROD#  persistentVolumeClaim:
-#PROD#      claimName: logs-cephfs-claim-crab
-#PROD#- name: varlog
-#PROD#  hostPath:
-#PROD#    path: /var/log
-#PROD#- name: varlibdockercontainers
-#PROD#  hostPath:
-#PROD#    path: /var/lib/docker/containers
-#PROD#- name: config
-#PROD#  configMap:
-#PROD#    defaultMode: 0640
-#PROD#    name: crabserver-filebeat-config
-#PROD#- name: data
-#PROD#  emptyDir: {}
+      - name: logs
+        emptyDir: {}
+      - name: logs
+        persistentVolumeClaim:
+            claimName: logs-cephfs-claim-crab
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+      - name: config
+        configMap:
+          defaultMode: 0640
+          name: crabserver-filebeat-config
+      - name: data
+        emptyDir: {}

--- a/kubernetes/cmsweb/services/crabserver.yaml
+++ b/kubernetes/cmsweb/services/crabserver.yaml
@@ -177,7 +177,7 @@ spec:
           mountPath: /var/lib/docker/containers
           readOnly: true
         securityContext:
-          allowPrivilegeEscalation: false
+          allowPrivilegeEscalation: true
       volumes:
       - name: proxy-secrets
         secret:

--- a/kubernetes/cmsweb/services/crabserver.yaml
+++ b/kubernetes/cmsweb/services/crabserver.yaml
@@ -148,10 +148,11 @@ spec:
           privileged: true
       - name: crabserver-filebeat
         image: docker.elastic.co/beats/filebeat:7.12.0
-        args: [
-          "-c", "/etc/filebeat.yml",
-          "-e",
-        ]
+        command: /bin/sh
+        # args: [
+        #   "-c", "/etc/filebeat.yml",
+        #   "-e",
+        # ]
         env:
         - name: MY_POD_NAME
           valueFrom:
@@ -177,7 +178,7 @@ spec:
           mountPath: /var/lib/docker/containers
           readOnly: true
         securityContext:
-          privileged: true
+          allowPrivilegeEscalation: false
       volumes:
       - name: proxy-secrets
         secret:

--- a/kubernetes/cmsweb/services/crabserver.yaml
+++ b/kubernetes/cmsweb/services/crabserver.yaml
@@ -177,7 +177,7 @@ spec:
           mountPath: /var/lib/docker/containers
           readOnly: true
         securityContext:
-          allowPrivilegeEscalation: true
+          privileged: true
       volumes:
       - name: proxy-secrets
         secret:

--- a/kubernetes/cmsweb/services/crabserver.yaml
+++ b/kubernetes/cmsweb/services/crabserver.yaml
@@ -148,7 +148,8 @@ spec:
           privileged: true
       - name: crabserver-filebeat
         image: docker.elastic.co/beats/filebeat:7.12.0
-        command: /bin/sh
+        command: 
+        - /bin/sh
         # args: [
         #   "-c", "/etc/filebeat.yml",
         #   "-e",

--- a/kubernetes/cmsweb/services/crabserver.yaml
+++ b/kubernetes/cmsweb/services/crabserver.yaml
@@ -150,6 +150,9 @@ spec:
         image: docker.elastic.co/beats/filebeat:7.12.0
         command: 
         - /bin/sh
+        args:
+        - "-c"
+        - "echo ciao"
         # args: [
         #   "-c", "/etc/filebeat.yml",
         #   "-e",

--- a/kubernetes/cmsweb/services/crabserver.yaml
+++ b/kubernetes/cmsweb/services/crabserver.yaml
@@ -201,7 +201,7 @@ spec:
 #TEST#  emptyDir: {}
 #PROD#- name: logs
 #PROD#  persistentVolumeClaim:
-            claimName: logs-cephfs-claim-crab
+#PROD#      claimName: logs-cephfs-claim-crab
       - name: varlog
         hostPath:
           path: /var/log

--- a/kubernetes/cmsweb/services/crabserver.yaml
+++ b/kubernetes/cmsweb/services/crabserver.yaml
@@ -197,10 +197,10 @@ spec:
       - name: setup-certs-and-run
         configMap:
           name: crabserver
-      - name: logs
-        emptyDir: {}
-      - name: logs
-        persistentVolumeClaim:
+#TEST#- name: logs
+#TEST#  emptyDir: {}
+#PROD#- name: logs
+#PROD#  persistentVolumeClaim:
             claimName: logs-cephfs-claim-crab
       - name: varlog
         hostPath:

--- a/kubernetes/cmsweb/services/crabserver.yaml
+++ b/kubernetes/cmsweb/services/crabserver.yaml
@@ -149,7 +149,7 @@ spec:
       - name: crabserver-filebeat
         image: docker.elastic.co/beats/filebeat:7.12.0
         command: ["/bin/sh"]
-        args: ["-c", "echo ciao"]
+        args: ["-c", "while true; do echo $(date); sleep 20;done"]
         # args: [
         #   "-c", "/etc/filebeat.yml",
         #   "-e",

--- a/kubernetes/cmsweb/services/crabserver.yaml
+++ b/kubernetes/cmsweb/services/crabserver.yaml
@@ -148,11 +148,8 @@ spec:
           privileged: true
       - name: crabserver-filebeat
         image: docker.elastic.co/beats/filebeat:7.12.0
-        command: 
-        - /bin/sh
-        args:
-        - "-c"
-        - "echo ciao"
+        command: ["/bin/sh"]
+        args: ["-c", "echo ciao"]
         # args: [
         #   "-c", "/etc/filebeat.yml",
         #   "-e",


### PR DESCRIPTION
When developing the crabserver rest on `cmsweb-test1` and `cmsweb-test2` environment, it would be handy to have persistent logging in case the `crabserver` pod is automatically restarted.

Taking inspiration from [1] , we can use a sidecar container whose sole purpose is to read the file where the crabserver is writing the log and stream it to its stdout. In this way:
- the logs from the crabserver are available with `kubectl -n crab logs $(kubectl -n crab get pods | tee | grep crabserver | grep "2/2" | awk '{print $1}') crabserver-sidecar | less`, even without entering in the crabserver container with bash
- the logs from the crabserver are not lost after it is restarted by the liveness probe.

I tested this on `cmsweb-test1` and it is working.

Any suggestion is very welcome! :)

fyi: @belforte 

[1]: https://kubernetes.io/docs/concepts/cluster-administration/logging/