### PR TITLE
Skip backfill path from consistency check

### DIFF
--- a/helm/rucio-consistency/Chart.yaml
+++ b/helm/rucio-consistency/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.5
+version: 0.4.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/rucio-consistency/templates/consistency-configmap.yaml
+++ b/helm/rucio-consistency/templates/consistency-configmap.yaml
@@ -34,6 +34,9 @@ data:
           - path: himc
           - path: relval
         dbdump:
+          path_root: /
+          ignore:
+            - backfill
 {{- if  (.Values.consistency.filter) }}
           filter: {{ .Values.consistency.filter }}
 {{- end }}


### PR DESCRIPTION
Remove `backfill/*/data`, `backfill/*/express` and `backfill/*/hidata` from consistency check and DB dumper. This path is used by Tier0 replays and should not be count for this tool.