### PR TITLE
Update logstash confs for new filebeat versions and add client_name

### DIFF
--- a/kubernetes/cmsweb/monitoring/aps/logstash.conf
+++ b/kubernetes/cmsweb/monitoring/aps/logstash.conf
@@ -9,15 +9,17 @@ input {
 filter {
   mutate {
       add_field => {
-          "hostname" => "%{[agent][hostname]}"
-          "agent_id" => "%{[agent][id]}"
+          "hostname" => "%{[host][name]}"
+          "filebeat_id" => "%{[agent][id]}"
+          "filebeat_name" => "%{[agent][name]}"
+          "filebeat_version" => "%{[agent][version]}"
           "ephemeral_id" => "%{[agent][ephemeral_id]}"
           "cmsweb_log" => "%{[log][file][path]}"
           "cmsweb_cluster" => "${CMSWEB_CLUSTER:NA}"
           "cmsweb_env" => "${CMSWEB_ENV:NA}"
       }
-      # We need to remove these nested fields that added by Logstash itself
-      remove_field => ["agent", "log", "input", "tags", "ecs", "host"]
+      # We need to remove these nested fields that added by Logstash&Filebeat itself
+      remove_field => ["agent", "log", "input", "tags", "ecs", "host", "event"]
   }
 }
 

--- a/kubernetes/cmsweb/monitoring/logstash.conf
+++ b/kubernetes/cmsweb/monitoring/logstash.conf
@@ -5,9 +5,9 @@ filter {
   mutate {
       add_field => {
           "hostname" => "%{[host][name]}"
-          "agent_name" => "%{[agent][name]}"
-          "agent_version" => "%{[agent][version]}"
-          "agent_id" => "%{[agent][id]}"
+          "filebeat_name" => "%{[agent][name]}"
+          "filebeat_version" => "%{[agent][version]}"
+          "filebeat_id" => "%{[agent][id]}"
           "ephemeral_id" => "%{[agent][ephemeral_id]}"
           "cmsweb_log" => "%{[log][file][path]}"
           "cmsweb_cluster" => "${CMSWEB_CLUSTER:NA}"
@@ -40,6 +40,9 @@ filter {
       if ![api] {
           mutate { replace => { "api" => "%{request}" } }
           mutate { replace => { "system" => "%{request}" } }
+      }
+      if [client] {
+          grok { match => { "client" => '%{DATA:client_name}/%{DATA:client_version}$' } }
       }
       date {
          match => [ "tstamp", "dd/MMM/yyyy:HH:mm:ss Z" ]
@@ -90,6 +93,9 @@ filter {
           ruby { code => "event.set('uri_params','')" }
       }
       grok { match => { "uri_path" => '/.*/%{DATA:api}$' } }
+      if [client] {
+          grok { match => { "client" => '%{DATA:client_name}/%{DATA:client_version}$' } }
+      }
       date {
          # Since date string does not provide timezone, we need to specify it explicitly
          match => [ "tstamp", "dd/MMM/yyyy:HH:mm:ss" ]
@@ -179,8 +185,10 @@ filter {
   if "_grokparsefailure" in [tags] { drop { } }
   # remove quotes from message entry since it will break the JSON
   mutate { gsub => [ "message", "\n", "", "message", "\"", ""] }
-  # last part we should remove object fields
-  mutate { remove_field => ["agent", "log", "input", "tags", "ecs", "host"] }
+
+  # We need to remove these nested fields that added by Logstash&Filebeat itself
+  # event: filebeat v7+
+  mutate { remove_field => ["agent", "log", "input", "tags", "ecs", "host", "event"] }
 
 }
 
@@ -201,7 +209,6 @@ output {
           format => "json_batch"
           # for message please use double quotes for string type and no-double
           # quotes for objects, e.g. %{agent} is an object, while "%{dn}" is a string
-          message => '{"producer": "cmswebk8s", "type": "frontend", "hostname": "%{hostname}", "agent_id": "%{agent_id}", "ephemeral_id": "%{ephemeral_id}", "cmsweb_log": "%{cmsweb_log}", "message": "%{message}", "api": "%{api}", "client": "%{client}", "clientip": "%{clientip}", "code": %{code}, "crypto": "%{crypto}", "date_object": "%{date_object}", "dn": "%{dn}", "frontend": "%{frontend}", "httpversion": "%{httpversion}", "method": "%{method}", "rec_date": "%{rec_date}", "rec_timestamp": %{rec_timestamp}, "request": "%{request}", "system": "%{system}", "tls": "%{tls}", "tstamp": "%{tstamp}", "uri_params": "%{uri_params}", "uri_path": "%{uri_path}", "bytes_sent": "%{bytes_sent}", "bytes_received": "%{bytes_received}", "body_size": "%{body_size}", "time_spent_ms": "%{time_spent_ms}", "cmsweb_env":"%{cmsweb_env}", "cmsweb_cluster":"%{cmsweb_cluster}", "fe_port": "%{fe_port}", "timestamp": "%{timestamp}"}'
           socket_timeout => 60
           connect_timeout => 60
       }
@@ -212,7 +219,6 @@ output {
           url => "http://monit-logs.cern.ch:10012/"
           content_type => "application/json; charset=UTF-8"
           format => "json_batch"
-          message => '{"producer": "cmswebk8s", "type": "couchdb", "hostname": "%{hostname}", "agent_id": "%{agent_id}", "ephemeral_id": "%{ephemeral_id}", "cmsweb_log": "%{cmsweb_log}", "message": "%{message}", "clientip":"%{clientip}", "method":"%{method}", "request":"%{request}", "rec_timestamp":"%{rec_timestamp}", "rec_date":"%{rec_date}", "log_level":"%{log_level}", "code":%{code}, "system":"%{system}", "uri_path":"%{uri_path}", "uri_params":"%{uri_params}", "uri_path":"%{uri_path}", "api":"%{api}", "cmsweb_env":"%{cmsweb_env}", "cmsweb_cluster":"%{cmsweb_cluster}", "timestamp": "%{timestamp}"}'
           socket_timeout => 60
           connect_timeout => 60
       }
@@ -223,7 +229,6 @@ output {
           url => "http://monit-logs.cern.ch:10012/"
           content_type => "application/json; charset=UTF-8"
           format => "json_batch"
-          message => '{"producer": "cmswebk8s", "type": "dbs", "hostname": "%{hostname}", "agent_id": "%{agent_id}", "ephemeral_id": "%{ephemeral_id}", "cmsweb_log": "%{cmsweb_log}", "message": "%{message}", "tstamp": "%{tstamp}", "backend": "%{backend}", "clientip": "%{clientip}", "method":"%{method}", "httpversion":"%{httpversion}", "code":%{code}, "status":"%{status}", "auth":"%{auth}", "dn":"%{dn}", "client_agent":"%{client_agent}", "instance":"%{instance}", "instance_type":"%{instance_type}", "instance_kind":"%{instance_kind}", "api":"%{api}", "params":"%{params}", "request":"%{request}", "rec_timestamp":"%{rec_timestamp}", "rec_date":"%{rec_date}", "cmsweb_env":"%{cmsweb_env}", "cmsweb_cluster":"%{cmsweb_cluster}", "timestamp": "%{timestamp}"}'
           socket_timeout => 60
           connect_timeout => 60
       }
@@ -234,7 +239,6 @@ output {
           url => "http://monit-logs.cern.ch:10012/"
           content_type => "application/json; charset=UTF-8"
           format => "json_batch"
-          message => '{"producer": "cmswebk8s", "type": "reqmgr2", "hostname": "%{hostname}", "agent_id": "%{agent_id}", "ephemeral_id": "%{ephemeral_id}", "cmsweb_log": "%{cmsweb_log}", "message": "%{message}", "tstamp": "%{tstamp}", "backend": "%{backend}", "clientip": "%{clientip}", "method":"%{method}", "httpversion":"%{httpversion}", "code":%{code}, "status":"%{status}", "auth":"%{auth}", "dn":"%{dn}", "client_agent":"%{client_agent}", "request":"%{request}", "rec_timestamp":"%{rec_timestamp}", "rec_date":"%{rec_date}", "cmsweb_env":"%{cmsweb_env}", "cmsweb_cluster":"%{cmsweb_cluster}", "timestamp": "%{timestamp}"}'
           socket_timeout => 60
           connect_timeout => 60
       }
@@ -245,7 +249,6 @@ output {
           url => "http://monit-logs.cern.ch:10012/"
           content_type => "application/json; charset=UTF-8"
           format => "json_batch"
-          message => '{"producer": "cmswebk8s", "type": "crabserver", "hostname": "%{hostname}", "agent_id": "%{agent_id}", "ephemeral_id": "%{ephemeral_id}", "cmsweb_log": "%{cmsweb_log}", "message": "%{message}", "api": "%{api}", "client": "%{client}", "clientip": "%{clientip}", "code": %{code}, "dn": "%{dn}", "backend": "%{backend}", "httpversion": "%{httpversion}", "method": "%{method}", "timestamp":"%{timestamp}", "rec_date": "%{rec_date}", "request": "%{request}", "uri_params": "%{uri_params}", "uri_path": "%{uri_path}", "bytes_sent": "%{bytes_sent}", "bytes_received": "%{bytes_received}", "time_spent_ms": "%{time_spent_ms}", "cmsweb_env":"%{cmsweb_env}", "cmsweb_cluster":"%{cmsweb_cluster}"}'
           socket_timeout => 60
           connect_timeout => 60
       }


### PR DESCRIPTION
- Tested with filebeat versions: v7.10, v7.12, v8.1.0, v8.1.2
- New default filebeat fields to remove
- Since we're using json_batch, we don't need `message` part which is confusing.
- New `client_name` is added which is extracted from `client`. `client_name` is equal to `user_agent_name` of aps/sps/xps one.
- `agent_name`, `agent_id`, `agent_version` are changed with `filebeat_` prefix since they are filebeat meta data.

@vkuznet what do you think about `client_name` parsing?