### PR TITLE
Fix crab logstash grok parser for crabhttpcall

### DIFF
--- a/kubernetes/cmsweb/monitoring/crab/logstash.conf
+++ b/kubernetes/cmsweb/monitoring/crab/logstash.conf
@@ -170,7 +170,7 @@ filter {
         }
       }
       grok {
-        match => { "message" => '\[%{NOTSPACE:timestamp_temp}\] %{DATA:backend} %{IPORHOST:clientip} "%{WORD:method} %{NOTSPACE:request} %{DATA:httpversion}" %{NUMBER:code:int}[^\[]* \[data: %{NUMBER:bytes_sent:int} in %{NUMBER:bytes_received:int} out %{NUMBER:time_spent_ms:int} us \] \[auth: %{DATA} "%{DATA:dn}".*\] \[ref: "%{DATA}.*" "%{DATA:client}" \]' }
+        match => { "message" => '\[%{NOTSPACE:timestamp_temp}\] %{DATA:backend} %{IPORHOST:clientip} "%{WORD:method} %{NOTSPACE:request} %{DATA:httpversion}" %{NUMBER:code:int} %{DATA} \[data: (-|%{NUMBER:bytes_sent:int}) in (-|%{NUMBER:bytes_received:int}) out (-|%{NUMBER:time_spent_ms:int}) us \] \[auth: %{DATA} "%{DATA:dn}".*\] \[ref: "%{DATA}.*" "%{DATA:client}" \]' }
       }
       grok {
         match => { "request" => '/%{WORD:system}%{UNIXPATH:uri_path}%{URIPARAM:uri_params}?' }


### PR DESCRIPTION
Fixes `-` value in `bytes_received` field which expected integer value in current crab logstash conf. Now, they'll be ignored and `bytes_received` will be null if `-` exists instead of a numeric value.

Example log that contains `-`: `503 Service Unavailable [data: 1437 in - out 8001856 us ]`
Previous grok expected: `503 Service Unavailable [data: 1437 in INTEGER out 8001856 us ]`

Tested and working fine @novicecpp 
@muhammadimranfarooqi could you please deploy this crab logstash conf after PR merged.