### PR TITLE
Update hdfs-exporter-eos image to new registry

### DIFF
--- a/kubernetes/monitoring/services/hdfs-exporter-eos.yaml
+++ b/kubernetes/monitoring/services/hdfs-exporter-eos.yaml
@@ -45,9 +45,8 @@ spec:
       spec:
         containers:
         - name: hdfs-exporter-eos
-          image: cmssw/sqoop:20210715
-          #image: cmssw/sqoop:20210323-v2
-          #image: cmssw/sqoop:20210212-v2
+          image: registry.cern.ch/cmsmonitoring/sqoop:20211123
+          #image: cmssw/sqoop:20210715
           command:
           - /bin/sh
           - /data/setup-and-run/setup-and-run.sh


### PR DESCRIPTION
@leggerf the pod is deployed with new image, this will solve "No data in HDFS EOS" alerts.
Now, all `cmssw/sqoop` images in CMSKubernetes deployments are totally migrated to new registry `registry.cern.ch/cmsmonitoring/sqoop:20211123` 