### PR TITLE
Update filebeat output to crab logstash, bump filebeat version

### DIFF
--- a/kubernetes/cmsweb/services/crabserver.yaml
+++ b/kubernetes/cmsweb/services/crabserver.yaml
@@ -45,9 +45,9 @@ data:
       max_backoff: 10s
       include_lines:
         - '^\[.+?\] crabserver-'
-      tags: ["crabserver"]
+      tags: ["crabhttpcall"]
     output.logstash:
-      hosts: ["logstash.monitoring:5044"]
+      hosts: ["logstash:5044"]
       compression_level: 3
       bulk_max_size: 4096
     queue.mem:
@@ -211,7 +211,7 @@ spec:
 #PROD#  securityContext:
 #PROD#    allowPrivilegeEscalation: false
 #PROD#- name: crabserver-filebeat-monit
-#PROD#  image: docker.elastic.co/beats/filebeat:7.12.1
+#PROD#  image: docker.elastic.co/beats/filebeat:8.1.3
 #PROD#  args: [
 #PROD#    "bash",
 #PROD#    "-c",
@@ -262,7 +262,7 @@ spec:
           name: crabserver
       - name: token-secrets
         secret:
-          secretName: token-secrets          
+          secretName: token-secrets
 #PROD#- name: logs
 #PROD#  persistentVolumeClaim:
 #PROD#      claimName: logs-cephfs-claim-crab


### PR DESCRIPTION
Adjust new tag and change endpoint to crab logstash, according to https://github.com/dmwm/CMSKubernetes/pull/1022
Also, bump filebeat version to 8.1.3.

cc @mrceyhun 