### PR TITLE
Add some delay to make sure crabserver produce PID file before monitor.sh scripts read it.

### DIFF
--- a/docker/crabserver/monitor.sh
+++ b/docker/crabserver/monitor.sh
@@ -1,11 +1,22 @@
 #!/bin/bash
 
-# start process exporter
-if [ -f /data/srv/state/crabserver/crabserver.pid ]; then
-    nohup process_monitor.sh /data/srv/state/crabserver/crabserver.pid crabserver ":18270" 15 2>&1 1>& crabserver_monitor.log < /dev/null &
-elif [ -f /data/srv/state/crabserver/pid ]; then
-    nohup process_monitor.sh /data/srv/state/crabserver/pid crabserver ":18270" 15 2>&1 1>& crabserver_monitor.log < /dev/null &
-fi
+# Check pid exist before start process_monitor.sh scripts
+# process_monitor.sh need PID to feed it to process_exporter
+RETRY=5
+for ((i=1; i<=${RETRY}; i++))
+do
+    if [ -f /data/srv/state/crabserver/crabserver.pid ]; then
+        nohup process_monitor.sh /data/srv/state/crabserver/crabserver.pid crabserver ":18270" 15 2>&1 1>& crabserver_monitor.log < /dev/null &
+    elif [ -f /data/srv/state/crabserver/pid ]; then
+        nohup process_monitor.sh /data/srv/state/crabserver/pid crabserver ":18270" 15 2>&1 1>& crabserver_monitor.log < /dev/null &
+    else
+        if [ ${i} -eq ${RETRY} ]; then
+            echo "Cannot find crabserver's PID file"
+        else
+            sleep 1
+        fi
+    fi
+done
 
 # run filebeat
 if [ -f /etc/secrets/filebeat.yaml ] && [ -f /usr/bin/filebeat ]; then

--- a/docker/crabserver/run.sh
+++ b/docker/crabserver/run.sh
@@ -68,6 +68,10 @@ sleep 5
 export CRYPTOGRAPHY_ALLOW_OPENSSL_102=true
 /data/srv/current/config/$srv/manage start 'I did read documentation'
 
+# Delay execution of /data/monitor.sh to let "crabserver" process produce PID file.
+# process_exporter need PID to monitor process
+sleep 5
+
 # run monitoring script
 if [ -f /data/monitor.sh ]; then
     /data/monitor.sh

--- a/docker/crabserver/run.sh
+++ b/docker/crabserver/run.sh
@@ -68,10 +68,6 @@ sleep 5
 export CRYPTOGRAPHY_ALLOW_OPENSSL_102=true
 /data/srv/current/config/$srv/manage start 'I did read documentation'
 
-# Delay execution of /data/monitor.sh to let "crabserver" process produce PID file.
-# process_exporter need PID to monitor process
-sleep 5
-
 # run monitoring script
 if [ -f /data/monitor.sh ]; then
     /data/monitor.sh


### PR DESCRIPTION
When we deploy or restart crabserver, sometime `process_exporter` is not running.
After investigate, it is race condition that PID file produced by crabserver's process is not there before `monitor.sh` scripts start reading.
- [/data/monitor.sh](https://github.com/dmwm/CMSKubernetes/blob/7258eb347091fe0f2e15de632b9efe7d50fd36c3/docker/crabserver/monitor.sh#L4) at line 4, check if PID file exists before start process_exporter
- The entrypoint script [/data/run.sh](https://github.com/dmwm/CMSKubernetes/blob/7258eb347091fe0f2e15de632b9efe7d50fd36c3/docker/crabserver/run.sh#L69-L73) that execute [/data/monitor.sh](https://github.com/dmwm/CMSKubernetes/blob/7258eb347091fe0f2e15de632b9efe7d50fd36c3/docker/crabserver/monitor.sh#L4) immediately after start crabserver.

~~Delay it for 5 seconds will fix this in most case.~~
Retry it for 5 times inside `monitor.sh` scripts before give up and echo error.
