### PR TITLE
Separate publisher crabtaskworker tags in crab logstash

### DIFF
--- a/kubernetes/cmsweb/monitoring/crab/logstash.conf
+++ b/kubernetes/cmsweb/monitoring/crab/logstash.conf
@@ -4,14 +4,9 @@ input { beats { port => 5044 } }
 
 filter {
   # whitelisted tags
-  if "crabtaskworker" not in [tags] { drop { } }
+  if "crabtaskworker" not in [tags] and "publisher" not in [tags] { drop { } }
 
   mutate {
-    # MONIT mandatory fields. Be aware that you cannot use any of these names in grok/mutate parsers!
-    replace => {
-      "producer" => "crab"
-      "type" => "crabtaskworker"
-    }
     # Metadata
     add_field => {
       "hostname" => "%{[cloud][instance][name]}"
@@ -21,115 +16,140 @@ filter {
     }
   }
 
-  if "completed in" in [message] {
-    grok {
-      match => {
-        "message" => "%{TIMESTAMP_ISO8601:timestamp_temp}:DEBUG:Worker,%{INT}:Process-%{NOTSPACE:slaveID}: %{NOTSPACE:workType} work on %{NOTSPACE:taskName} completed in %{NUMBER:completionTime:int} seconds"
-      }
-      add_field => {"log_type" => "work_on_task_completed"}
-      overwrite => ["message"]
-    }
+  if "crabtaskworker" in [tags] {
 
-  } else if "PUBSTART" in [message] {
-      grok {
-        match => {
-          "message" => "%{TIMESTAMP_ISO8601:timestamp_temp}:%{NOTSPACE:logMsg}:PublisherMaster,%{INT}:PUBSTART:%{GREEDYDATA:pb_json_data}"
-        }
-        add_field => {"log_type" => "publisher_config_data"}
-        overwrite => ["message"]
-      }
-      if [pb_json_data] {
-        json{
-          source => "pb_json_data"
-          target => "pb_json_data"
+      # TASKWORKER
+      mutate {
+        # MONIT mandatory fields. Be aware that you cannot use any of these names in grok/mutate parsers!
+        replace => {
+          "producer" => "crab"
+          "type" => "crabtaskworker"
         }
       }
-
-  } else if "TWSTART" in [message] {
-      grok {
+      if "completed in" in [message] {
+        grok {
           match => {
-            "message" => "%{TIMESTAMP_ISO8601:timestamp_temp}:%{NOTSPACE:logMsg}:MasterWorker,%{INT}:TWSTART: %{GREEDYDATA:tw_json_data}"
+            "message" => "%{TIMESTAMP_ISO8601:timestamp_temp}:DEBUG:Worker,%{INT}:Process-%{NOTSPACE:slaveID}: %{NOTSPACE:workType} work on %{NOTSPACE:taskName} completed in %{NUMBER:completionTime:int} seconds"
           }
-          add_field => {"log_type" => "tw_config_data"}
+          add_field => {"log_type" => "work_on_task_completed"}
           overwrite => ["message"]
-      }
-      if [tw_json_data] {
-        json {
-          source => "tw_json_data"
-          target => "tw_json_data"
+        }
+
+      } else if ( [message] =~ /.*Starting.*at.*on.*/ ) {
+          grok {
+            match => {
+              "message" => "%{TIMESTAMP_ISO8601:timestamp_temp}:DEBUG:Worker,%{INT}:Process-%{NOTSPACE:slaveID}: Starting <function %{NOTSPACE:functionName} at %{DATA:taskID}> on %{NOTSPACE:taskName}"
+            }
+            add_field => {"log_type" => "start_new_task"}
+            overwrite => ["message"]
+          }
+      } else if "TWSTART" in [message] {
+          grok {
+              match => {
+                "message" => "%{TIMESTAMP_ISO8601:timestamp_temp}:%{NOTSPACE:logMsg}:MasterWorker,%{INT}:TWSTART: %{GREEDYDATA:tw_json_data}"
+              }
+              add_field => {"log_type" => "tw_config_data"}
+              overwrite => ["message"]
+          }
+          if [tw_json_data] {
+            json {
+              source => "tw_json_data"
+              target => "tw_json_data"
+            }
+          }
+
+      } else if ( [message] =~ /.*Finished.*object at .*/ ) {
+          grok {
+            match => {
+              "message" => "%{TIMESTAMP_ISO8601:timestamp_temp}:INFO:Handler,%{INT}:Finished <TaskWorker.Actions.%{NOTSPACE:action} object at %{DATA:taskID}> on %{NOTSPACE:taskName} in %{NUMBER:completionTime:int} seconds"
+            }
+            add_field => {"log_type" => "action_on_task_finished"}
+            overwrite => ["message"]
+          }
+      } else { drop {} }
+
+  } else if "publisher" in [tags] {
+
+      # PUBLISHER
+      mutate {
+        # MONIT mandatory fields. Be aware that you cannot use any of these names in grok/mutate parsers!
+        replace => {
+          "producer" => "crab"
+          "type" => "publisher"
         }
       }
 
-  } else if ( [message] =~ /.*Starting.*at.*on.*/ ) {
-      grok {
-        match => {
-          "message" => "%{TIMESTAMP_ISO8601:timestamp_temp}:DEBUG:Worker,%{INT}:Process-%{NOTSPACE:slaveID}: Starting <function %{NOTSPACE:functionName} at %{DATA:taskID}> on %{NOTSPACE:taskName}"
-        }
-        add_field => {"log_type" => "start_new_task"}
-        overwrite => ["message"]
-      }
+      if "PUBSTART" in [message] {
+          grok {
+            match => {
+              "message" => "%{TIMESTAMP_ISO8601:timestamp_temp}:%{NOTSPACE:logMsg}:PublisherMaster,%{INT}:PUBSTART:%{GREEDYDATA:pb_json_data}"
+            }
+            add_field => {"log_type" => "publisher_config_data"}
+            overwrite => ["message"]
+          }
+          if [pb_json_data] {
+            json{
+              source => "pb_json_data"
+              target => "pb_json_data"
+            }
+          }
 
-  } else if ( [message] =~ /.*blocks failed.*files.*/ ) {
-      grok {
-        match => {
-          "message" => "%{TIMESTAMP_ISO8601:timestamp_temp}:%{NOTSPACE:logMsg}:PublisherMaster,%{INT}:Taskname %{NOTSPACE:taskName} : %{INT:blocks} blocks failed for a total of %{INT:files} files"
-        }
-        add_field => {"log_type" => "failed_publication"}
-        overwrite => ["message"]
-      }
+      } else if ( [message] =~ /.*blocks failed.*files.*/ ) {
+          grok {
+            match => {
+              "message" => "%{TIMESTAMP_ISO8601:timestamp_temp}:%{NOTSPACE:logMsg}:PublisherMaster,%{INT}:Taskname %{NOTSPACE:taskName} : %{INT:blocks} blocks failed for a total of %{INT:files} files"
+            }
+            add_field => {"log_type" => "failed_publication"}
+            overwrite => ["message"]
+          }
 
-  } else if ( [message] =~ /.*Published.*files in.*/ ) {
-      grok {
-        match => {
-          "message" => "%{TIMESTAMP_ISO8601:timestamp_temp}:%{NOTSPACE:logMsg}:PublisherMaster,%{INT}:Taskname %{NOTSPACE:taskName} is %{NOTSPACE:publicationResult}. Published %{INT:filesPublished} files in %{INT:blocks} blocks."
-        }
-        add_field => {"log_type" => "successful_publication"}
-        overwrite => ["message"]
-      }
+      } else if ( [message] =~ /.*Published.*files in.*/ ) {
+          grok {
+            match => {
+              "message" => "%{TIMESTAMP_ISO8601:timestamp_temp}:%{NOTSPACE:logMsg}:PublisherMaster,%{INT}:Taskname %{NOTSPACE:taskName} is %{NOTSPACE:publicationResult}. Published %{INT:filesPublished} files in %{INT:blocks} blocks."
+            }
+            add_field => {"log_type" => "successful_publication"}
+            overwrite => ["message"]
+          }
 
-  } else if ( [message] =~ /.*Exception.*TaskPublish.*/ ) {
-      grok {
-        match => {
-          "message" => "%{TIMESTAMP_ISO8601:timestamp_temp}:%{NOTSPACE:logMsg}:PublisherMaster,%{INT}:%{GREEDYDATA:exceptionHandled}"
-        }
-        add_field => {"log_type" => "publication_error"}
-        overwrite => ["message"]
-      }
+      } else if ( [message] =~ /.*Exception.*TaskPublish.*/ ) {
+          grok {
+            match => {
+              "message" => "%{TIMESTAMP_ISO8601:timestamp_temp}:%{NOTSPACE:logMsg}:PublisherMaster,%{INT}:%{GREEDYDATA:exceptionHandled}"
+            }
+            add_field => {"log_type" => "publication_error"}
+            overwrite => ["message"]
+          }
 
-  # This filter is currently used for production publisher. After we deploy preprod to prod, this filter can be dropped
-  } else if "DEBUG:master" in [message] {
-      grok {
-        match => {
-          "message" => "%{TIMESTAMP_ISO8601:timestamp_temp}:%{NOTSPACE:logMsg}:master:%{SPACE}%{INT:acquiredFiles}%{SPACE}:%{SPACE}%{NOTSPACE:taskName}"
-        }
-        add_field => {"log_type" => "acquired_files"}
-        overwrite => ["message"]
-      }
+      # This filter is currently used for production publisher. After we deploy preprod to prod, this filter can be dropped
+      } else if "DEBUG:master" in [message] {
+          grok {
+            match => {
+              "message" => "%{TIMESTAMP_ISO8601:timestamp_temp}:%{NOTSPACE:logMsg}:master:%{SPACE}%{INT:acquiredFiles}%{SPACE}:%{SPACE}%{NOTSPACE:taskName}"
+            }
+            add_field => {"log_type" => "acquired_files"}
+            overwrite => ["message"]
+          }
 
-  # this filter mathces changes in #6861, which is already in preprod and dev
-  } else if "acquired_files" in [message] {
-      grok {
-        match => {
-          "message" => "%{TIMESTAMP_ISO8601:timestamp_temp}:%{NOTSPACE:logMsg}:PublisherMaster,%{INT}:acquired_files:%{SPACE}%{NOTSPACE:acquiredFilesStatus}%{SPACE}%{INT:acquiredFiles}%{SPACE}:%{SPACE}%{NOTSPACE:taskName}"
-        }
-        add_field => {"log_type" => "acquired_files_status"}
-        overwrite => ["message"]
-      }
+      # this filter mathces changes in #6861, which is already in preprod and dev
+      } else if "acquired_files" in [message] {
+          grok {
+            match => {
+              "message" => "%{TIMESTAMP_ISO8601:timestamp_temp}:%{NOTSPACE:logMsg}:PublisherMaster,%{INT}:acquired_files:%{SPACE}%{NOTSPACE:acquiredFilesStatus}%{SPACE}%{INT:acquiredFiles}%{SPACE}:%{SPACE}%{NOTSPACE:taskName}"
+            }
+            add_field => {"log_type" => "acquired_files_status"}
+            overwrite => ["message"]
+          }
 
-  } else if ( [message] =~ /.*Finished.*object at .*/ ) {
-      grok {
-        match => {
-          "message" => "%{TIMESTAMP_ISO8601:timestamp_temp}:INFO:Handler,%{INT}:Finished <TaskWorker.Actions.%{NOTSPACE:action} object at %{DATA:taskID}> on %{NOTSPACE:taskName} in %{NUMBER:completionTime:int} seconds"
-        }
-        add_field => {"log_type" => "action_on_task_finished"}
-        overwrite => ["message"]
-      }
-  } else { drop { } }
+      } else { drop { } }
+
+  }
 
   date {
       match => ["timestamp_temp", "YYYY-MM-dd HH:mm:ss,SSS"]
       target => "rec_timestamp_str"
   }
+
   if "_grokparsefailure" in [tags] { drop { } }
 
   # "metadata.timestamp" equals to record time
@@ -142,10 +162,11 @@ filter {
   mutate {
     remove_field => ["@timestamp", "@version", "timestamp_temp", "agent", "log", "input", "tags", "ecs", "host", "cloud", "event" ]
   }
+
 }
 
 output {
-  if [type] == "crabtaskworker" {
+  if [type] == "crabtaskworker" or [type] == "publisher" {
     http {
       http_method => post
       url => "http://monit-logs.cern.ch:10012/"
@@ -154,5 +175,8 @@ output {
       socket_timeout => 60
       connect_timeout => 60
     }
+  } else {
+    # For debugging, please keep it to catch problems
+    stdout { codec => json }
   }
 }


### PR DESCRIPTION
@muhammadimranfarooqi could we replace `logstash.conf` with this one in crab logstash `-n crab`

fyi @novicecpp , you need to separate tags in in publisher and tw, like:
 ```
 filebeat.inputs:
- type: log
  enabled: true
  paths:
    - /data/test/PUBLISHER*
  #ignore_older: 1h !You can edit this setting to not send old data!
  scan_frequency: 10s
  backoff: 5s
  max_backoff: 10s
  tags: ["publisher"]
- type: log
  enabled: true
  paths:
    - /data/test/TW*
  #ignore_older: 1h !You can edit this setting to not send old data!
  scan_frequency: 10s
  backoff: 5s
  max_backoff: 10s
  tags: ["crabtaskworker"]

rest is same ...
```