### PR TITLE
reduce memory limit to 1.5Gi and incerase hpa to 10

### DIFF
--- a/kubernetes/cmsweb/hpa/crabserver-hpa.yaml
+++ b/kubernetes/cmsweb/hpa/crabserver-hpa.yaml
@@ -4,8 +4,8 @@ metadata:
   name: crabserver-hpa
   namespace: crab
 spec:
-  maxReplicas: 8
-  minReplicas: 5
+  maxReplicas: 10
+  minReplicas: 10
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment

--- a/kubernetes/cmsweb/services/crabserver.yaml
+++ b/kubernetes/cmsweb/services/crabserver.yaml
@@ -69,7 +69,7 @@ spec:
   selector:
     matchLabels:
       app: crabserver
-  replicas: 1 #PROD# 5
+  replicas: 1 #PROD# 10
   template:
     metadata:
       labels:
@@ -92,7 +92,7 @@ spec:
             memory: "256Mi"
             cpu: "200m"
           limits:
-            memory: "3Gi"
+            memory: "1.5Gi"
             cpu: "1500m"
         livenessProbe:
           exec:


### PR DESCRIPTION
Reduce mem limit to 1.5Gi to use with new crabserver config: 10 threadpool, scale out pod to 10.

[memory usage of 5(green)/10(orange)/15(magenta)/25(sky) threadpools](https://monit-grafana.cern.ch/d/cmsweb_crabserver/crabserver-cmsweb?orgId=11&from=1644434324136&to=1645026172547&viewPanel=29)
![Screenshot from 2022-02-17 10-25-49](https://user-images.githubusercontent.com/2346664/154445764-10ac2d2d-3dcd-4aa8-be7f-e02853fe5543.png)

Increase hpa number in case anyone accidentally apply hpa manifest.