### PR TITLE
Increase socket and connect timeout of logstash

### DIFF
--- a/kubernetes/cmsweb/monitoring/logstash.conf
+++ b/kubernetes/cmsweb/monitoring/logstash.conf
@@ -176,6 +176,8 @@ output {
           # for message please use double quotes for string type and no-double
           # quotes for objects, e.g. %{agent} is an object, while "%{dn}" is a string
           message => '{"producer": "cmswebk8s", "type": "frontend", "hostname": "%{hostname}", "agent_id": "%{agent_id}", "ephemeral_id": "%{ephemeral_id}", "cmsweb_log": "%{cmsweb_log}", "message": "%{message}", "api": "%{api}", "client": "%{client}", "clientip": "%{clientip}", "code": %{code}, "crypto": "%{crypto}", "date_object": "%{date_object}", "dn": "%{dn}", "frontend": "%{frontend}", "httpversion": "%{httpversion}", "method": "%{method}", "rec_date": "%{rec_date}", "rec_timestamp": %{rec_timestamp}, "request": "%{request}", "system": "%{system}", "tls": "%{tls}", "tstamp": "%{tstamp}", "uri_params": "%{uri_params}", "uri_path": "%{uri_path}", "bytes_sent": "%{bytes_sent}", "bytes_received": "%{bytes_received}", "body_size": "%{body_size}", "time_spent_ms": "%{time_spent_ms}", "cmsweb_env":"%{cmsweb_env}", "cmsweb_cluster":"%{cmsweb_cluster}", "fe_port": "%{fe_port}", "timestamp": "%{timestamp}"}'
+          socket_timeout => 60
+          connect_timeout => 60
       }
   }
   if [type] == "couchdb" {
@@ -185,6 +187,8 @@ output {
           content_type => "application/json; charset=UTF-8"
           format => "json_batch"
           message => '{"producer": "cmswebk8s", "type": "couchdb", "hostname": "%{hostname}", "agent_id": "%{agent_id}", "ephemeral_id": "%{ephemeral_id}", "cmsweb_log": "%{cmsweb_log}", "message": "%{message}", "clientip":"%{clientip}", "method":"%{method}", "request":"%{request}", "rec_timestamp":"%{rec_timestamp}", "rec_date":"%{rec_date}", "log_level":"%{log_level}", "code":%{code}, "system":"%{system}", "uri_path":"%{uri_path}", "uri_params":"%{uri_params}", "uri_path":"%{uri_path}", "api":"%{api}", "cmsweb_env":"%{cmsweb_env}", "cmsweb_cluster":"%{cmsweb_cluster}", "timestamp": "%{timestamp}"}'
+          socket_timeout => 60
+          connect_timeout => 60
       }
   }
   if [type] == "dbs" {
@@ -194,6 +198,8 @@ output {
           content_type => "application/json; charset=UTF-8"
           format => "json_batch"
           message => '{"producer": "cmswebk8s", "type": "dbs", "hostname": "%{hostname}", "agent_id": "%{agent_id}", "ephemeral_id": "%{ephemeral_id}", "cmsweb_log": "%{cmsweb_log}", "message": "%{message}", "tstamp": "%{tstamp}", "backend": "%{backend}", "clientip": "%{clientip}", "method":"%{method}", "httpversion":"%{httpversion}", "code":%{code}, "status":"%{status}", "auth":"%{auth}", "dn":"%{dn}", "client_agent":"%{client_agent}", "instance":"%{instance}", "instance_type":"%{instance_type}", "instance_kind":"%{instance_kind}", "api":"%{api}", "params":"%{params}", "request":"%{request}", "rec_timestamp":"%{rec_timestamp}", "rec_date":"%{rec_date}", "cmsweb_env":"%{cmsweb_env}", "cmsweb_cluster":"%{cmsweb_cluster}", "timestamp": "%{timestamp}"}'
+          socket_timeout => 60
+          connect_timeout => 60
       }
   }
   if [type] == "reqmgr2" {
@@ -203,6 +209,8 @@ output {
           content_type => "application/json; charset=UTF-8"
           format => "json_batch"
           message => '{"producer": "cmswebk8s", "type": "reqmgr2", "hostname": "%{hostname}", "agent_id": "%{agent_id}", "ephemeral_id": "%{ephemeral_id}", "cmsweb_log": "%{cmsweb_log}", "message": "%{message}", "tstamp": "%{tstamp}", "backend": "%{backend}", "clientip": "%{clientip}", "method":"%{method}", "httpversion":"%{httpversion}", "code":%{code}, "status":"%{status}", "auth":"%{auth}", "dn":"%{dn}", "client_agent":"%{client_agent}", "request":"%{request}", "rec_timestamp":"%{rec_timestamp}", "rec_date":"%{rec_date}", "cmsweb_env":"%{cmsweb_env}", "cmsweb_cluster":"%{cmsweb_cluster}", "timestamp": "%{timestamp}"}'
+          socket_timeout => 60
+          connect_timeout => 60
       }
   }
 


### PR DESCRIPTION
Increases Logstash http output socket and connect timeouts to 60 seconds which had 10 seconds as default.
Ref: https://www.elastic.co/guide/en/logstash/current/plugins-outputs-http.html
