### PR TITLE
Add cmsweb cluster and env metadata to crab logstash

### DIFF
--- a/kubernetes/cmsweb/monitoring/crab/logstash.conf
+++ b/kubernetes/cmsweb/monitoring/crab/logstash.conf
@@ -13,6 +13,8 @@ filter {
       "log_file" => "%{[log][file][path]}"
       "agent_name" => "%{[agent][name]}"
       "agent_version" => "%{[agent][version]}"
+      "cmsweb_cluster" => "${CMSWEB_CLUSTER:NA}"
+      "cmsweb_env" => "${CMSWEB_ENV:NA}"
     }
   }
 

--- a/kubernetes/cmsweb/scripts/deploy.sh
+++ b/kubernetes/cmsweb/scripts/deploy.sh
@@ -741,10 +741,13 @@ deploy_monitoring()
         kubectl create configmap logstash \
         --from-file=monitoring/aps/logstash.conf --from-file=monitoring/logstash.yml -n monitoring
     else
-	kubectl create configmap logstash \
+    # create monitoring logstash config map
+    kubectl create configmap logstash \
         --from-file=monitoring/logstash.conf --from-file=monitoring/logstash.yml -n monitoring
+    # creat crab logstash config map
     kubectl create configmap logstash \
         --from-file=monitoring/crab/logstash.conf --from-file=monitoring/crab/logstash.yml -n crab
+
     fi
     # add secrets for loki service
     if [ -n "`kubectl get secrets -n monitoring | grep loki-secrets`" ]; then


### PR DESCRIPTION
@muhammadimranfarooqi I deployed new crab logstash conf to `cmsweb-testbed` , could you deploy it to `cmsweb` one. This PR includes basic indentation fixes in deploy.sh too.

@novicecpp sorry I forget to add cluster metadata to distinguish prod and test logstashes.