### PR TITLE
Improve cron jobs which dump rucio dids and contents tables to hdfs

### DIFF
--- a/docker/sqoop/cronjobs.txt
+++ b/docker/sqoop/cronjobs.txt
@@ -20,8 +20,9 @@
 30 06 * * * cd /data/sqoop; ./run.sh ./rucio_replicas.sh
 
 # Rucio DIDS table dump
-# 30 01 * * 1 cd /data/sqoop; ./run.sh ./rucio_dids.sh
-# 30 02 * * 1 cd /data/sqoop; ./run.sh ./rucio_contents.sh
+00 01 * * * cd /data/sqoop; ./run.sh ./rucio_dids.sh
+# Rucio CONTENTS table dump
+15 02 * * * cd /data/sqoop; ./run.sh ./rucio_contents.sh
 
 # DBS dumps
 27 03 * * *   cd /data/sqoop; ./run.sh ./cms-dbs3-datasets.sh

--- a/docker/sqoop/scripts/rucio_contents.sh
+++ b/docker/sqoop/scripts/rucio_contents.sh
@@ -1,43 +1,67 @@
-# Imports CMS_RUCIO_PROD.CONTENTS table for access time of datasets
-BASE_PATH=/project/awg/cms/rucio_contents/
-JDBC_URL=jdbc:oracle:thin:@cms-nrac-scan.cern.ch:10121/CMSR_CMS_NRAC.cern.ch
-if [ -f /etc/secrets/rucio ]; then
-  USERNAME=$(grep username </etc/secrets/rucio | awk '{print $2}')
-  PASSWORD=$(grep password </etc/secrets/rucio | awk '{print $2}')
-else
-  echo "Unable to read Rucio credentials"
-  exit 1
-fi
+#!/bin/bash
+set -e
 
-# There should be always one folder
-PREVIOUS_FOLDER=$(hadoop fs -ls $BASE_PATH | awk '{ORS=""; print $8}')
-LOG_FILE=log/$(date +'%F_%H%m%S')_$(basename "$0")
+# Imports CMS_RUCIO_PROD.CONTENTS table for access time of datasets
+
+# Hdfs output path
+BASE_PATH=/project/awg/cms/rucio_contents/
+TARGET_DIR=$BASE_PATH"$(date +%Y-%m-%d)"
+
+# Rucio table name
 TABLE=CMS_RUCIO_PROD.CONTENTS
+# Oracle jdbc conn
+JDBC_URL=jdbc:oracle:thin:@cms-nrac-scan.cern.ch:10121/CMSR_CMS_NRAC.cern.ch
+
+# Log file
+LOG_FILE=log/$(date +'%F_%H%m%S')_$(basename "$0")
+# Timezone
 TZ=UTC
+
+####
+trap 'onFailExit' ERR
+onFailExit() {
+    echo "Finished with error! Please see logs!"
+    echo "Log files: ${LOG_FILE}"
+    echo FAILED
+    exit 1
+}
+
+####
+if [ -f /etc/secrets/rucio ]; then
+    USERNAME=$(grep username </etc/secrets/rucio | awk '{print $2}')
+    PASSWORD=$(grep password </etc/secrets/rucio | awk '{print $2}')
+else
+    echo "Unable to read Rucio credentials"
+    exit 1
+fi
 
 # Check sqoop and hadoop executables exist
 if ! [ -x "$(command -v hadoop)" ] || ! [ -x "$(command -v sqoop)" ]; then
-  echo "It seems 'sqoop' or 'hadoop' is not exist in PATH! Exiting..."
-  exit 1
+    echo "It seems 'sqoop' or 'hadoop' is not exist in PATH! Exiting..."
+    exit 1
 fi
 
+echo "[INFO] Sqoob job for Rucio CONTENTS table is starting.."
+echo "[INFO] Rucio table will be imported: ${TABLE}"
 sqoop import \
-  -Dmapreduce.job.user.classpath.first=true \
-  -Ddfs.client.socket-timeout=120000 \
-  --username "$USERNAME" --password "$PASSWORD" \
-  -m 1 \
-  -z \
-  --direct \
-  --connect $JDBC_URL \
-  --fetch-size 10000 \
-  --as-avrodatafile \
-  --target-dir "$BASE_PATH""$(date +%Y-%m-%d)" \
-  --query "SELECT * FROM ${TABLE} WHERE did_type='D' AND child_type='F' AND \$CONDITIONS" \
-  1>"$LOG_FILE".stdout 2>"$LOG_FILE".stderr
+    -Dmapreduce.job.user.classpath.first=true \
+    -Doraoop.timestamp.string=false \
+    -Dmapred.child.java.opts="-Djava.security.egd=file:/dev/../dev/urandom" \
+    -Ddfs.client.socket-timeout=120000 \
+    --username "$USERNAME" --password "$PASSWORD" \
+    -z \
+    --direct \
+    --throw-on-error \
+    --connect $JDBC_URL \
+    --num-mappers 100 \
+    --fetch-size 10000 \
+    --as-avrodatafile \
+    --target-dir "$TARGET_DIR" \
+    --table "$TABLE" 1>"$LOG_FILE".stdout 2>"$LOG_FILE".stderr
 
 # change permission of HDFS area
-hadoop fs -chmod -R o+rx $BASE_PATH"$(date +%Y-%m-%d)"
+hadoop fs -chmod -R o+rx "$TARGET_DIR"
 
-# Delete previous folder
-hadoop fs -rmdir --ignore-fail-on-non-empty "$PREVIOUS_FOLDER"
-echo "$PREVIOUS_FOLDER is deleted"
+echo "[INFO] Sqoob job for Rucio CONTENTS table is finished."
+echo "[INFO] Output hdfs path : ${TARGET_DIR}"
+echo SUCCESS

--- a/docker/sqoop/scripts/rucio_dids.sh
+++ b/docker/sqoop/scripts/rucio_dids.sh
@@ -1,43 +1,69 @@
-# Imports CMS_RUCIO_PROD.DIDS table for access time of datasets
-BASE_PATH=/project/awg/cms/rucio_dids/
-JDBC_URL=jdbc:oracle:thin:@cms-nrac-scan.cern.ch:10121/CMSR_CMS_NRAC.cern.ch
-if [ -f /etc/secrets/rucio ]; then
-  USERNAME=$(grep username </etc/secrets/rucio | awk '{print $2}')
-  PASSWORD=$(grep password </etc/secrets/rucio | awk '{print $2}')
-else
-  echo "Unable to read Rucio credentials"
-  exit 1
-fi
+#!/bin/bash
+set -e
 
-# There should be always one folder
-PREVIOUS_FOLDER=$(hadoop fs -ls $BASE_PATH | awk '{ORS=""; print $8}')
-LOG_FILE=log/$(date +'%F_%H%m%S')_$(basename "$0")
+# Imports CMS_RUCIO_PROD.DIDS table for access time of datasets
+
+# Hdfs output path
+BASE_PATH=/project/awg/cms/rucio_dids/
+TARGET_DIR=$BASE_PATH"$(date +%Y-%m-%d)"
+
+# Oracle jdbc conn
+JDBC_URL=jdbc:oracle:thin:@cms-nrac-scan.cern.ch:10121/CMSR_CMS_NRAC.cern.ch
+# Rucio table
 TABLE=CMS_RUCIO_PROD.DIDS
+# sqoop import query
+SQL_QUERY="SELECT * FROM ${TABLE} WHERE scope='cms' AND deleted_at IS NULL AND hidden=0 AND \$CONDITIONS"
+
+# Local log file for both sqoop job stdout and stderr
+LOG_FILE=log/$(date +'%F_%H%m%S')_$(basename "$0")
+# Timezone
 TZ=UTC
+
+####
+trap 'onFailExit' ERR
+onFailExit() {
+    echo "Finished with error! Please see logs!"
+    echo "Log files: ${LOG_FILE}"
+    echo FAILED
+    exit 1
+}
+
+####
+if [ -f /etc/secrets/rucio ]; then
+    USERNAME=$(grep username </etc/secrets/rucio | awk '{print $2}')
+    PASSWORD=$(grep password </etc/secrets/rucio | awk '{print $2}')
+else
+    echo "[ERROR] Unable to read Rucio credentials"
+    exit 1
+fi
 
 # Check sqoop and hadoop executables exist
 if ! [ -x "$(command -v hadoop)" ] || ! [ -x "$(command -v sqoop)" ]; then
-  echo "It seems 'sqoop' or 'hadoop' is not exist in PATH! Exiting..."
-  exit 1
+    echo "[ERROR] It seems 'sqoop' or 'hadoop' is not exist in PATH! Exiting..."
+    exit 1
 fi
 
+# Start sqoop
+echo "[INFO] Sqoob job for Rucio DIDS table is starting.."
+echo "[INFO] Rucio table will be imported: ${TABLE}"
+echo "[INFO] Import SQL query: ${SQL_QUERY}"
 sqoop import \
-  -Dmapreduce.job.user.classpath.first=true \
-  -Ddfs.client.socket-timeout=120000 \
-  --username "$USERNAME" --password "$PASSWORD" \
-  -m 1 \
-  -z \
-  --direct \
-  --connect $JDBC_URL \
-  --fetch-size 10000 \
-  --as-avrodatafile \
-  --target-dir "$BASE_PATH""$(date +%Y-%m-%d)" \
-  --query "SELECT * FROM ${TABLE} WHERE scope='cms' AND deleted_at IS NULL AND hidden=0 AND \$CONDITIONS" \
-  1>"$LOG_FILE".stdout 2>"$LOG_FILE".stderr
+    -Dmapreduce.job.user.classpath.first=true \
+    -Ddfs.client.socket-timeout=120000 \
+    --username "$USERNAME" --password "$PASSWORD" \
+    -m 1 \
+    -z \
+    --direct \
+    --throw-on-error \
+    --connect $JDBC_URL \
+    --fetch-size 10000 \
+    --as-avrodatafile \
+    --target-dir "$TARGET_DIR" \
+    --query "$SQL_QUERY" 1>"$LOG_FILE".stdout 2>"$LOG_FILE".stderr
 
 # change permission of HDFS area
-hadoop fs -chmod -R o+rx $BASE_PATH"$(date +%Y-%m-%d)"
+hadoop fs -chmod -R o+rx "$TARGET_DIR"
 
-# Delete previous folder
-hadoop fs -rmdir --ignore-fail-on-non-empty "$PREVIOUS_FOLDER"
-echo "$PREVIOUS_FOLDER is deleted"
+echo "[INFO] Sqoob job for Rucio DIDS table is finished."
+echo "[INFO] Output hdfs path : ${TARGET_DIR}"
+echo SUCCESS

--- a/docker/sqoop/tests/test_rucio_dids.sh
+++ b/docker/sqoop/tests/test_rucio_dids.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Create ./test/log directory if not exist
+[ -d ./log ] || mkdir -p ./log
+
+BASE_PATH=/tmp/cmssqoop/rucio_dids/
+
+sed -e "s,BASE_PATH=.*,BASE_PATH=${BASE_PATH},g" \
+    -e "s,WHERE scope,WHERE ROWNUM <= 10 AND scope,g" \
+    /data/sqoop/rucio_dids.sh >.test_rucio_dids.tmp
+#bash .test_rucio_dids.tmp
+#rm .test_rucio_dids.tmp


### PR DESCRIPTION
Improve cron jobs which dump Rucio DIDS and CONTENTS tables to HDFS, to produce datasets and tables which are not read last N months.

- Dump logic is changed: cron jobs will run every day and will produce daily dumps in hdfs _without deleting old ones_.
- Bash function usage is removed to catch errors.
- Trap function implemented
