### PR TITLE
Bump logstash images to 8.1.3

### DIFF
--- a/kubernetes/cmsweb/monitoring/crab/logstash.yaml
+++ b/kubernetes/cmsweb/monitoring/crab/logstash.yaml
@@ -15,7 +15,7 @@ spec:
         app: logstash
     spec:
       containers:
-      - image: docker.elastic.co/logstash/logstash:8.1.0
+      - image: docker.elastic.co/logstash/logstash:8.1.3
         name: logstash
         env:
         - name: CMSWEB_CLUSTER

--- a/kubernetes/cmsweb/monitoring/logstash.yaml
+++ b/kubernetes/cmsweb/monitoring/logstash.yaml
@@ -19,7 +19,7 @@ spec:
         app: logstash
     spec:
       containers:
-      - image: docker.elastic.co/logstash/logstash:7.16.1
+      - image: docker.elastic.co/logstash/logstash:8.1.3
         name: logstash
         env:
         - name: CMSWEB_CLUSTER


### PR DESCRIPTION
Update logstash docker images to latest version which does not have Log4Shell CVE vulnerability.

@muhammadimranfarooqi I tested and it's working fine. Could you please deploy them to test, testbed and prod clusters? I suggest to upgrade filebeat to 8.1.3 version too. Filebeat versions are defined in helm charts and rpm repos AFAIK, so I did not touch them.
