### PR TITLE
add Type in s3 log

### DIFF
--- a/kubernetes/cmsweb/services/crabserver.yaml
+++ b/kubernetes/cmsweb/services/crabserver.yaml
@@ -12,14 +12,32 @@ data:
     - type: log
       enabled: true
       paths:
-        - /data/srv/logs/crabserver/*${MY_POD_NAME}*.log
+        - /data/srv/logs/crabserver/crabserver-*${MY_POD_NAME}*.log
       ignore_older: 1h
       scan_frequency: 10s
       backoff: 5s
       max_backoff: 10s
+      processors:
+        - add_fields:
+            target: logtype
+            fields:
+              name: cherrypylog
+    - type: log
+      enabled: true
+      paths:
+        - /data/srv/logs/crabserver/CRAB-*${MY_POD_NAME}*.log
+      ignore_older: 1h
+      scan_frequency: 10s
+      backoff: 5s
+      max_backoff: 10s
+      processors:
+        - add_fields:
+            target: logtype
+            fields:
+              name: crablog
     output.console:
       codec.format:
-        string: '%{[message]} - Podname=${MY_POD_NAME}'
+        string: '%{[message]} - Podname=${MY_POD_NAME} Type=%{[logtype][name]}'
         pretty: false
     queue.mem:
       events: 65536


### PR DESCRIPTION
Add Type={cherrypylog,crablog} to s3 log lines, make it easier to grep specific log file in shared log machine.

We have 2 logs produced by CRABServer pod, 
- `crabserver-*${MY_POD_NAME}*.log` e.g. `crabserver-20220514-crabserver-emptydir-5d959bcc4f-2kbs2.log`. All logs from cherrypy's logger will output to this file.
- `CRAB-*${MY_POD_NAME}*.log` e.g. `CRAB-crabserver-emptydir-5d959bcc4f-2kbs2.log`. It is the log from crabserver's logger.

The current config delivers both log files to s3. But it is hard to read when we want to follow one specific log file to understand what is going on before the error line appears.

I have tested it on "testbed", and it works fine (logs are copied to the log machine).