### PR TITLE
Fix rucio mon crond

### DIFF
--- a/docker/cmsmon-rucio-ds/Dockerfile
+++ b/docker/cmsmon-rucio-ds/Dockerfile
@@ -4,8 +4,7 @@ ENV WDIR=/data
 WORKDIR $WDIR
 
 ENV HADOOP_CONF_DIR=/etc/hadoop/conf
-ENV PATH="${PATH}:${WDIR}/CMSSpark/bin"
-
+ENV PATH="${PATH}:/usr/hdp/hadoop/bin/hadoop:/usr/hdp/spark3/bin:/usr/hdp/sqoop/bin:${WDIR}/CMSSpark/bin"
 # CMSMonitoring folder is in WDIR
 ENV PYTHONPATH "${PYTHONPATH}:${WDIR}:${WDIR}/CMSSpark/src/python"
 
@@ -33,12 +32,12 @@ RUN yum remove -y hbase-bin-2.3 && \
     rm -rf stomp-v700 && \
     svn export https://github.com/dmwm/CMSMonitoring.git/branches/master/src/python/CMSMonitoring && \
     zip -r CMSMonitoring.zip CMSMonitoring/* && \
-    git clone https://github.com/mrceyhun/CMSSpark.git && \
-    cd CMSSpark && git checkout f-rucio_datasets_daily_stats && \
+    git clone https://github.com/dmwm/CMSSpark.git && \
     yum clean all &&  rm -rf /var/cache/yum && \
     rm -f /usr/bin/python && ln -s /usr/bin/python3.6 /usr/bin/python && \
-    hadoop-set-default-conf.sh analytix && \
-    source hadoop-setconf.sh analytix 3.2 spark3
-
+    hadoop-set-default-conf.sh analytix && source hadoop-setconf.sh analytix 3.2 spark3
 
 WORKDIR $WDIR
+
+# Run crond
+CMD ["crond", "-n", "-s", "&"]

--- a/docker/cmsmon-rucio-ds/README.md
+++ b/docker/cmsmon-rucio-ds/README.md
@@ -10,12 +10,13 @@ Installs:
 - Only src/python/CMSMonitoring cluster of dmwm/CMSMonitoring repo and creates its zip for Spark job to submit
 - dmwm/CMSSpark
 
-#### How to build
+#### How to build and push
 
 ```shell
+cd docker/cmsmon-rucio-ds
+#
 docker_registry=registry.cern.ch/cmsmonitoring
-image_tag=20220415
+image_tag=20220418
 docker build -t "${docker_registry}/cmsmon-rucio-ds:${image_tag}" .
-# push
 docker push "${docker_registry}/cmsmon-rucio-ds:${image_tag}"
 ```

--- a/kubernetes/monitoring/services/cmsmon-rucio-ds.yaml
+++ b/kubernetes/monitoring/services/cmsmon-rucio-ds.yaml
@@ -26,18 +26,22 @@ metadata:
   namespace: hdfs
   labels:
     app: cmsmon-rucio-ds
+# Reference: https://www.ibm.com/support/pages/cron-environment-and-cron-job-failures
 data:
   run.sh: |
     #!/bin/bash
-    $WDIR/CMSSpark/bin/cron4rucio_datasets_daily_stats.sh --keytab /etc/secrets/keytab \
-        --cmsr /etc/secrets/cmsr_cstring --rucio /etc/secrets/rucio --amq /etc/secrets/amq-creds.json \
-        --cmsmonitoring $WDIR/CMSMonitoring.zip --stomp $WDIR/stomp-v700.zip --k8s
-
-  run-cron.sh: |
-    cat <<EOF | crontab -
-    45 7 * * * /data/cronjob/run.sh
-    EOF
-    crond -n -s
+    # Get env variables, since cron's process environment is different than shell's one
+    . /etc/environment
+    # Run and print all results(except for Spark logs) to stdout
+    /data/CMSSpark/bin/cron4rucio_datasets_daily_stats.sh \
+      --keytab /etc/secrets/keytab \
+      --cmsr /etc/secrets/cmsr_cstring \
+      --rucio /etc/secrets/rucio \
+      --amq /etc/secrets/amq-creds.json \
+      --cmsmonitoring /data/CMSMonitoring.zip \
+      --stomp /data/stomp-v700.zip \
+      --eos /eos/user/c/cmsmonit/www/rucio_daily_ds_stats \
+      >> /proc/$(cat /var/run/crond.pid)/fd/1 2>&1
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -59,18 +63,28 @@ spec:
       hostname: cmsmon-rucio-ds
       containers:
         - name: cmsmon-rucio-ds
-          image: registry.cern.ch/cmsmonitoring/cmsmon-rucio-ds:20220415
+          image: registry.cern.ch/cmsmonitoring/cmsmon-rucio-ds:20220418
           imagePullPolicy: Always
-          command:
-            - /bin/sh
-            - /data/cronjob/run-cron.sh
-          tty: true
-          stdin: true
           env:
             - name: MY_NODE_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - "sh"
+                  - "-c"
+                  - >
+                    export > /etc/environment;
+                    chmod +x /data/cronjob/run.sh;
+                    echo "45 6  * * * /bin/bash /data/cronjob/run.sh" | crontab -;
+          ports:
+            - containerPort: 31201 # spark.driver.port
+              name: port-0
+            - containerPort: 31202 # spark.driver.blockManager.port
+              name: port-1
           resources:
             limits:
               cpu: 2000m
@@ -78,15 +92,8 @@ spec:
             requests:
               cpu: 500m
               memory: 750Mi
-          ports:
-            - containerPort: 31201 # spark.driver.port
-              name: port-0
-            - containerPort: 31202 # spark.driver.blockManager.port
-              name: port-1
-          lifecycle:
-            postStart:
-              exec:
-                command: [ "/bin/sh", "-c", "export > /etc/environment" ]
+          stdin: true
+          tty: true
           volumeMounts:
             - name: rucio-daily-stats-secrets
               mountPath: /etc/secrets


### PR DESCRIPTION
NodePorts 31201 and 31202 will be used in `cmsmonitoring` cluster to reach Spark Cluster (UI and Block Manager)
Related with  https://github.com/dmwm/CMSSpark/pull/84

fyi @vkuznet 