### PR TITLE
Merge CRAB tw, publisher, crabserver data pipelne in crab logstash

### DIFF
--- a/kubernetes/cmsweb/monitoring/crab/logstash.conf
+++ b/kubernetes/cmsweb/monitoring/crab/logstash.conf
@@ -4,22 +4,23 @@ input { beats { port => 5044 } }
 
 filter {
   # whitelisted tags
-  if "crabtaskworker" not in [tags] and "publisher" not in [tags] { drop { } }
+  if "crabtaskworker" not in [tags] and "crabpublisher" not in [tags] and "crabhttpcall" not in [tags] { drop { } }
 
   mutate {
-    # Metadata
+    # ---- Common fields ---- [metadata]
     add_field => {
-      "hostname" => "%{[host][name]}"
-      "log_file" => "%{[log][file][path]}"
-      "agent_name" => "%{[agent][name]}"
-      "agent_version" => "%{[agent][version]}"
       "cmsweb_cluster" => "${CMSWEB_CLUSTER:NA}"
       "cmsweb_env" => "${CMSWEB_ENV:NA}"
+      "filebeat_id" => "%{[agent][id]}"
+      "filebeat_name" => "%{[agent][name]}"
+      "filebeat_version" => "%{[agent][version]}"
+      "hostname" => "%{[host][name]}"
+      "log_file" => "%{[log][file][path]}"
     }
   }
 
   if "crabtaskworker" in [tags] {
-
+      # ------------------------------------------------------------------------------------------------------------------------------------------------------------------
       # TASKWORKER
       mutate {
         # MONIT mandatory fields. Be aware that you cannot use any of these names in grok/mutate parsers!
@@ -70,14 +71,21 @@ filter {
           }
       } else { drop {} }
 
-  } else if "publisher" in [tags] {
-
-      # PUBLISHER
+      date {
+        # Since date string does not provide timezone, we need to specify it explicitly
+        match => ["timestamp_temp", "YYYY-MM-dd HH:mm:ss,SSS"]
+        timezone => "Europe/Zurich"
+        target => "rec_timestamp_str"
+      }
+      # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+  } else if "crabpublisher" in [tags] {
+      # ------------------------------------------------------------------------------------------------------------------------------------------------------------------
+      # CRABPUBLISHER
       mutate {
         # MONIT mandatory fields. Be aware that you cannot use any of these names in grok/mutate parsers!
         replace => {
           "producer" => "crab"
-          "type" => "publisher"
+          "type" => "crabpublisher"
         }
       }
 
@@ -144,40 +152,90 @@ filter {
           }
 
       } else { drop { } }
-
+      date {
+        # Since date string does not provide timezone, we need to specify it explicitly
+        match => ["timestamp_temp", "YYYY-MM-dd HH:mm:ss,SSS"]
+        timezone => "Europe/Zurich"
+        target => "rec_timestamp_str"
+      }
+      # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+  } else if "crabhttpcall" in [tags] {
+      # ------------------------------------------------------------------------------------------------------------------------------------------------------------------
+      # CRABHTTPCALL (previously crabserver)
+      mutate {
+        # MONIT mandatory fields. Be aware that you cannot use any of these names in grok/mutate parsers!
+        replace => {
+          "producer" => "crab"
+          "type" => "crabhttpcall"
+        }
+      }
+      grok {
+        match => { "message" => '\[%{NOTSPACE:timestamp_temp}\] %{DATA:backend} %{IPORHOST:clientip} "%{WORD:method} %{NOTSPACE:request} %{DATA:httpversion}" %{NUMBER:code:int}[^\[]* \[data: %{NUMBER:bytes_sent:int} in %{NUMBER:bytes_received:int} out %{NUMBER:time_spent_ms:int} us \] \[auth: %{DATA} "%{DATA:dn}".*\] \[ref: "%{DATA}.*" "%{DATA:client}" \]' }
+      }
+      grok {
+        match => { "request" => '/%{WORD:system}%{UNIXPATH:uri_path}%{URIPARAM:uri_params}?' }
+      }
+      if ![uri_params] {
+          ruby { code => "event.set('uri_params','')" }
+      }
+      grok { match => { "uri_path" => '/.*/%{DATA:api}$' } }
+      if [client] {
+          grok { match => { "client" => '%{DATA:client_name}/%{DATA:client_version}$' } }
+      }
+      # !ATTENTION! Different date-time format than publisher and TW, means that special for crabserver.
+      date {
+         # Since date string does not provide timezone, we need to specify it explicitly
+         match => [ "timestamp_temp", "dd/MMM/yyyy:HH:mm:ss" ]
+         timezone => "Europe/Zurich"
+         target => "rec_timestamp_str"
+      }
+      mutate { gsub =>  [ "dn","/CN=\d+","" ] }
+      # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
   }
 
-  date {
-      # Since date string does not provide timezone, we need to specify it explicitly
-      match => ["timestamp_temp", "YYYY-MM-dd HH:mm:ss,SSS"]
-      timezone => "Europe/Zurich"
-      target => "rec_timestamp_str"
-  }
-
+  # ---- Common modifications ----
   if "_grokparsefailure" in [tags] { drop { } }
 
+  # Date operations
   ruby {
-      # "metadata.timestamp"(date in ES) equals to record_time(int in ES) which we need for latency calculation
-      # "producer_time" is filebeat process tstamp.
-      code => "event.set('timestamp', (event.get('rec_timestamp_str').to_f * 1000).to_i)
-               event.set('record_time', (event.get('rec_timestamp_str').to_f * 1000).to_i)
-               event.set('producer_time', (event.get('@timestamp').to_f * 1000).to_i)
-               "
+    # "metadata.timestamp"(date in ES) equals to record_time(int in ES) which we need for latency calculation
+    # "producer_time" is filebeat process time stamp.
+    code => "event.set('timestamp', (event.get('rec_timestamp_str').to_f * 1000).to_i)
+           event.set('record_time', (event.get('rec_timestamp_str').to_f * 1000).to_i)
+           event.set('producer_time', (event.get('@timestamp').to_f * 1000).to_i)
+           "
   }
 
+  # remove quotes from message entry since it will break the JSON
   mutate { gsub => [ "message", "\n", "", "message", "\"", ""] }
 
   # remove undesired fields and objects
-  mutate {
-    remove_field => ["@timestamp", "@version", "timestamp_temp", "agent", "log", "input", "tags", "ecs", "host", "cloud", "event" ]
-  }
+  mutate { remove_field => ["@timestamp", "@version", "timestamp_temp", "agent", "log", "input", "tags", "ecs", "host", "cloud", "event" ] }
 
 }
 
 output {
-  if [type] == "crabtaskworker" or [type] == "publisher" {
+  if [type] == "crabtaskworker" {
     http {
       http_method => post
+      url => "http://monit-logs.cern.ch:10012/"
+      content_type => "application/json; charset=UTF-8"
+      format => "json_batch"
+      socket_timeout => 60
+      connect_timeout => 60
+    }
+  } else if [type] == "crabpublisher" {
+    http {
+      http_method => post
+      url => "http://monit-logs.cern.ch:10012/"
+      content_type => "application/json; charset=UTF-8"
+      format => "json_batch"
+      socket_timeout => 60
+      connect_timeout => 60
+    }
+  } else if [type] == "crabhttpcall" {
+    http {
+      http_method => "post"
       url => "http://monit-logs.cern.ch:10012/"
       content_type => "application/json; charset=UTF-8"
       format => "json_batch"

--- a/kubernetes/cmsweb/monitoring/logstash.conf
+++ b/kubernetes/cmsweb/monitoring/logstash.conf
@@ -81,36 +81,6 @@ filter {
       }
       mutate { gsub =>  [ "dn","/CN=\d+","" ] }
   }
-  if "crabserver" in [tags] {
-      mutate { replace => { "type" => "crabserver" } }
-      grok {
-        match => { "message" => '\[%{NOTSPACE:tstamp}\] %{DATA:backend} %{IPORHOST:clientip} "%{WORD:method} %{NOTSPACE:request} %{DATA:httpversion}" %{NUMBER:code:int}[^\[]* \[data: %{NUMBER:bytes_sent:int} in %{NUMBER:bytes_received:int} out %{NUMBER:time_spent_ms:int} us \] \[auth: %{DATA} "%{DATA:dn}".*\] \[ref: "%{DATA}.*" "%{DATA:client}" \]' }
-      }
-      grok {
-        match => { "request" => '/%{WORD:system}%{UNIXPATH:uri_path}%{URIPARAM:uri_params}?' }
-      }
-      if ![uri_params] {
-          ruby { code => "event.set('uri_params','')" }
-      }
-      grok { match => { "uri_path" => '/.*/%{DATA:api}$' } }
-      if [client] {
-          grok { match => { "client" => '%{DATA:client_name}/%{DATA:client_version}$' } }
-      }
-      date {
-         # Since date string does not provide timezone, we need to specify it explicitly
-         match => [ "tstamp", "dd/MMM/yyyy:HH:mm:ss" ]
-         timezone => "Europe/Zurich"
-         target => "date_object"
-      }
-      ruby {
-         # rec_timestamp(int in ES) is for latency calculation, type is msec
-         code => "event.set('timestamp',(event.get('date_object').to_f * 1000).to_i)
-                  event.set('rec_timestamp',(event.get('date_object').to_f * 1000).to_i)
-                  event.set('rec_date',event.get('date_object'))
-                 "
-      }
-      mutate { gsub =>  [ "dn","/CN=\d+","" ] }
-  }
   if "crabcache" in [tags] {
       mutate { replace => { "type" => "crabcache" } }
   }
@@ -243,17 +213,6 @@ output {
           connect_timeout => 60
       }
   }
-  if [type] == "crabserver" {
-      http {
-          http_method => "post"
-          url => "http://monit-logs.cern.ch:10012/"
-          content_type => "application/json; charset=UTF-8"
-          format => "json_batch"
-          socket_timeout => 60
-          connect_timeout => 60
-      }
-  }
-
 
   # example how to feed data to a local file
   #file {


### PR DESCRIPTION
- Remove "crabserver" from cmsweb Logstash and move to CRAB logstash with different MONIT producer and type.
- Arrange CRAB logstash accordingly

@novicecpp It is not tested yet, but I would like to get your ideas. For example, as it is requested in https://its.cern.ch/jira/browse/CMSMONIT-463 , "crabserver" logs type will be "crabhttpcall" and I forced to use "crabhttpcall" tag in filebeat too (same with type to differentiate easily).

After tests, i'll announce its production ready version.