### PR TITLE
Fix httpgo

### DIFF
--- a/kubernetes/monitoring/services/httpgo.yaml
+++ b/kubernetes/monitoring/services/httpgo.yaml
@@ -48,11 +48,3 @@ spec:
               command: ["/bin/sh", "-c", "ls"]
         ports:
         - containerPort: 8888
-        volumeMounts:
-        - name: proxy-secrets
-          mountPath: /etc/proxy
-          readOnly: true
-      volumes:
-      - name: proxy-secrets
-        secret:
-          secretName: proxy-secrets


### PR DESCRIPTION
Already deployed to ha1 (others are fine). 

@vkuznet  Should we add HA deployments to `deploy.sh`? 
`deploy.sh` needs some improvements IIUC: secrets deployments are not same with `deploy-secrets.sh` and no HA deployments. I'll implement it in another PR if you give green light.