### PR TITLE
adding crabserver grok to logstash

### DIFF
--- a/kubernetes/cmsweb/monitoring/logstash.conf
+++ b/kubernetes/cmsweb/monitoring/logstash.conf
@@ -18,8 +18,8 @@ filter {
         match => { "message" => '\[%{HTTPDATE:tstamp}\] %{DATA:frontend} %{IPORHOST:clientip} "%{WORD:method} %{NOTSPACE:request} %{DATA:httpversion}" %{NUMBER:code:int} \[data: %{NUMBER:bytes_sent:int} in %{NUMBER:bytes_received:int} out %{NUMBER:body_size:int} body %{NUMBER:time_spent_ms:int} us \] \[auth: %{DATA:tls} %{DATA:crypto} "%{DATA:dn}".*\] \[ref: "%{DATA}.*" "%{DATA:client}" \](?: %{NUMBER:fe_port}|)' }
       }
       grok {
-        pattern_definitions => { "WORDHYPHEN" => "\b[\w\-]+\b" } 
-        match => { "request" => '/%{WORDHYPHEN:system}%{UNIXPATH:uri_path}%{URIPARAM:uri_params}?' } 
+        pattern_definitions => { "WORDHYPHEN" => "\b[\w\-]+\b" }
+        match => { "request" => '/%{WORDHYPHEN:system}%{UNIXPATH:uri_path}%{URIPARAM:uri_params}?' }
       }
       if [uri_params] {
           grok { match => { "uri_path" => '/.*/%{DATA:api}$' } }
@@ -78,6 +78,26 @@ filter {
   }
   if "crabserver" in [tags] {
       mutate { replace => { "type" => "crabserver" } }
+      grok {
+        match => { "message" => '\[%{NOTSPACE:tstamp}\] %{DATA:backend} %{IPORHOST:clientip} "%{WORD:method} %{NOTSPACE:request} %{DATA:httpversion}" %{NUMBER:code:int}[^\[]* \[data: %{NUMBER:bytes_sent:int} in %{NUMBER:bytes_received:int} out %{NUMBER:time_spent_ms:int} us \] \[auth: %{DATA} "%{DATA:dn}".*\] \[ref: "%{DATA}.*" "%{DATA:client}" \]' }
+      }
+      grok {
+        match => { "request" => '/%{WORD:system}%{UNIXPATH:uri_path}%{URIPARAM:uri_params}?' }
+      }
+      if ![uri_params] {
+          ruby { code => "event.set('uri_params','')" }
+      }
+      grok { match => { "uri_path" => '/.*/%{DATA:api}$' } }
+      date {
+         match => [ "tstamp", "dd/MMM/yyyy:HH:mm:ss" ]
+         target => "date_object"
+      }
+      ruby {
+         code => "event.set('rec_timestamp',event.get('date_object').to_i)
+                  event.set('rec_date',event.get('date_object'))
+                 "
+      }
+      mutate { gsub =>  [ "dn","/CN=\d+","" ] }
   }
   if "crabcache" in [tags] {
       mutate { replace => { "type" => "crabcache" } }
@@ -213,6 +233,18 @@ output {
           connect_timeout => 60
       }
   }
+  if [type] == "crabserver" {
+      http {
+          http_method => "post"
+          url => "http://172.18.0.1:10012/"
+          content_type => "application/json; charset=UTF-8"
+          format => "message"
+          message => '{"producer": "cmswebk8s", "type": "crabserver", "hostname": "%{hostname}", "agent_id": "%{agent_id}", "ephemeral_id": "%{ephemeral_id}", "cmsweb_log": "%{cmsweb_log}", "message": "%{message}", "api": "%{api}", "client": "%{client}", "clientip": "%{clientip}", "code": %{code}, "dn": "%{dn}", "backend": "%{backend}", "httpversion": "%{httpversion}", "method": "%{method}", "rec_date": "%{rec_date}", "rec_timestamp":"%{rec_timestamp}", "request": "%{request}", "uri_params": "%{uri_params}", "uri_path": "%{uri_path}", "bytes_sent": "%{bytes_sent}", "bytes_received": "%{bytes_received}", "time_spent_ms": "%{time_spent_ms}", "cmsweb_env":"%{cmsweb_env}", "cmsweb_cluster":"%{cmsweb_cluster}"'
+          socket_timeout => 60
+          connect_timeout => 60
+      }
+  }
+
 
   # example how to feed data to a local file
   #file {

--- a/kubernetes/cmsweb/monitoring/logstash.conf
+++ b/kubernetes/cmsweb/monitoring/logstash.conf
@@ -93,7 +93,7 @@ filter {
          target => "date_object"
       }
       ruby {
-         code => "event.set('rec_timestamp',event.get('date_object').to_i)
+         code => "event.set('timestamp',(event.get('date_object').to_f * 1000).to_i)
                   event.set('rec_date',event.get('date_object'))
                  "
       }
@@ -239,7 +239,7 @@ output {
           url => "http://monit-logs.cern.ch:10012/"
           content_type => "application/json; charset=UTF-8"
           format => "json_batch"
-          message => '{"producer": "cmswebk8s", "type": "crabserver", "hostname": "%{hostname}", "agent_id": "%{agent_id}", "ephemeral_id": "%{ephemeral_id}", "cmsweb_log": "%{cmsweb_log}", "message": "%{message}", "api": "%{api}", "client": "%{client}", "clientip": "%{clientip}", "code": %{code}, "dn": "%{dn}", "backend": "%{backend}", "httpversion": "%{httpversion}", "method": "%{method}", "rec_date": "%{rec_date}", "rec_timestamp":"%{rec_timestamp}", "request": "%{request}", "uri_params": "%{uri_params}", "uri_path": "%{uri_path}", "bytes_sent": "%{bytes_sent}", "bytes_received": "%{bytes_received}", "time_spent_ms": "%{time_spent_ms}", "cmsweb_env":"%{cmsweb_env}", "cmsweb_cluster":"%{cmsweb_cluster}"}'
+          message => '{"producer": "cmswebk8s", "type": "crabserver", "hostname": "%{hostname}", "agent_id": "%{agent_id}", "ephemeral_id": "%{ephemeral_id}", "cmsweb_log": "%{cmsweb_log}", "message": "%{message}", "api": "%{api}", "client": "%{client}", "clientip": "%{clientip}", "code": %{code}, "dn": "%{dn}", "backend": "%{backend}", "httpversion": "%{httpversion}", "method": "%{method}", "timestamp":"%{timestamp}", "rec_date": "%{rec_date}", "request": "%{request}", "uri_params": "%{uri_params}", "uri_path": "%{uri_path}", "bytes_sent": "%{bytes_sent}", "bytes_received": "%{bytes_received}", "time_spent_ms": "%{time_spent_ms}", "cmsweb_env":"%{cmsweb_env}", "cmsweb_cluster":"%{cmsweb_cluster}"}'
           socket_timeout => 60
           connect_timeout => 60
       }

--- a/kubernetes/cmsweb/monitoring/logstash.conf
+++ b/kubernetes/cmsweb/monitoring/logstash.conf
@@ -236,10 +236,10 @@ output {
   if [type] == "crabserver" {
       http {
           http_method => "post"
-          url => "http://172.18.0.1:10012/"
+          url => "http://monit-logs.cern.ch:10012/"
           content_type => "application/json; charset=UTF-8"
-          format => "message"
-          message => '{"producer": "cmswebk8s", "type": "crabserver", "hostname": "%{hostname}", "agent_id": "%{agent_id}", "ephemeral_id": "%{ephemeral_id}", "cmsweb_log": "%{cmsweb_log}", "message": "%{message}", "api": "%{api}", "client": "%{client}", "clientip": "%{clientip}", "code": %{code}, "dn": "%{dn}", "backend": "%{backend}", "httpversion": "%{httpversion}", "method": "%{method}", "rec_date": "%{rec_date}", "rec_timestamp":"%{rec_timestamp}", "request": "%{request}", "uri_params": "%{uri_params}", "uri_path": "%{uri_path}", "bytes_sent": "%{bytes_sent}", "bytes_received": "%{bytes_received}", "time_spent_ms": "%{time_spent_ms}", "cmsweb_env":"%{cmsweb_env}", "cmsweb_cluster":"%{cmsweb_cluster}"'
+          format => "json_batch"
+          message => '{"producer": "cmswebk8s", "type": "crabserver", "hostname": "%{hostname}", "agent_id": "%{agent_id}", "ephemeral_id": "%{ephemeral_id}", "cmsweb_log": "%{cmsweb_log}", "message": "%{message}", "api": "%{api}", "client": "%{client}", "clientip": "%{clientip}", "code": %{code}, "dn": "%{dn}", "backend": "%{backend}", "httpversion": "%{httpversion}", "method": "%{method}", "rec_date": "%{rec_date}", "rec_timestamp":"%{rec_timestamp}", "request": "%{request}", "uri_params": "%{uri_params}", "uri_path": "%{uri_path}", "bytes_sent": "%{bytes_sent}", "bytes_received": "%{bytes_received}", "time_spent_ms": "%{time_spent_ms}", "cmsweb_env":"%{cmsweb_env}", "cmsweb_cluster":"%{cmsweb_cluster}"}'
           socket_timeout => 60
           connect_timeout => 60
       }


### PR DESCRIPTION
https://its.cern.ch/jira/projects/CMSMONIT/issues/CMSMONIT-458

Add crabserver grok to cmsweb's logstash.
From what I understand, we (CRAB team) will use logstash/es-monit instances to build dashboard like [CRAB timber](https://monit-grafana.cern.ch/d/qUVV6S0Gk/crab-timber-pods?orgId=11&refresh=1h), but data will come from `crabserver` cherrypy logs instead.

I will open another PR for new crabserver sidecar.