### PR TITLE
docker crabserver - fix a couple of remotes of WMCore

### DIFF
--- a/docker/crabserver/addGH.sh
+++ b/docker/crabserver/addGH.sh
@@ -33,8 +33,8 @@ cd ..
 cd WMCore
 git checkout $WMCoreGHTag
 git remote add stefano https://github.com/belforte/WMCore.git
-git remote add dario https://github.com/mapellidario/CRABServer.git
-git remote add wa https://github.com/novicecpp/CRABServer.git
+git remote add dario https://github.com/mapellidario/WMCore.git
+git remote add wa https://github.com/novicecpp/WMCore.git
 
 # add dummy global names to git for git stash to work
 git config --global user.email dummy@nowhere


### PR DESCRIPTION
While investigating the current incidents, i noticed that a couple of remotes for WMCore repo were still pointing to CRABServer.
