### PR TITLE
Fix sqoop jobs rucio_dids and rucio_contents

### DIFF
--- a/docker/sqoop/cronjobs.txt
+++ b/docker/sqoop/cronjobs.txt
@@ -22,7 +22,7 @@
 # Rucio DIDS table dump
 00 01 * * * cd /data/sqoop; ./run.sh ./rucio_dids.sh
 # Rucio CONTENTS table dump
-15 02 * * * cd /data/sqoop; ./run.sh ./rucio_contents.sh
+30 02 * * * cd /data/sqoop; ./run.sh ./rucio_contents.sh
 
 # DBS dumps
 27 03 * * *   cd /data/sqoop; ./run.sh ./cms-dbs3-datasets.sh

--- a/docker/sqoop/scripts/rucio_dids.sh
+++ b/docker/sqoop/scripts/rucio_dids.sh
@@ -11,8 +11,6 @@ TARGET_DIR=$BASE_PATH"$(date +%Y-%m-%d)"
 JDBC_URL=jdbc:oracle:thin:@cms-nrac-scan.cern.ch:10121/CMSR_CMS_NRAC.cern.ch
 # Rucio table
 TABLE=CMS_RUCIO_PROD.DIDS
-# sqoop import query
-SQL_QUERY="SELECT * FROM ${TABLE} WHERE scope='cms' AND deleted_at IS NULL AND hidden=0 AND \$CONDITIONS"
 
 # Local log file for both sqoop job stdout and stderr
 LOG_FILE=log/$(date +'%F_%H%m%S')_$(basename "$0")
@@ -22,9 +20,8 @@ TZ=UTC
 ####
 trap 'onFailExit' ERR
 onFailExit() {
-    echo "Finished with error! Please see logs!"
-    echo "Log files: ${LOG_FILE}"
-    echo FAILED
+    echo "Finished with error!" >>"$LOG_FILE".stdout
+    echo "FAILED" >>"$LOG_FILE".stdout
     exit 1
 }
 
@@ -33,37 +30,43 @@ if [ -f /etc/secrets/rucio ]; then
     USERNAME=$(grep username </etc/secrets/rucio | awk '{print $2}')
     PASSWORD=$(grep password </etc/secrets/rucio | awk '{print $2}')
 else
-    echo "[ERROR] Unable to read Rucio credentials"
+    echo "[ERROR] Unable to read Rucio credentials" >>"$LOG_FILE".stdout
     exit 1
 fi
 
 # Check sqoop and hadoop executables exist
-if ! [ -x "$(command -v hadoop)" ] || ! [ -x "$(command -v sqoop)" ]; then
-    echo "[ERROR] It seems 'sqoop' or 'hadoop' is not exist in PATH! Exiting..."
+if ! [ -x "$(command -v hadoop)" ]; then
+    echo "[ERROR] It seems 'hadoop' is not exist in PATH! Exiting..." >>"$LOG_FILE".stdout
     exit 1
 fi
 
+{
+    echo "[INFO] Sqoob job for Rucio DIDS table is starting.."
+    echo "[INFO] Rucio table will be imported: ${TABLE}"
+} >>"$LOG_FILE".stdout
+
 # Start sqoop
-echo "[INFO] Sqoob job for Rucio DIDS table is starting.."
-echo "[INFO] Rucio table will be imported: ${TABLE}"
-echo "[INFO] Import SQL query: ${SQL_QUERY}"
-sqoop import \
+/usr/hdp/sqoop/bin/sqoop import \
     -Dmapreduce.job.user.classpath.first=true \
+    -Doraoop.timestamp.string=false \
+    -Dmapred.child.java.opts="-Djava.security.egd=file:/dev/../dev/urandom" \
     -Ddfs.client.socket-timeout=120000 \
     --username "$USERNAME" --password "$PASSWORD" \
-    -m 1 \
     -z \
     --direct \
     --throw-on-error \
     --connect $JDBC_URL \
+    --num-mappers 100 \
     --fetch-size 10000 \
     --as-avrodatafile \
     --target-dir "$TARGET_DIR" \
-    --query "$SQL_QUERY" 1>"$LOG_FILE".stdout 2>"$LOG_FILE".stderr
+    --table "$TABLE" 1>"$LOG_FILE".stdout 2>"$LOG_FILE".stderr
 
 # change permission of HDFS area
 hadoop fs -chmod -R o+rx "$TARGET_DIR"
 
-echo "[INFO] Sqoob job for Rucio DIDS table is finished."
-echo "[INFO] Output hdfs path : ${TARGET_DIR}"
-echo SUCCESS
+{
+    echo "[INFO] Sqoob job for Rucio DIDS table is finished."
+    echo "[INFO] Output hdfs path : ${TARGET_DIR}"
+    echo "SUCCESS"
+} >>"$LOG_FILE".stdout


### PR DESCRIPTION
Couple of fixes and improvements:

- Cron did not get `sqoop` path, full path of `sqoop` is set
- Logging improved, now appends to log files
- Sqoop job takes too long when sql query used in DIDS table. 
   - Because there is no integer primary key in that table (there is compound pk) to use paralel import functionality of Sqoop. 
   - So sqoop import changed to full dump of the table. 
   - Process time decreased from 1hour+ to less than 15min. 
   - And hdfs directory size did not increased drasticly (just 100MB) 