### PR TITLE
use value from [host][name] as metadata.hostname for filebeat 7.17

### DIFF
--- a/kubernetes/cmsweb/monitoring/crab/logstash.conf
+++ b/kubernetes/cmsweb/monitoring/crab/logstash.conf
@@ -9,7 +9,7 @@ filter {
   mutate {
     # Metadata
     add_field => {
-      "hostname" => "%{[cloud][instance][name]}"
+      "hostname" => "%{[host][name]}"
       "log_file" => "%{[log][file][path]}"
       "agent_name" => "%{[agent][name]}"
       "agent_version" => "%{[agent][version]}"


### PR DESCRIPTION
We update Taskworker/Publisher baseimage to newest version https://github.com/dmwm/CRABServer/commit/01c1bdd55853164a55a669cfa581212d17cf5682. New baseimage also come with Filebeat 7.17.

I don't know why Filebeat 7.17 does not provide hostname field `[cloud][instance][name]` from `add_cloud_metadata` anymore.
But we still can get hostname from field `[host][name]` via `add_host_metadata` processor instead. 

Logstash in monitoring namespace also get hostname from this field here: https://github.com/dmwm/CMSKubernetes/blob/8f198884e80d0ffc3251a179caa60b3a17f2c73e/kubernetes/cmsweb/monitoring/logstash.conf#L7.

@mrceyhun @muhammadimranfarooqi Please review.