### PR TITLE
crabserver - use https:// instead of git:// for unauthenticated repo cloning

### DIFF
--- a/docker/crabserver/install.sh
+++ b/docker/crabserver/install.sh
@@ -8,7 +8,7 @@ PKGS="admin backend crabserver/preprod"
 SERVER=cmsrep.cern.ch
 
 cd $WDIR
-git clone git://github.com/dmwm/deployment.git cfg
+git clone https://github.com/dmwm/deployment.git cfg
 mkdir $WDIR/srv
 
 cd $WDIR/cfg


### PR DESCRIPTION
While building the `crabserver` docker image, I encountered this error

```plaintext
Step 13/17 : RUN $WDIR/install.sh
 ---> Running in 81dc55cd0c1a
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
Cloning into 'cfg'...
/data/install.sh: line 14: cd: /data/cfg: No such file or directory
fatal: Not a git repository (or any of the parent directories): .git
sed: can't read crabserver/deploy: No such file or directory
```

I solved the problem with the changes that i propose in this PR.

I see that the same line is used also in other images such as [1], am i the only one that had this problem or can you replicate it?

[1] https://github.com/dmwm/CMSKubernetes/blob/ef0ef9d804f113edbc2797e9f227a430434aefc0/docker/reqmon/install.sh#L11