### PR TITLE
Modify logstash for filebeat v8+

### DIFF
--- a/kubernetes/cmsweb/monitoring/logstash.conf
+++ b/kubernetes/cmsweb/monitoring/logstash.conf
@@ -4,7 +4,9 @@ filter {
   ruby { code => "event.set('logtime',(event.get('@timestamp').to_f * 1000).to_i)" }
   mutate {
       add_field => {
-          "hostname" => "%{[agent][hostname]}"
+          "hostname" => "%{[host][name]}"
+          "agent_name" => "%{[agent][name]}"
+          "agent_version" => "%{[agent][version]}"
           "agent_id" => "%{[agent][id]}"
           "ephemeral_id" => "%{[agent][ephemeral_id]}"
           "cmsweb_log" => "%{[log][file][path]}"


### PR DESCRIPTION
- There is no `[agent][hostname]` in filebeat v8+ anymore
- These 2 fields are common in filebeat v7* and v8*, for both `type: log`(deprecate in v7.16+) and `type: filestream` : 
   - `[agent][name]` : name of the agent, can be set. If empty, default is the hostname of the server, [see ref](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-general-options.html#configuration-general)
   -  `[host][name]` : hostname of the server
- Additionally, I would like to put filebeat version. I guess we'll start to use v8+ in near future and we may need it to debug things.

fyi @leggerf @brij01 