### PR TITLE
Move monitoring images to new registry, bump alpine versions and upgrade promxy, loki

### DIFF
--- a/docker/cmsmon-alerts/Dockerfile
+++ b/docker/cmsmon-alerts/Dockerfile
@@ -20,7 +20,7 @@ RUN go build -ldflags="-s -w -extldflags -static" ggus_alerting.go
 RUN go build -ldflags="-s -w -extldflags -static" es_exporter.go
 RUN go build -ldflags="-s -w -extldflags -static" hdfs_exporter.go
 
-FROM alpine:3.15
+FROM alpine:3.15.4
 RUN mkdir /data
 COPY --from=go-builder /data/CMSMonitoring/src/go/MONIT/monit /data
 COPY --from=go-builder /data/CMSMonitoring/src/go/MONIT/ssb_alerting /data

--- a/docker/cmsmon-intelligence/Dockerfile
+++ b/docker/cmsmon-intelligence/Dockerfile
@@ -15,7 +15,7 @@ ARG CGO_ENABLED=0
 WORKDIR $WDIR/CMSMonitoring
 RUN git checkout tags/$CMSMON_TAG -b build && cd src/go/intelligence && make
 
-FROM alpine:3.15
+FROM alpine:3.15.4
 RUN mkdir /data
 COPY --from=go-builder /data/CMSMonitoring/src/go/intelligence/intelligence /data
 ENV PATH $PATH:/data

--- a/docker/cmsmon-rucio-ds/README.md
+++ b/docker/cmsmon-rucio-ds/README.md
@@ -13,8 +13,7 @@ Installs:
 #### How to build and push
 
 ```shell
-cd docker/cmsmon-rucio-ds
-#
+# docker image prune -a OR docker system prune -f -a
 docker_registry=registry.cern.ch/cmsmonitoring
 image_tag=20220418
 docker build -t "${docker_registry}/cmsmon-rucio-ds:${image_tag}" .

--- a/docker/cmsmon/Dockerfile
+++ b/docker/cmsmon/Dockerfile
@@ -1,4 +1,4 @@
-FROM cmssw/cmsweb:20210628
+FROM registry.cern.ch/cmsweb/cmsweb
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 
 # add environment

--- a/docker/cmsmon/README.md
+++ b/docker/cmsmon/README.md
@@ -46,5 +46,16 @@ docker push USERNAME/cmsmon:v0.1
 docker system prune -f -a
 ```
 
+#### How to build for cern registry
+
+```shell
+docker_registry=registry.cern.ch/cmsmonitoring
+image_tag=20220421
+docker build -t "${docker_registry}/cmsmon:${image_tag}" .
+# push
+docker push "${docker_registry}/cmsmon:${image_tag}"
+```
+
+
 Docker commands guide can be found
 [here](https://docs.docker.com/engine/reference/commandline/docker/)

--- a/docker/condor-cpu-eff/README.md
+++ b/docker/condor-cpu-eff/README.md
@@ -7,6 +7,7 @@ Resultant page: https://cmsdatapop.web.cern.ch/cmsdatapop/
 #### How to build
 
 ```shell
+# docker image prune -a OR docker system prune -f -a
 docker_registry=registry.cern.ch/cmsmonitoring
 image_tag=20220419
 docker build -t "${docker_registry}/condor_cpu_eff:${image_tag}" .

--- a/docker/http-exporter/Dockerfile
+++ b/docker/http-exporter/Dockerfile
@@ -2,14 +2,16 @@ FROM golang:latest as go-builder
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 ENV WDIR=/data
 WORKDIR $WDIR
+# go-1.18+ requires go.mod to run go get
+RUN go mod init github.com/vkuznet/http-exporter
 RUN go get github.com/prometheus/client_golang/prometheus
 RUN go get github.com/prometheus/common
 RUN go get github.com/vkuznet/x509proxy
 RUN curl -ksLO https://raw.githubusercontent.com/dmwm/cmsweb-exporters/master/http_exporter.go
 RUN mkdir /build
 ARG CGO_ENABLED=0
-RUN go mod init github.com/vkuznet/http-exporter && go mod tidy && go build -o /build/http_exporter -ldflags="-s -w -extldflags -static" http_exporter.go
+RUN go mod tidy && go build -o /build/http_exporter -ldflags="-s -w -extldflags -static" http_exporter.go
 
-FROM alpine:3.15
+FROM alpine:3.15.4
 RUN mkdir /data
 COPY --from=go-builder /build/http_exporter /data/

--- a/docker/http-exporter/README.md
+++ b/docker/http-exporter/README.md
@@ -1,0 +1,9 @@
+#### How to build
+
+```shell
+docker_registry=registry.cern.ch/cmsmonitoring
+image_tag=20220420
+docker build -t "${docker_registry}/http-exporter:${image_tag}" .
+# push
+docker push "${docker_registry}/http-exporter:${image_tag}"
+```

--- a/docker/karma/Dockerfile
+++ b/docker/karma/Dockerfile
@@ -1,14 +1,14 @@
-FROM node:12.16.3-alpine3.11 as nodejs-builder
+FROM node:18.0.0-alpine as nodejs-builder
 RUN apk add make git
 RUN git clone https://github.com/prymitive/karma.git
 RUN mkdir -p /src/ui
 RUN cp karma/ui/package.json karma/ui/package-lock.json /src/ui/
-RUN cd /src/ui && npm install
+RUN cd /src/ui && npm ci && touch node_modules/.install
 RUN apk add make git
 RUN cp -R karma/ui /src
 RUN make -C /src/ui build
 
-FROM golang:1.14.3-alpine3.11 as go-builder
+FROM golang:1.18.1-alpine as go-builder
 RUN apk add make git
 RUN git clone https://github.com/prymitive/karma.git
 RUN mkdir -p /src
@@ -17,9 +17,10 @@ RUN cp -R karma/make /src/make
 RUN cp karma/go.mod /src/go.mod
 RUN cp karma/go.sum /src/go.sum
 RUN make -C /src download-deps-go
-RUN make -C /src install-deps-build-go
 COPY --from=nodejs-builder /src/ui/src /src/ui/src
 COPY --from=nodejs-builder /src/ui/build /src/ui/build
+COPY --from=nodejs-builder /src/ui/mock /src/ui/mock
+COPY --from=nodejs-builder /src/ui/embed.go /src/ui/embed.go
 RUN cp -R karma/cmd /src/cmd
 RUN cp -R karma/internal /src/internal
 ARG VERSION

--- a/docker/karma/README.md
+++ b/docker/karma/README.md
@@ -1,0 +1,9 @@
+#### How to build and push
+
+```shell
+# docker image prune -a OR docker system prune -f -a
+docker_registry=registry.cern.ch/cmsmonitoring
+image_tag=20220421
+docker build -t "${docker_registry}/karma:${image_tag}" .
+docker push "${docker_registry}/karma:${image_tag}"
+```

--- a/docker/kerberos/Dockerfile
+++ b/docker/kerberos/Dockerfile
@@ -1,4 +1,4 @@
-FROM cern/cc7-base:20201201-1.x86_64
+FROM cern/cc7-base:20220401-1.x86_64
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 RUN yum install -y sudo krb5-workstation krb5-libs pam_krb5 && yum clean all && rm -rf /var/cache/yum
 # Install latest kubectl

--- a/docker/kerberos/README.md
+++ b/docker/kerberos/README.md
@@ -1,0 +1,10 @@
+#### How to build
+
+```shell
+# docker image prune -a OR docker system prune -f -a
+docker_registry=registry.cern.ch/cmsmonitoring
+image_tag=20220421
+docker build -t "${docker_registry}/kerberos:${image_tag}" .
+# push
+docker push "${docker_registry}/kerberos:${image_tag}"
+```

--- a/docker/log-clustering/Dockerfile
+++ b/docker/log-clustering/Dockerfile
@@ -1,21 +1,19 @@
-FROM cern/cc7-base:20200504-1.x86_64
+FROM registry.cern.ch/cmsmonitoring/cmsmon-hadoop-base:20220401-1-spark2
 #FROM cmssw/cmsweb
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 
-ADD hadoop.repo /etc/yum.repos.d/hadoop.repo
-# ADD slc7-cernonly.repo /etc/yum.repos.d/slc7-cernonly.repo
-# ADD RPM-GPG-KEY-wlcg /etc/pki/rpm-gpg/RPM-GPG-KEY-wlcg
-
+WORKDIR /
 # hadoop related RPMs
-RUN yum install -y cern-hadoop-config spark-bin-2.3.0 hadoop-bin-2.7.5 hbase-bin-1.2.6 sqoop-bin-1.4 \
-    java-1.8.0-openjdk-devel python27-python-pip python36-pip python36-devel gcc git golang
-RUN yum clean all
+RUN yum install -y python3 gcc golang && python3 -m pip install --upgrade pip
+RUN yum clean all &&  rm -rf /var/cache/yum
 
 # replace python2 with python3
 RUN rm /usr/bin/python
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
 # setup proper environment
+
+ENV HADOOP_CONF_DIR=/etc/hadoop/conf
 ENV PATH $PATH:/usr/hdp/hadoop/bin:/usr/hdp/sqoop/bin:/usr/hdp/spark/bin
 RUN hadoop-set-default-conf.sh analytix
 RUN source hadoop-setconf.sh analytix
@@ -29,17 +27,19 @@ ENV PYTHONPATH="/usr/local/lib64/python3.6/site-packages:${WDIR}/log-clustering/
 ENV GOPATH=$WDIR/gopath
 RUN mkdir -p $GOPATH
 ENV PATH="${PATH}:${GOROOT}/bin:${WDIR}"
+WORKDIR /
 RUN git clone https://github.com/dmwm/CMSMonitoring.git
-RUN go get github.com/go-stomp/stomp
 RUN cp CMSMonitoring/src/go/MONIT/monit.go .
+RUN go mod init monit.go
+RUN go get github.com/go-stomp/stomp
 RUN go build monit.go
 RUN cp monit $WDIR
 
 # install log-clustering and required dependencies
 WORKDIR $WDIR
 RUN git clone https://github.com/vkuznet/log-clustering.git
-RUN pip-3 install Cython
-RUN pip-3 install -r log-clustering/workflow/requirements.txt
+RUN pip3 install Cython
+RUN pip3 install -r log-clustering/workflow/requirements.txt
 RUN python3 -c "import nltk; nltk.download('stopwords')"
 
 # add crons

--- a/docker/log-clustering/README.md
+++ b/docker/log-clustering/README.md
@@ -1,0 +1,9 @@
+#### How to build for cern registry
+
+```shell
+docker_registry=registry.cern.ch/cmsmonitoring
+image_tag=20220421
+docker build -t "${docker_registry}/log-clustering:${image_tag}" .
+# push
+docker push "${docker_registry}/log-clustering:${image_tag}"
+```

--- a/docker/loki/Dockerfile
+++ b/docker/loki/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:latest as go-builder
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 
 RUN apt-get update && apt-get install -y unzip
-RUN curl -ksLO https://github.com/grafana/loki/releases/download/v2.2.0/loki-linux-amd64.zip && \
+RUN curl -ksLO https://github.com/grafana/loki/releases/download/v2.5.0/loki-linux-amd64.zip && \
     unzip loki-linux-amd64.zip && mv loki-linux-amd64 loki
 
 FROM alpine:3.15

--- a/docker/nats-sub/Dockerfile
+++ b/docker/nats-sub/Dockerfile
@@ -3,5 +3,7 @@ MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 ENV WDIR=/data
 WORKDIR $WDIR
 RUN curl -ksLO https://raw.githubusercontent.com/dmwm/CMSMonitoring/master/src/go/NATS/nats-sub.go
+RUN go mod init nats-sub.go
 RUN go get github.com/nats-io/nats.go
+RUN go mod tidy
 RUN go build nats-sub.go

--- a/docker/nats-sub/README.md
+++ b/docker/nats-sub/README.md
@@ -1,0 +1,9 @@
+#### How to build and push
+
+```shell
+# docker image prune -a OR docker system prune -f -a
+docker_registry=registry.cern.ch/cmsmonitoring
+image_tag=20220421
+docker build -t "${docker_registry}/nats-sub:${image_tag}" .
+docker push "${docker_registry}/nats-sub:${image_tag}"
+```

--- a/docker/promxy/Dockerfile
+++ b/docker/promxy/Dockerfile
@@ -4,9 +4,9 @@ ENV WDIR=/data
 ENV USER=promxy
 EXPOSE 8082
 WORKDIR $WDIR
-ENV VER=v0.0.70
+ENV VER=v0.0.75
 RUN curl -ksLO https://github.com/jacksontj/promxy/releases/download/${VER}/promxy-${VER}-linux-amd64 && mv promxy-${VER}-linux-amd64 promxy && chmod +x /data/promxy
 
-FROM alpine:3.15
+FROM alpine:3.15.4
 RUN mkdir -p /data
 COPY --from=go-builder /data/promxy /data/

--- a/docker/promxy/README.md
+++ b/docker/promxy/README.md
@@ -1,0 +1,9 @@
+#### How to build
+
+```shell
+docker_registry=registry.cern.ch/cmsmonitoring
+image_tag=v0.0.75
+docker build -t "${docker_registry}/promxy:${image_tag}" .
+# push
+docker push "${docker_registry}/promxy:${image_tag}"
+```

--- a/docker/vmbackup-utility/Dockerfile
+++ b/docker/vmbackup-utility/Dockerfile
@@ -1,4 +1,4 @@
-FROM cern/cc7-base:20210501-2.x86_64 as base_image
+FROM cern/cc7-base:20220401-1.x86_64 as base_image
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 
 RUN mkdir -p /data/

--- a/docker/vmbackup-utility/README.md
+++ b/docker/vmbackup-utility/README.md
@@ -1,0 +1,10 @@
+#### How to build
+
+```shell
+# docker image prune -a OR docker system prune -f -a
+docker_registry=registry.cern.ch/cmsmonitoring
+image_tag=20220421
+docker build -t "${docker_registry}/vmbackup-utility:${image_tag}" .
+# push
+docker push "${docker_registry}/vmbackup-utility:${image_tag}"
+```

--- a/kubernetes/monitoring/crons/cron-kerberos.yaml
+++ b/kubernetes/monitoring/crons/cron-kerberos.yaml
@@ -1,3 +1,4 @@
+# cmsmonit-new and HA1 clusters version is 1.19.3, use apiVersion: batch/v1beta1, HA2 is 1.22.3, use: batch/v1
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -12,7 +13,7 @@ spec:
           serviceAccountName: kerberos-account
           containers:
           - name: kerberos
-            image: cmssw/kerberos
+            image: registry.cern.ch/cmsmonitoring/kerberos:20220421
             args:
             - /bin/sh
             - -c

--- a/kubernetes/monitoring/crons/cron-proxy.yaml
+++ b/kubernetes/monitoring/crons/cron-proxy.yaml
@@ -1,3 +1,4 @@
+# cmsmonit-new and HA1 clusters version is 1.19.3, use apiVersion: batch/v1beta1, HA2 is 1.22.3, use: batch/v1
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -12,7 +13,7 @@ spec:
           serviceAccountName: proxy-account
           containers:
           - name: proxy
-            image: cmssw/proxy
+            image: registry.cern.ch/cmsweb/proxy
             args:
             - /bin/sh
             - -c

--- a/kubernetes/monitoring/deploy-secrets.sh
+++ b/kubernetes/monitoring/deploy-secrets.sh
@@ -100,7 +100,11 @@ elif [ "$secret" == "proxy-secrets" ]; then
     voms-proxy-init -voms cms -rfc -out /tmp/proxy
     files="--from-file=/tmp/proxy"
 elif [ "$secret" == "log-clustering-secrets" ]; then
-    files=`ls $sdir/log-clustering/ | awk '{ORS=" " ; print "--from-file="D"/"$1""}' D=$sdir/log-clustering | sed "s, $,,g"`
+    # creds.json
+    log_f=`ls $sdir/log-clustering/ | awk '{ORS=" " ; print "--from-file="D"/"$1""}' D=$sdir/log-clustering | sed "s, $,,g"`
+    # cmsmonit keytab
+    cmsmonit_f=`ls $sdir/cmsmonit-keytab/ | awk '{ORS=" " ; print "--from-file="D"/"$1""}' D=$sdir/cmsmonit-keytab | sed "s, $,,g"`
+    files="${log_f} ${cmsmonit_f}"
 elif [ "$secret" == "condor-cpu-eff-secrets" ]; then
     files=`ls $sdir/cmsmonit-keytab/ | awk '{ORS=" " ; print "--from-file="D"/"$1""}' D=$sdir/cmsmonit-keytab | sed "s, $,,g"`
 elif [ "$secret" == "es-wma-secrets" ]; then

--- a/kubernetes/monitoring/services/agg/victoria-metrics-long.yaml
+++ b/kubernetes/monitoring/services/agg/victoria-metrics-long.yaml
@@ -52,7 +52,7 @@ spec:
           - name: vm-volume
             mountPath: /tsdb
         - name: vmbackup
-          image: cmssw/vmbackup-utility
+          image: registry.cern.ch/cmsmonitoring/vmbackup-utility:20220421
           volumeMounts:
           - name: vm-volume
             mountPath: /tsdb

--- a/kubernetes/monitoring/services/agg/victoria-metrics.yaml
+++ b/kubernetes/monitoring/services/agg/victoria-metrics.yaml
@@ -52,7 +52,7 @@ spec:
           - name: vm-volume
             mountPath: /tsdb
         - name: vmbackup
-          image: cmssw/vmbackup-utility
+          image: registry.cern.ch/cmsmonitoring/vmbackup-utility:20220421
           volumeMounts:
           - name: vm-volume
             mountPath: /tsdb

--- a/kubernetes/monitoring/services/cmsmon-vol.yaml
+++ b/kubernetes/monitoring/services/cmsmon-vol.yaml
@@ -20,7 +20,7 @@ spec:
           fsGroup: 2000
         containers:
         - name: cmsmon-vol
-          image: cmssw/cmsmon
+          image: registry.cern.ch/cmsmonitoring/cmsmon:20220421
           volumeMounts:
           - name: share-cinder-volume
             mountPath: /tmp/share

--- a/kubernetes/monitoring/services/ha/httpgo.yaml
+++ b/kubernetes/monitoring/services/ha/httpgo.yaml
@@ -30,7 +30,7 @@ spec:
         app: httpgo
     spec:
       containers:
-      - image: cmssw/httpgo
+      - image: registry.cern.ch/cmsweb/httpgo
         name: httpgo
         resources:
           requests:

--- a/kubernetes/monitoring/services/hdfs-exporter-eos.yaml
+++ b/kubernetes/monitoring/services/hdfs-exporter-eos.yaml
@@ -45,7 +45,7 @@ spec:
       spec:
         containers:
         - name: hdfs-exporter-eos
-          image: registry.cern.ch/cmsmonitoring/sqoop:sqoop-0.0.5
+          image: registry.cern.ch/cmsmonitoring/sqoop:sqoop-0.0.7
           command:
           - /bin/sh
           - /data/setup-and-run/setup-and-run.sh

--- a/kubernetes/monitoring/services/http-exp-wmstatssrv.yaml
+++ b/kubernetes/monitoring/services/http-exp-wmstatssrv.yaml
@@ -48,7 +48,7 @@ spec:
           - "600"
           - -verbose
           name: http-exp-wmstatssrv
-          image: cmssw/http-exporter:20200615
+          image: registry.cern.ch/cmsmonitoring/http-exporter:20220420
           ports:
           - containerPort: 18009
           volumeMounts:

--- a/kubernetes/monitoring/services/http-exporter-arucio.yaml
+++ b/kubernetes/monitoring/services/http-exporter-arucio.yaml
@@ -46,7 +46,7 @@ spec:
           - "600"
           - -verbose
           name: http-exporter-arucio
-          image: cmssw/http-exporter:20200615
+          image: registry.cern.ch/cmsmonitoring/http-exporter:20220420
           ports:
           - containerPort: 18012
           volumeMounts:

--- a/kubernetes/monitoring/services/http-exporter-cric.yaml
+++ b/kubernetes/monitoring/services/http-exporter-cric.yaml
@@ -42,8 +42,7 @@ spec:
           - "monitoring"
           - -verbose
           name: http-exporter-cric
-          image: cmssw/http-exporter:20210921
-#           image: cmssw/http-exporter:20200615
+          image: registry.cern.ch/cmsmonitoring/http-exporter:20220420
           ports:
           - containerPort: 18004
           env:

--- a/kubernetes/monitoring/services/http-exporter-detox.yaml
+++ b/kubernetes/monitoring/services/http-exporter-detox.yaml
@@ -42,6 +42,6 @@ spec:
           - "monitoring"
           - -verbose
           name: http-exporter-detox
-          image: cmssw/http-exporter:20200615
+          image: registry.cern.ch/cmsmonitoring/http-exporter:20220420
           ports:
           - containerPort: 18002

--- a/kubernetes/monitoring/services/http-exporter-dmytro.yaml
+++ b/kubernetes/monitoring/services/http-exporter-dmytro.yaml
@@ -42,6 +42,6 @@ spec:
           - "monitoring"
           - -verbose
           name: http-exporter-dmytro
-          image: cmssw/http-exporter:20200615
+          image: registry.cern.ch/cmsmonitoring/http-exporter:20220420
           ports:
           - containerPort: 18010

--- a/kubernetes/monitoring/services/http-exporter-mcm.yaml
+++ b/kubernetes/monitoring/services/http-exporter-mcm.yaml
@@ -44,7 +44,7 @@ spec:
           - "monitoring"
           - -verbose
           name: http-exporter-mcm
-          image: cmssw/http-exporter:20200615
+          image: registry.cern.ch/cmsmonitoring/http-exporter:20220420
           ports:
           - containerPort: 18006
           volumeMounts:

--- a/kubernetes/monitoring/services/http-exporter-mss.yaml
+++ b/kubernetes/monitoring/services/http-exporter-mss.yaml
@@ -42,6 +42,6 @@ spec:
           - "monitoring"
           - -verbose
           name: http-exporter-mss
-          image: cmssw/http-exporter:20200615
+          image: registry.cern.ch/cmsmonitoring/http-exporter:20220420
           ports:
           - containerPort: 18003

--- a/kubernetes/monitoring/services/http-exporter-rucio.yaml
+++ b/kubernetes/monitoring/services/http-exporter-rucio.yaml
@@ -44,6 +44,6 @@ spec:
           - "600"
           - -verbose
           name: http-exporter-rucio
-          image: cmssw/http-exporter:20200615
+          image: registry.cern.ch/cmsmonitoring/http-exporter:20220420
           ports:
           - containerPort: 18011

--- a/kubernetes/monitoring/services/http-exporter-unified.yaml
+++ b/kubernetes/monitoring/services/http-exporter-unified.yaml
@@ -42,6 +42,6 @@ spec:
           - "monitoring"
           - -verbose
           name: http-exporter-unified
-          image: cmssw/http-exporter:20200615
+          image: registry.cern.ch/cmsmonitoring/http-exporter:20220420
           ports:
           - containerPort: 18005

--- a/kubernetes/monitoring/services/http-exporter-wmstats.yaml
+++ b/kubernetes/monitoring/services/http-exporter-wmstats.yaml
@@ -46,7 +46,7 @@ spec:
           - "600"
           - -verbose
           name: http-exporter-wmstats
-          image: cmssw/http-exporter:20200615
+          image: registry.cern.ch/cmsmonitoring/http-exporter:20220420
           ports:
           - containerPort: 18008
           volumeMounts:

--- a/kubernetes/monitoring/services/http-exporter.yaml
+++ b/kubernetes/monitoring/services/http-exporter.yaml
@@ -42,6 +42,6 @@ spec:
           - "monitoring"
           - -verbose
           name: http-sub
-          image: cmssw/http-exporter:20200615
+          image: registry.cern.ch/cmsmonitoring/http-exporter:20220420
           ports:
           - containerPort: 18000

--- a/kubernetes/monitoring/services/httpgo.yaml
+++ b/kubernetes/monitoring/services/httpgo.yaml
@@ -30,7 +30,7 @@ spec:
         app: httpgo
     spec:
       containers:
-      - image: cmssw/httpgo
+      - image: registry.cern.ch/cmsweb/httpgo
         name: httpgo
         resources:
           requests:

--- a/kubernetes/monitoring/services/karma.yaml
+++ b/kubernetes/monitoring/services/karma.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
       - name: karma
-        image: cmssw/karma:20200527
+        image: registry.cern.ch/cmsmonitoring/karma:20220421
 #         imagePullPolicy: Always
         env:
         - name: ALERTMANAGER_URI

--- a/kubernetes/monitoring/services/log-clustering.yaml
+++ b/kubernetes/monitoring/services/log-clustering.yaml
@@ -23,8 +23,7 @@ spec:
         - args:
           - crond
           - -n
-          #image: cmssw/log-clustering:20200605
-          image: cmssw/log-clustering:20200623
+          image: registry.cern.ch/cmsmonitoring/log-clustering:20220421
           name: log-clustering
           volumeMounts:
           - name: log-clustering-secrets

--- a/kubernetes/monitoring/services/nats-sub-dbs.yaml
+++ b/kubernetes/monitoring/services/nats-sub-dbs.yaml
@@ -26,7 +26,7 @@ spec:
           - -vmUri=http://cms-monitoring.cern.ch:30422
           - "cms.dbs.>"
           name: nats-sub
-          image: cmssw/nats-sub
+          image: registry.cern.ch/cmsmonitoring/nats-sub:20220421
           volumeMounts:
           - name: nats-secrets
             mountPath: /etc/nats

--- a/kubernetes/monitoring/services/nats-sub-exitcode.yaml
+++ b/kubernetes/monitoring/services/nats-sub-exitcode.yaml
@@ -26,7 +26,7 @@ spec:
           - -vmUri=http://cms-monitoring.cern.ch:30422
           - "cms.wmarchive.exitCodes.>"
           name: nats-sub
-          image: cmssw/nats-sub
+          image: registry.cern.ch/cmsmonitoring/nats-sub:20220421
           volumeMounts:
           - name: nats-secrets
             mountPath: /etc/nats

--- a/kubernetes/monitoring/services/nats-sub-reqmgr2.yaml
+++ b/kubernetes/monitoring/services/nats-sub-reqmgr2.yaml
@@ -26,7 +26,7 @@ spec:
           - -vmUri=http://cms-monitoring.cern.ch:30422
           - "cms.reqmgr2.>"
           name: nats-sub
-          image: cmssw/nats-sub
+          image: registry.cern.ch/cmsmonitoring/nats-sub:20220421
           volumeMounts:
           - name: nats-secrets
             mountPath: /etc/nats

--- a/kubernetes/monitoring/services/nats-sub-stats.yaml
+++ b/kubernetes/monitoring/services/nats-sub-stats.yaml
@@ -27,7 +27,7 @@ spec:
           - -gatewayUri=http://cms-monitoring.cern.ch:30091
           - "cms.wmarchive.exitCode.>"
           name: nats-sub
-          image: cmssw/nats-sub
+          image: registry.cern.ch/cmsmonitoring/nats-sub:20220421
           volumeMounts:
           - name: nats-secrets
             mountPath: /etc/nats

--- a/kubernetes/monitoring/services/nats-sub-t1.yaml
+++ b/kubernetes/monitoring/services/nats-sub-t1.yaml
@@ -26,7 +26,7 @@ spec:
           - -vmUri=http://cms-monitoring.cern.ch:30422
           - "cms.wmarchive.site.T1.>"
           name: nats-sub
-          image: cmssw/nats-sub
+          image: registry.cern.ch/cmsmonitoring/nats-sub:20220421
           volumeMounts:
           - name: nats-secrets
             mountPath: /etc/nats

--- a/kubernetes/monitoring/services/nats-sub-t2.yaml
+++ b/kubernetes/monitoring/services/nats-sub-t2.yaml
@@ -26,7 +26,7 @@ spec:
           - -vmUri=http://cms-monitoring.cern.ch:30422
           - "cms.wmarchive.site.T2.>"
           name: nats-sub
-          image: cmssw/nats-sub
+          image: registry.cern.ch/cmsmonitoring/nats-sub:20220421
           volumeMounts:
           - name: nats-secrets
             mountPath: /etc/nats

--- a/kubernetes/monitoring/services/nats-sub.yaml
+++ b/kubernetes/monitoring/services/nats-sub.yaml
@@ -25,7 +25,7 @@ spec:
           - -vmUri=http://cms-monitoring.cern.ch:30422"
           - "cms.wmarchive.exitCode.>"
           name: nats-sub
-          image: cmssw/nats-sub
+          image: registry.cern.ch/cmsmonitoring/nats-sub:20220421
           volumeMounts:
           - name: nats-secrets
             mountPath: /etc/nats

--- a/kubernetes/monitoring/services/promxy.yaml
+++ b/kubernetes/monitoring/services/promxy.yaml
@@ -36,8 +36,7 @@ spec:
           - /data/promxy
           - --config=/etc/promxy/config.yaml
           name: promxy
-          image: cmssw/promxy:v0.0.70
-#           image: cmssw/promxy
+          image: registry.cern.ch/cmsmonitoring/promxy:v0.0.75
           ports:
           - containerPort: 8082
             protocol: TCP

--- a/kubernetes/monitoring/services/sqoop.yaml
+++ b/kubernetes/monitoring/services/sqoop.yaml
@@ -21,7 +21,7 @@ spec:
           - /data/sqoop/log
           - "7"
           - "7200"
-          image: registry.cern.ch/cmsmonitoring/sqoop:sqoop-0.0.5
+          image: registry.cern.ch/cmsmonitoring/sqoop:sqoop-0.0.7
           name: sqoop
           volumeMounts:
           - name: sqoop-secrets


### PR DESCRIPTION
Related with CMSKUBERNETES-133

- I built `promxy` image with the latest release, however I did not test it yet. Please not merge.
- Other builds are autamatically triggered and built by GH workflows in CMSMonitoring. They will be tested.  
- @muhammadimranfarooqi `loki` is already in [cmsweb cern registry](https://registry.cern.ch/harbor/projects/1771/repositories/loki) . It has a new release: `v2.5.0` and I added it to this commit. Please inform me, if you don't want to use new loki version and then I can rollback it.

fyi @leggerf @brij01 