### PR TITLE
Fix golang 1.18 go get not supported outside a module

### DIFF
--- a/docker/sqoop/Dockerfile
+++ b/docker/sqoop/Dockerfile
@@ -15,10 +15,10 @@ WORKDIR $WDIR
 ENV GOPATH=$WDIR/gopath
 RUN mkdir -p $GOPATH
 ENV PATH="${PATH}:${GOROOT}/bin:${WDIR}"
+WORKDIR $WDIR/CMSMonitoring/src/go/MONIT
 RUN go get github.com/go-stomp/stomp
 RUN go get github.com/prometheus/client_golang/prometheus
 RUN go get github.com/prometheus/client_golang/prometheus/promhttp
-WORKDIR $WDIR/CMSMonitoring/src/go/MONIT
 RUN go build monit.go && go build hdfs_exporter.go && cp monit hdfs_exporter $WDIR
 WORKDIR $WDIR
 


### PR DESCRIPTION
go 1.18+ requires to run `go get module` inside of the go module(i.e. src/go/MONIT) that includes `go.mod` and `go.sum` files. `golang:latest` official docker image uses `go1.18.1`. Tested and working fine.

fyi @vkuznet 

