### PR TITLE
Implement monitoring rucio datasets service

### DIFF
--- a/docker/cmsmon-hadoop-base/Dockerfile
+++ b/docker/cmsmon-hadoop-base/Dockerfile
@@ -1,5 +1,12 @@
-FROM cern/cc7-base:20220202-1
+ARG CC7_BASE_VERSION
+
+FROM cern/cc7-base:$CC7_BASE_VERSION
 MAINTAINER Ceyhun Uzunoglu ceyhunuzngl@gmail.com
+
+ARG HADOOP_VERSION
+ARG SPARK_VERSION
+ARG SPARK_MAJOR_VERSION
+#RUN echo hadoop:$HADOOP_VERSION spark:$SPARK_VERSION $SPARK_MAJOR_VERSION
 
 ENV WDIR=/data
 WORKDIR $WDIR
@@ -33,19 +40,24 @@ RUN yum -y update && yum install -y cern-get-certificate fetch-crl \
     voms-devel globus-gsi-credential-devel globus-gsi-cert-utils-devel \
     globus-common-devel globus-gsi-sysconfig-devel globus-gsi-callback-devel \
     oracle-instantclient-tnsnames.ora HEP_OSlibs python-pip  \
-    hadoop-bin-2.7 \
-    spark-bin-2.4 \
+    hadoop-bin-${HADOOP_VERSION} \
+    spark-bin-${SPARK_VERSION} \
     sqoop-bin-1.4 \
     hbase-bin-2.3 \
-    java-1.8.0-openjdk-devel \
     cern-hadoop-xrootd-connector cern-hadoop-config &&  \
     hadoop-set-default-conf.sh analytix && \
-    source hadoop-setconf.sh analytix && \
+    source hadoop-setconf.sh analytix ${HADOOP_VERSION} ${SPARK_MAJOR_VERSION} && \
     yum clean all && rm -rf /var/cache/yum &&  \
-    cp /usr/hdp/spark/kubernetes/dockerfiles/spark/entrypoint.sh /usr/bin/entrypoint.sh &&  \
     touch /etc/hadoop/conf/topology.table.file && ln -s /bin/bash /usr/bin/bashs && \
     echo "32 */6 * * * root ! /usr/sbin/fetch-crl -q -r 360" > /etc/cron.d/fetch-crl-docker
 # add fetch-crl to fetch all sertificates
+
+# Copy entrypoint.sh according to spark version
+RUN if [ "$SPARK_MAJOR_VERSION" = "spark3" ] ; then \
+        cp /usr/hdp/spark3/kubernetes/dockerfiles/spark/entrypoint.sh /usr/bin/entrypoint.sh ; \
+    else  \
+        cp /usr/hdp/spark/kubernetes/dockerfiles/spark/entrypoint.sh /usr/bin/entrypoint.sh ;  \
+    fi
 
 # start the setup
 WORKDIR ${WDIR}

--- a/docker/cmsmon-hadoop-base/README.md
+++ b/docker/cmsmon-hadoop-base/README.md
@@ -1,0 +1,25 @@
+### cmsmon-hadoop-base
+
+This docker image is created as an base image for cern analytix cluster; which includes:
+
+- hadoop
+- spark (spark-submit, spark-shell, etc)
+- hbase
+- sqoop
+
+Since there are different versions of Analytix cluster, this image also has spark2 and spark3 versions
+
+#### How to build
+
+Image tag will be changed accordingly cern/cc7-base tag and spark cluster version. For example:
+
+- For spark3: `registry.cern.ch/cmsmonitoring-20220401-1-spark3`
+- For spark2: `registry.cern.ch/cmsmonitoring-20220401-1-spark2`
+
+```shell
+# Build for spark2: spark 2.4, hadoop 2.7
+./build-and-push.sh 2
+
+# Build for spark3: spark 3.2, hadoop 3.2
+./build-and-push.sh 3
+```

--- a/docker/cmsmon-hadoop-base/build-and-push.sh
+++ b/docker/cmsmon-hadoop-base/build-and-push.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# Builds and push cmsmon-hadoop-base image based on analytix cluster and spark version
+# Usage: build.sh <ANALYTIX_VERSION>(2|3)
+
+set -e
+
+if [ $# -ne 1 ] || ! { [ "$1" -eq 2 ] || [ "$1" -eq 3 ]; }; then
+    echo "No arguments supplied or not desired. Analytix cluster version should be either 2 or 3"
+fi
+
+echo "!! Reminder, do not forget to clean local images with: docker system prune -f -a"
+
+CC7_BASE_VERSION=20220401-1
+DOCKER_REGISTRY=registry.cern.ch/cmsmonitoring
+
+# Get argument, should be 2 or 3
+ANALYTIX_VERSION="$1"
+echo Image will be built: "${DOCKER_REGISTRY}/cmsmon-hadoop-base:${image_tag}"
+
+if [ "$ANALYTIX_VERSION" -eq 3 ]; then
+    hadoop_v=3.2
+    spark_v=3.2
+    spark_major_v=spark3
+    image_tag="${CC7_BASE_VERSION}-${spark_major_v}"
+elif [ "$ANALYTIX_VERSION" -eq 2 ]; then
+    hadoop_v=2.7
+    spark_v=2.4
+    spark_major_v=spark2
+    image_tag="${CC7_BASE_VERSION}-${spark_major_v}"
+fi
+
+echo Image will be built: "${DOCKER_REGISTRY}/cmsmon-hadoop-base:${image_tag}"
+
+# build
+docker build \
+    --build-arg CC7_BASE_VERSION="$CC7_BASE_VERSION" \
+    --build-arg HADOOP_VERSION="$hadoop_v" \
+    --build-arg SPARK_VERSION="$spark_v" \
+    --build-arg SPARK_MAJOR_VERSION="$spark_major_v" \
+    -t "${DOCKER_REGISTRY}/cmsmon-hadoop-base:${image_tag}" .
+
+echo Build finished
+
+# push
+docker push "${DOCKER_REGISTRY}/cmsmon-hadoop-base:${image_tag}"
+
+echo Push finished : "${DOCKER_REGISTRY}/cmsmon-hadoop-base:${image_tag}"

--- a/docker/cmsmon-rucio-ds/Dockerfile
+++ b/docker/cmsmon-rucio-ds/Dockerfile
@@ -1,0 +1,44 @@
+FROM registry.cern.ch/cmsmonitoring/cmsmon-hadoop-base:20220401-1-spark3
+
+ENV WDIR=/data
+WORKDIR $WDIR
+
+ENV HADOOP_CONF_DIR=/etc/hadoop/conf
+ENV PATH="${PATH}:${WDIR}/CMSSpark/bin"
+
+# CMSMonitoring folder is in WDIR
+ENV PYTHONPATH "${PYTHONPATH}:${WDIR}:${WDIR}/CMSSpark/src/python"
+
+ENV PYSPARK_PYTHON=/usr/bin/python3
+ENV PYSPARK_DRIVER_PYTHON=/usr/bin/python3
+
+# Steps:
+#   - Remove hbase, not needed
+#   - Install python3
+#   - Install python libs and specifically stomp.py==7.0.0 which is latest working version with StompAMQ7
+#   - Install and create stomp.py v7.0.0 zip file to send to Spark workers,
+#         because Spark nodes have old version of it (v3 or v4)
+#   - Clone only src/python/CMSMonitoring folder of CMSMoinitoring repo using svn and zip it,
+#         zip file will be used to send specific CMSMonitoring folder to Spark workers with '--py-files'.
+#   - Clone CMSSpark repo which includes Spark job and bash script to run both Spark job and Sqoop imports
+RUN yum remove -y hbase-bin-2.3 && \
+    yum update -y && \
+    yum install -y svn python3 && \
+    python3 -m pip install --upgrade pip && \
+    pip3 install --no-cache-dir pandas click pyspark stomp.py==7.0.0 && \
+    pip3 install --no-cache-dir -t stomp-v700 https://github.com/jasonrbriggs/stomp.py/archive/refs/tags/v7.0.0.zip && \
+    cd stomp-v700 && \
+    zip -r ../stomp-v700.zip . && \
+    cd .. && \
+    rm -rf stomp-v700 && \
+    svn export https://github.com/dmwm/CMSMonitoring.git/branches/master/src/python/CMSMonitoring && \
+    zip -r CMSMonitoring.zip CMSMonitoring/* && \
+    git clone https://github.com/mrceyhun/CMSSpark.git && \
+    cd CMSSpark && git checkout f-rucio_datasets_daily_stats && \
+    yum clean all &&  rm -rf /var/cache/yum && \
+    rm -f /usr/bin/python && ln -s /usr/bin/python3.6 /usr/bin/python && \
+    hadoop-set-default-conf.sh analytix && \
+    source hadoop-setconf.sh analytix 3.2 spark3
+
+
+WORKDIR $WDIR

--- a/docker/cmsmon-rucio-ds/README.md
+++ b/docker/cmsmon-rucio-ds/README.md
@@ -1,0 +1,21 @@
+## cmsmon-rucio-ds
+
+For sending rucio datasets information data to MONIT.
+
+Analytix cluster 3.2, spark3 and python3.6 will be used. Base image already contains sqoop.
+
+Installs:
+
+- stomp.py==7.0.0 and creates its zip for Spark job to submit
+- Only src/python/CMSMonitoring cluster of dmwm/CMSMonitoring repo and creates its zip for Spark job to submit
+- dmwm/CMSSpark
+
+#### How to build
+
+```shell
+docker_registry=registry.cern.ch/cmsmonitoring
+image_tag=20220415
+docker build -t "${docker_registry}/cmsmon-rucio-ds:${image_tag}" .
+# push
+docker push "${docker_registry}/cmsmon-rucio-ds:${image_tag}"
+```

--- a/docker/sqoop/Dockerfile
+++ b/docker/sqoop/Dockerfile
@@ -27,13 +27,14 @@ RUN curl -ksLO https://github.com/prometheus/alertmanager/releases/download/v0.2
 RUN tar xfz alertmanager-0.20.0.linux-amd64.tar.gz && mv alertmanager-0.20.0.linux-amd64/amtool $WDIR/ && rm -rf alertmanager-0.20.0.linux-amd64*
 
 
-FROM registry.cern.ch/cmsmonitoring/cmsmon-hadoop-base:20220202-1
+FROM registry.cern.ch/cmsmonitoring/cmsmon-hadoop-base:20220401-1-spark2
+# Do not use spark3, it requires additional settings
 MAINTAINER Ceyhun Uzunoglu ceyhunuzngl@gmail.com
 
 ENV WDIR=/data
 WORKDIR $WDIR
 
-RUN mkdir -p $WDIR/sqoop/log
+RUN yum remove -y hbase-bin-2.3 && mkdir -p $WDIR/sqoop/log
 COPY --from=go-builder /data/amtool /data
 COPY --from=go-builder /data/hdfs_exporter /data
 COPY --from=go-builder /data/monit /data

--- a/kubernetes/monitoring/deploy-secrets.sh
+++ b/kubernetes/monitoring/deploy-secrets.sh
@@ -22,6 +22,7 @@
 ##H        robot-secrets
 ##H        rumble-secrets
 ##H        rucio-secrets
+##H        rucio-daily-stats-secrets
 ##H        sqoop-secrets
 ##H        vmalert-secrets
 ##H Examples:
@@ -118,6 +119,13 @@ elif [ "$secret" == "rumble-secrets" ]; then
     files=`ls $sdir/rumble/ | awk '{ORS=" " ; print "--from-file="D"/"$1""}' D=$sdir/rumble | sed "s, $,,g"`
 elif [ "$secret" == "rucio-secrets" ]; then
     files=`ls $sdir/rucio/ | awk '{ORS=" " ; print "--from-file="D"/"$1""}' D=$sdir/rucio | sed "s, $,,g"`
+elif [ "$secret" == "rucio-daily-stats-secrets" ]; then
+    # Grep cmsr to grep cmsr_string file only, since sqoop keytab conflicts with cmsmon keytab
+    sqoop_f=`ls $sdir/sqoop/ | grep cmsr | awk '{ORS=" " ; print "--from-file="D"/"$1""}' D=$sdir/sqoop | sed "s, $,,g"`
+    rucio_f=`ls $sdir/rucio/ | awk '{ORS=" " ; print "--from-file="D"/"$1""}' D=$sdir/rucio | sed "s, $,,g"`
+    amq_creds_f=`ls $sdir/cms-rucio-dailystats/ | awk '{ORS=" " ; print "--from-file="D"/"$1""}' D=$sdir/cms-rucio-dailystats | sed "s, $,,g"`
+    cmsmonit_f=`ls $sdir/cmsmonit-keytab/ | awk '{ORS=" " ; print "--from-file="D"/"$1""}' D=$sdir/cmsmonit-keytab | sed "s, $,,g"`
+    files="${sqoop_f} ${rucio_f} ${amq_creds_f} ${cmsmonit_f}"
 elif [ "$secret" == "sqoop-secrets" ]; then
     s_files=`ls $sdir/sqoop/ | awk '{ORS=" " ; print "--from-file="D"/"$1""}' D=$sdir/sqoop | sed "s, $,,g"`
     c_files=`ls $cdir/sqoop/ | awk '{ORS=" " ; print "--from-file="D"/"$1""}' D=$cdir/sqoop | sed "s, $,,g"`

--- a/kubernetes/monitoring/services/cmsmon-rucio-ds.yaml
+++ b/kubernetes/monitoring/services/cmsmon-rucio-ds.yaml
@@ -1,0 +1,108 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: cmsmon-rucio-ds
+  namespace: hdfs
+spec:
+  selector:
+    app: cmsmon-rucio-ds
+  type: NodePort
+  ports:
+    - name: port-0 # spark.driver.port, cern default is 5201
+      nodePort: 31201
+      port: 31201
+      protocol: TCP
+      targetPort: 31201
+    - name: port-1 # spark.driver.blockManager.port
+      nodePort: 31202
+      port: 31202
+      protocol: TCP
+      targetPort: 31202
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: cmsmon-rucio-ds
+  namespace: hdfs
+  labels:
+    app: cmsmon-rucio-ds
+data:
+  run.sh: |
+    #!/bin/bash
+    $WDIR/CMSSpark/bin/cron4rucio_datasets_daily_stats.sh --keytab /etc/secrets/keytab \
+        --cmsr /etc/secrets/cmsr_cstring --rucio /etc/secrets/rucio --amq /etc/secrets/amq-creds.json \
+        --cmsmonitoring $WDIR/CMSMonitoring.zip --stomp $WDIR/stomp-v700.zip --k8s
+
+  run-cron.sh: |
+    cat <<EOF | crontab -
+    45 7 * * * /data/cronjob/run.sh
+    EOF
+    crond -n -s
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cmsmon-rucio-ds
+  namespace: hdfs
+  labels:
+    app: cmsmon-rucio-ds
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cmsmon-rucio-ds
+  template:
+    metadata:
+      labels:
+        app: cmsmon-rucio-ds
+    spec:
+      hostname: cmsmon-rucio-ds
+      containers:
+        - name: cmsmon-rucio-ds
+          image: registry.cern.ch/cmsmonitoring/cmsmon-rucio-ds:20220415
+          imagePullPolicy: Always
+          command:
+            - /bin/sh
+            - /data/cronjob/run-cron.sh
+          tty: true
+          stdin: true
+          env:
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 4Gi
+            requests:
+              cpu: 500m
+              memory: 750Mi
+          ports:
+            - containerPort: 31201 # spark.driver.port
+              name: port-0
+            - containerPort: 31202 # spark.driver.blockManager.port
+              name: port-1
+          lifecycle:
+            postStart:
+              exec:
+                command: [ "/bin/sh", "-c", "export > /etc/environment" ]
+          volumeMounts:
+            - name: rucio-daily-stats-secrets
+              mountPath: /etc/secrets
+              readOnly: true
+            - name: eos # EOS access
+              mountPath: /eos
+              mountPropagation: HostToContainer
+            - name: cronjobs-configmap
+              mountPath: /data/cronjob
+      volumes:
+        - name: rucio-daily-stats-secrets
+          secret:
+            secretName: rucio-daily-stats-secrets
+        - name: eos
+          hostPath:
+            path: /var/eos
+        - name: cronjobs-configmap
+          configMap:
+            name: cmsmon-rucio-ds


### PR DESCRIPTION
This PR exceeded its aim and title but it was required.

- `docker/cmsmon-hadoop-base` is parametrized to build both spark2 and spark3 based images. spark2 is used in `sqoop` docker image, `spark3` is used in `docker/cmsmon-rucio-ds` and will be used in other K8s pods which run spark jobs. Its `build-and-push.sh` script can easily build and push docker image. Readme file provides detailes.
- `docker/cmsmon-rucio-ds` is implemented to run [bin/cron4rucio_datasets_daily_stats.sh](https://github.com/dmwm/CMSSpark/pull/83), related with [CMSMONIT-450](https://its.cern.ch/jira/browse/CMSMONIT-450)
- `services/cmsmon-rucio-ds.yaml` will run Rucio datasets daily stats Spark job in `hdfs` namespace.
- New secret deployment command is added for `rucio-daily-stats-secrets` in `deploy-secrets.sh`

I tried to keep service name as short as possible, `ds` refers to datasets in `cmsmon-rucio-ds.yaml`. Open to suggestions..

fyi @vkuznet 