### PR TITLE
Update cmsmon-alerts and cmsmon-int images tag

### DIFF
--- a/kubernetes/monitoring/services/cmsmon-intelligence.yaml
+++ b/kubernetes/monitoring/services/cmsmon-intelligence.yaml
@@ -20,8 +20,7 @@ spec:
           - /data/intelligence
           - -config
           - /etc/secrets/config.json
-          image: registry.cern.ch/cmsmonitoring/cmsmon-int:go-0.5.37
-          #image: cmssw/cmsmon-intelligence:0.5.29
+          image: registry.cern.ch/cmsmonitoring/cmsmon-int:go-0.5.38
           name: intelligence
           imagePullPolicy: Always
           volumeMounts:

--- a/kubernetes/monitoring/services/es-exporter-wma.yaml
+++ b/kubernetes/monitoring/services/es-exporter-wma.yaml
@@ -41,8 +41,7 @@ spec:
           - -port
           - ":18000"
           name: es-exporter-wma
-          image: registry.cern.ch/cmsmonitoring/cmsmon-alerts:go-0.5.37
-          #image: cmssw/cmsmon-alerts:0.5.17
+          image: registry.cern.ch/cmsmonitoring/cmsmon-alerts:go-0.5.38
           ports:
           - containerPort: 18000
           volumeMounts:

--- a/kubernetes/monitoring/services/ggus-alerts.yaml
+++ b/kubernetes/monitoring/services/ggus-alerts.yaml
@@ -25,8 +25,7 @@ spec:
           - "cms"
           - "10"
           - "1"
-          image: registry.cern.ch/cmsmonitoring/cmsmon-alerts:go-0.5.37
-          #image: cmssw/cmsmon-alerts:0.5.35
+          image: registry.cern.ch/cmsmonitoring/cmsmon-alerts:go-0.5.38
           name: alerts
           env:
             - name: X509_USER_PROXY

--- a/kubernetes/monitoring/services/ha/cmsmon-intelligence.yaml
+++ b/kubernetes/monitoring/services/ha/cmsmon-intelligence.yaml
@@ -20,8 +20,7 @@ spec:
           - /data/intelligence
           - -config
           - /etc/secrets/config.json
-          image: registry.cern.ch/cmsmonitoring/cmsmon-int:go-0.5.37
-          #image: cmssw/cmsmon-intelligence:20201103-v1
+          image: registry.cern.ch/cmsmonitoring/cmsmon-int:go-0.5.38
           name: intelligence
           imagePullPolicy: Always
           volumeMounts:

--- a/kubernetes/monitoring/services/ha/ggus-alerts-ha1.yaml
+++ b/kubernetes/monitoring/services/ha/ggus-alerts-ha1.yaml
@@ -25,8 +25,7 @@ spec:
           - "cms"
           - "10"
           - "1"
-          image: registry.cern.ch/cmsmonitoring/cmsmon-alerts:go-0.5.37
-          #image: cmssw/cmsmon-alerts:0.5.35
+          image: registry.cern.ch/cmsmonitoring/cmsmon-alerts:go-0.5.38
           name: alerts
           env:
             - name: X509_USER_PROXY

--- a/kubernetes/monitoring/services/ha/ggus-alerts-ha2.yaml
+++ b/kubernetes/monitoring/services/ha/ggus-alerts-ha2.yaml
@@ -25,8 +25,7 @@ spec:
           - "cms"
           - "10"
           - "1"
-          image: registry.cern.ch/cmsmonitoring/cmsmon-alerts:go-0.5.37
-          #image: cmssw/cmsmon-alerts:0.5.35
+          image: registry.cern.ch/cmsmonitoring/cmsmon-alerts:go-0.5.38
           name: alerts
           env:
             - name: X509_USER_PROXY

--- a/kubernetes/monitoring/services/ha/ssb-alerts-ha1.yaml
+++ b/kubernetes/monitoring/services/ha/ssb-alerts-ha1.yaml
@@ -24,8 +24,7 @@ spec:
           - "http://cms-monitoring-ha1.cern.ch:30093"
           - "60"
           - "1"
-          image: registry.cern.ch/cmsmonitoring/cmsmon-alerts:go-0.5.37
-          #image: cmssw/cmsmon-alerts:0.5.35
+          image: registry.cern.ch/cmsmonitoring/cmsmon-alerts:go-0.5.38
           name: alerts
           volumeMounts:
           - name: alerts-secrets

--- a/kubernetes/monitoring/services/ha/ssb-alerts-ha2.yaml
+++ b/kubernetes/monitoring/services/ha/ssb-alerts-ha2.yaml
@@ -24,8 +24,7 @@ spec:
           - "http://cms-monitoring-ha2.cern.ch:30093"
           - "60"
           - "1"
-          image: registry.cern.ch/cmsmonitoring/cmsmon-alerts:go-0.5.37
-          #image: cmssw/cmsmon-alerts:0.5.35
+          image: registry.cern.ch/cmsmonitoring/cmsmon-alerts:go-0.5.38
           name: alerts
           volumeMounts:
           - name: alerts-secrets

--- a/kubernetes/monitoring/services/ssb-alerts.yaml
+++ b/kubernetes/monitoring/services/ssb-alerts.yaml
@@ -24,8 +24,7 @@ spec:
           - "http://cms-monitoring.cern.ch:30093"
           - "60"
           - "1"
-          image: registry.cern.ch/cmsmonitoring/cmsmon-alerts:go-0.5.37
-          #image: cmssw/cmsmon-alerts:0.5.35
+          image: registry.cern.ch/cmsmonitoring/cmsmon-alerts:go-0.5.38
           name: alerts
           volumeMounts:
           - name: alerts-secrets


### PR DESCRIPTION
- cmsmonit intelligence service is working fine now, I can see annotations
- `cmsmonit-intelligence`, `ggus_alerts`, `ssb_alerts` and `es-exporter-wma` services image tags are updated with the last one.
- All mentioned services deployed to 3 clusters and working fine.
- Documentation is updated: [PR](https://gitlab.cern.ch/cmsmonitoring/cmsmonit-docs/-/merge_requests/9)