### PR TITLE
Bump cmsmonit auth image version

### DIFF
--- a/kubernetes/monitoring/daemonset/auth-proxy-server.yaml
+++ b/kubernetes/monitoring/daemonset/auth-proxy-server.yaml
@@ -27,11 +27,7 @@ spec:
         role: auth
       dnsPolicy: ClusterFirstWithHostNet
       containers:
-#       - image: cmssw/auth-proxy-server #imagetag
-#       - image: cmssw/auth-proxy-server:0.1.81 #imagetag
-#       - image: cmssw/auth-proxy-server:0.1.106 #imagetag
-#       - image: cmssw/auth-proxy-server:0.1.106-static #imagetag
-      - image: cmssw/auth-proxy-server:0.2.05
+      - image: registry.cern.ch/cmsweb/auth-proxy-server:0.2.34
         name: auth-proxy-server
 #         imagePullPolicy: Always
         args:

--- a/kubernetes/monitoring/services/auth-proxy-server.yaml
+++ b/kubernetes/monitoring/services/auth-proxy-server.yaml
@@ -35,10 +35,7 @@ spec:
         prometheus.io/port: "9091"
     spec:
       containers:
-      #- image: cmssw/auth-proxy-server:0.1.81
-      #- image: cmssw/auth-proxy-server:0.1.106
-#       - image: cmssw/auth-proxy-server:0.1.106-static
-      - image: cmssw/auth-proxy-server:0.2.07
+      - image: registry.cern.ch/cmsweb/auth-proxy-server:0.2.34
         name: auth-proxy-server
         imagePullPolicy: Always
         args:
@@ -62,7 +59,6 @@ spec:
         volumeMounts:
         - name: auth-secrets
           mountPath: /etc/secrets
-          defaultMode: 256
         - name: proxy-secrets
           mountPath: /etc/proxy
           readOnly: true


### PR DESCRIPTION
Auth pods run as service in monitoring cluster. New k8s api v1 did not allow `defaultMode` so I deleted it. `monitoring/services/auth-proxy-server.yaml` is already deployed.

fyi @muhammadimranfarooqi @vkuznet 