### PR TITLE
Adjust k8s api versions and image tags

### DIFF
--- a/kubernetes/monitoring/crons/cron-kerberos.yaml
+++ b/kubernetes/monitoring/crons/cron-kerberos.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: cron-kerberos

--- a/kubernetes/monitoring/crons/cron-proxy.yaml
+++ b/kubernetes/monitoring/crons/cron-proxy.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: cron-proxy

--- a/kubernetes/monitoring/services/ha/kube-eagle.yaml
+++ b/kubernetes/monitoring/services/ha/kube-eagle.yaml
@@ -8,7 +8,7 @@ metadata:
   name: sa-kube-eagle                         
 ---                     
 # Source: kube-eagle/templates/clusterrole.yaml
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:          
   labels:                  
@@ -32,7 +32,7 @@ rules:
       - get               
       - list                                                  
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding          
 metadata:                  
   labels:                            

--- a/kubernetes/monitoring/services/hdfs-exporter-eos.yaml
+++ b/kubernetes/monitoring/services/hdfs-exporter-eos.yaml
@@ -45,8 +45,7 @@ spec:
       spec:
         containers:
         - name: hdfs-exporter-eos
-          image: registry.cern.ch/cmsmonitoring/sqoop:20211123
-          #image: cmssw/sqoop:20210715
+          image: registry.cern.ch/cmsmonitoring/sqoop:sqoop-0.0.5
           command:
           - /bin/sh
           - /data/setup-and-run/setup-and-run.sh

--- a/kubernetes/monitoring/services/karma.yaml
+++ b/kubernetes/monitoring/services/karma.yaml
@@ -42,7 +42,6 @@ spec:
         volumeMounts:
         - name: karma-secrets
           mountPath: /etc/secrets
-          defaultMode: 256
       volumes:
       - name: karma-secrets
         secret:

--- a/kubernetes/monitoring/services/sqoop.yaml
+++ b/kubernetes/monitoring/services/sqoop.yaml
@@ -21,7 +21,7 @@ spec:
           - /data/sqoop/log
           - "7"
           - "7200"
-          image: registry.cern.ch/cmsmonitoring/sqoop:sqoop-0.0.2
+          image: registry.cern.ch/cmsmonitoring/sqoop:sqoop-0.0.5
           name: sqoop
           volumeMounts:
           - name: sqoop-secrets


### PR DESCRIPTION
- Some api versions are updated because of newer K8s version requirements.
- sqoop tags are updated.
- `defaultMode: 256` did not work in HA2 cluster. I checked HA1 karma and it also has default one `0400`, so I deleted it.

All of them are already deployed and working fine.