### PR TITLE
Fix sqoop dockerfile

### DIFF
--- a/docker/sqoop/Dockerfile
+++ b/docker/sqoop/Dockerfile
@@ -41,9 +41,6 @@ COPY --from=go-builder /data/monit /data
 COPY --from=go-builder /data/CMSMonitoring/sqoop /data/sqoop
 
 WORKDIR $WDIR/sqoop
-RUN crontab cronjobs.txt
-
-WORKDIR $WDIR/sqoop/scripts
-RUN ln -s /etc/cmsdb/cmsr_cstring && ln -s /etc/cmsdb/lcgr_cstring
+RUN crontab cronjobs.txt && ln -s /etc/cmsdb/cmsr_cstring && ln -s /etc/cmsdb/lcgr_cstring
 
 WORKDIR $WDIR


### PR DESCRIPTION
@vkuznet 

Sorry, It seems I mistakenly created symbolic links in wrong directory. These crons are affected, should I run them manually now or should we wait next run? 

- cms-aso.sh
- cms-dbs3-blocks.sh
- cms-dbs3-datasets.sh
- cms-dbs3-files.sh
- phedex-file-catalog.sh
- phedex-blk-replicas-snapshot.sh
- 120215_cms-aso.sh