### PR TITLE
Update monitoring cc7 base images for 2022-06-01 release

### DIFF
--- a/docker/cmsmon-alerts/Dockerfile
+++ b/docker/cmsmon-alerts/Dockerfile
@@ -20,7 +20,7 @@ RUN go build -ldflags="-s -w -extldflags -static" ggus_alerting.go
 RUN go build -ldflags="-s -w -extldflags -static" es_exporter.go
 RUN go build -ldflags="-s -w -extldflags -static" hdfs_exporter.go
 
-FROM alpine:3.15.4
+FROM alpine:3.16
 RUN mkdir /data
 COPY --from=go-builder /data/CMSMonitoring/src/go/MONIT/monit /data
 COPY --from=go-builder /data/CMSMonitoring/src/go/MONIT/ssb_alerting /data

--- a/docker/cmsmon-hadoop-base/Dockerfile
+++ b/docker/cmsmon-hadoop-base/Dockerfile
@@ -1,12 +1,9 @@
-ARG CC7_BASE_VERSION
-
-FROM cern/cc7-base:$CC7_BASE_VERSION
+FROM registry.cern.ch/cmsmonitoring/cmsmon-py:3.9.13
 MAINTAINER Ceyhun Uzunoglu ceyhunuzngl@gmail.com
 
 ARG HADOOP_VERSION
 ARG SPARK_VERSION
 ARG SPARK_MAJOR_VERSION
-#RUN echo hadoop:$HADOOP_VERSION spark:$SPARK_VERSION $SPARK_MAJOR_VERSION
 
 ENV WDIR=/data
 WORKDIR $WDIR
@@ -21,43 +18,49 @@ ENV PATH $PATH:/usr/hdp/hadoop/bin:/usr/hdp/sqoop/bin
 ENV PATH $PATH:/data
 
 # add necessary RPMs for cmsweb deployment
-RUN yum -y update && yum install -y cern-get-certificate fetch-crl \
-    git-core zip unzip which file bzip2 e2fsprogs e2fsprogs-libs compat-libstdc++-33 \
-    CERN-CA-certs ca-certificates dummy-ca-certs ca-policy-lcg ca-policy-egi-core \
-    ca_EG-GRID ca_CERN-GridCA ca_CERN-LCG-IOTA-CA ca_CERN-Root-2 \
-    wlcg-voms-cms krb5-workstation krb5-libs pam_krb5 myproxy voms-clients-cpp voms-clients-java \
-    sudo openssl openssl-devel openssl-libs openssh openssh-clients python-backports-ssl_match_hostname \
-    cmake voms voms-devel globus-gsi-credential-devel globus-gsi-cert-utils-devel \
-    globus-common-devel globus-gsi-sysconfig globus-gsi-sysconfig-devel globus-gsi-callback-devel \
-    globus-gsi-openssl-error globus-gsi-proxy-ssl globus-openssl-module \
-    shibboleth log4shib xmltooling-schemas opensaml-schemas \
-    perl-Thread-Queue zsh tk freetype perl-ExtUtils-Embed fontconfig \
-    perl-Test-Harness perl-Data-Dumper perl-Digest-MD5 perl-Switch perl-Env \
-    libX11-devel libX11 libXmu libSM libICE libXcursor libXext libXrandr libXft \
-    mesa-libGLU mesa-libGL libXi libXinerama libXft-devel libXrender libXpm \
-    libXpm-devel libXext-devel mesa-libGLU-devel \
-    libaio libaio-devel net-tools lsof bind-utils initscripts patch \
-    voms-devel globus-gsi-credential-devel globus-gsi-cert-utils-devel \
-    globus-common-devel globus-gsi-sysconfig-devel globus-gsi-callback-devel \
-    oracle-instantclient-tnsnames.ora HEP_OSlibs python-pip  \
-    hadoop-bin-${HADOOP_VERSION} \
-    spark-bin-${SPARK_VERSION} \
-    sqoop-bin-1.4 \
-    hbase-bin-2.3 \
-    cern-hadoop-xrootd-connector cern-hadoop-config &&  \
+RUN yum -y update && \
+    yum install -y  \
+        cern-get-certificate fetch-crl \
+        git-core zip unzip which file bzip2 e2fsprogs e2fsprogs-libs compat-libstdc++-33 \
+        CERN-CA-certs ca-certificates dummy-ca-certs ca-policy-lcg ca-policy-egi-core \
+        ca_EG-GRID ca_CERN-GridCA ca_CERN-LCG-IOTA-CA ca_CERN-Root-2 \
+        wlcg-voms-cms krb5-workstation krb5-libs pam_krb5 myproxy voms-clients-cpp voms-clients-java \
+        sudo openssl openssl-devel openssl-libs openssh openssh-clients python-backports-ssl_match_hostname \
+        cmake voms voms-devel globus-gsi-credential-devel globus-gsi-cert-utils-devel \
+        globus-common-devel globus-gsi-sysconfig globus-gsi-sysconfig-devel globus-gsi-callback-devel \
+        globus-gsi-openssl-error globus-gsi-proxy-ssl globus-openssl-module \
+        shibboleth log4shib xmltooling-schemas opensaml-schemas \
+        perl-Thread-Queue zsh tk freetype perl-ExtUtils-Embed fontconfig \
+        perl-Test-Harness perl-Data-Dumper perl-Digest-MD5 perl-Switch perl-Env \
+        libX11-devel libX11 libXmu libSM libICE libXcursor libXext libXrandr libXft \
+        mesa-libGLU mesa-libGL libXi libXinerama libXft-devel libXrender libXpm \
+        libXpm-devel libXext-devel mesa-libGLU-devel \
+        libaio libaio-devel net-tools lsof bind-utils initscripts patch \
+        voms-devel globus-gsi-credential-devel globus-gsi-cert-utils-devel \
+        globus-common-devel globus-gsi-sysconfig-devel globus-gsi-callback-devel \
+        oracle-instantclient-tnsnames.ora HEP_OSlibs python-pip libffi-devel \
+        hadoop-bin-${HADOOP_VERSION} \
+        spark-bin-${SPARK_VERSION} \
+        sqoop-bin-1.4 \
+        cern-hadoop-xrootd-connector  \
+        cern-hadoop-config && \
+    yum clean all && rm -rf /var/cache/yum && \
     hadoop-set-default-conf.sh analytix && \
     source hadoop-setconf.sh analytix ${HADOOP_VERSION} ${SPARK_MAJOR_VERSION} && \
-    yum clean all && rm -rf /var/cache/yum &&  \
     touch /etc/hadoop/conf/topology.table.file && ln -s /bin/bash /usr/bin/bashs && \
     echo "32 */6 * * * root ! /usr/sbin/fetch-crl -q -r 360" > /etc/cron.d/fetch-crl-docker
-# add fetch-crl to fetch all sertificates
+    # add fetch-crl to fetch all sertificates
 
-# Copy entrypoint.sh according to spark version
 RUN if [ "$SPARK_MAJOR_VERSION" = "spark3" ] ; then \
-        cp /usr/hdp/spark3/kubernetes/dockerfiles/spark/entrypoint.sh /usr/bin/entrypoint.sh ; \
+# set default python as python3 if spark3
+        rm -f /usr/bin/python && ln -s /usr/bin/python3 /usr/bin/python && \
+        rm -f /usr/bin/pip && ln -s /usr/bin/pip3 /usr/bin/pip && \
+# copy spark3 entrypoint.sh
+        cp /usr/hdp/spark3/kubernetes/dockerfiles/spark/entrypoint.sh /usr/bin/entrypoint.sh; \
     else  \
-        cp /usr/hdp/spark/kubernetes/dockerfiles/spark/entrypoint.sh /usr/bin/entrypoint.sh ;  \
-    fi
+# copy spark2 entrypoint.sh
+        cp /usr/hdp/spark/kubernetes/dockerfiles/spark/entrypoint.sh /usr/bin/entrypoint.sh; \
+  fi
 
 # start the setup
 WORKDIR ${WDIR}

--- a/docker/cmsmon-hadoop-base/README.md
+++ b/docker/cmsmon-hadoop-base/README.md
@@ -1,6 +1,6 @@
 ### cmsmon-hadoop-base
 
-This docker image is created as an base image for cern analytix cluster; which includes:
+This docker image is created as a base image for cern analytix cluster; which includes:
 
 - hadoop
 - spark (spark-submit, spark-shell, etc)
@@ -8,6 +8,15 @@ This docker image is created as an base image for cern analytix cluster; which i
 - sqoop
 
 Since there are different versions of Analytix cluster, this image also has spark2 and spark3 versions
+
+### Attention for `-spark3` image
+
+This docker image uses `python 3.9` as default python executable in `/usr/bin/python`. Because of this fact be careful for:
+- You cannot use `yum`, which requires python2, if you use this image as base.
+- Your spark job should use python3
+- You need to set `PYSPARK_DRIVER_PYTHON` and `PYSPARK_PYTHON` in your Spark jobs. 
+  - `PYSPARK_DRIVER_PYTHON` should be set as `/usr/bin/python` which is python3.9
+  - `PYSPARK_PYTHON` should be set according to your Spark worker python3.9 path. Recommended to set `/cvmfs` python3.9 path.
 
 #### How to build
 

--- a/docker/cmsmon-hadoop-base/build-and-push.sh
+++ b/docker/cmsmon-hadoop-base/build-and-push.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Builds and push cmsmon-hadoop-base image based on analytix cluster and spark version
+# Builds and push cmsmon-hadoop-base image based on spark version
 # Usage: build.sh <ANALYTIX_VERSION>(2|3)
 
 set -e
@@ -10,30 +10,28 @@ fi
 
 echo "!! Reminder, do not forget to clean local images with: docker system prune -f -a"
 
-CC7_BASE_VERSION=20220401-1
+CURRENT_DATE=$(date +"%Y%m%d")
 DOCKER_REGISTRY=registry.cern.ch/cmsmonitoring
 
 # Get argument, should be 2 or 3
 ANALYTIX_VERSION="$1"
-echo Image will be built: "${DOCKER_REGISTRY}/cmsmon-hadoop-base:${image_tag}"
 
 if [ "$ANALYTIX_VERSION" -eq 3 ]; then
     hadoop_v=3.2
     spark_v=3.2
     spark_major_v=spark3
-    image_tag="${CC7_BASE_VERSION}-${spark_major_v}"
+    image_tag="${spark_major_v}-${CURRENT_DATE}"
 elif [ "$ANALYTIX_VERSION" -eq 2 ]; then
     hadoop_v=2.7
     spark_v=2.4
     spark_major_v=spark2
-    image_tag="${CC7_BASE_VERSION}-${spark_major_v}"
+    image_tag="${spark_major_v}-${CURRENT_DATE}"
 fi
 
 echo Image will be built: "${DOCKER_REGISTRY}/cmsmon-hadoop-base:${image_tag}"
 
 # build
 docker build \
-    --build-arg CC7_BASE_VERSION="$CC7_BASE_VERSION" \
     --build-arg HADOOP_VERSION="$hadoop_v" \
     --build-arg SPARK_VERSION="$spark_v" \
     --build-arg SPARK_MAJOR_VERSION="$spark_major_v" \

--- a/docker/cmsmon-hadoop-base/epel.repo
+++ b/docker/cmsmon-hadoop-base/epel.repo
@@ -1,6 +1,6 @@
 [epel]
-name=Extra Packages for Enterprise Linux [20220401]
-baseurl=http://linuxsoft.cern.ch/internal/yumsnapshot/20220401/epel/7/x86_64
+name=Extra Packages for Enterprise Linux [20220601]
+baseurl=http://linuxsoft.cern.ch/internal/yumsnapshot/20220601/epel/7/x86_64
 enabled=1
 gpgcheck=1
 gpgkey=http://linuxsoft.cern.ch/epel/RPM-GPG-KEY-EPEL-7

--- a/docker/cmsmon-hadoop-base/slc7-cernonly.repo
+++ b/docker/cmsmon-hadoop-base/slc7-cernonly.repo
@@ -1,6 +1,6 @@
 [slc7-cernonly]
-name=CentOS-7 - CERN Only [20220401]
-baseurl=http://linuxsoft.cern.ch/internal/yumsnapshot/20220401/cern/centos/7/cernonly/x86_64
+name=CentOS-7 - CERN Only [20220601]
+baseurl=http://linuxsoft.cern.ch/internal/yumsnapshot/20220601/cern/centos/7/cernonly/x86_64
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-cern

--- a/docker/cmsmon-intelligence/Dockerfile
+++ b/docker/cmsmon-intelligence/Dockerfile
@@ -15,7 +15,7 @@ ARG CGO_ENABLED=0
 WORKDIR $WDIR/CMSMonitoring
 RUN git checkout tags/$CMSMON_TAG -b build && cd src/go/intelligence && make
 
-FROM alpine:3.15.4
+FROM alpine:3.16
 RUN mkdir /data
 COPY --from=go-builder /data/CMSMonitoring/src/go/intelligence/intelligence /data
 ENV PATH $PATH:/data

--- a/docker/cmsmon-py/Dockerfile
+++ b/docker/cmsmon-py/Dockerfile
@@ -1,0 +1,28 @@
+FROM cern/cc7-base:20220601-1
+MAINTAINER Ceyhun Uzunoglu ceyhunuzngl@gmail.com
+
+ENV WDIR=/data
+WORKDIR $WDIR
+
+# Should be full such that includes minor version
+ARG PY_VERSION=3.9.13
+
+RUN yum -y update && \
+    yum install -y python-pip gcc openssl-devel bzip2-devel libffi-devel zlib-devel wget make && \
+    yum clean all && rm -rf /var/cache/yum && \
+    wget https://www.python.org/ftp/python/${PY_VERSION}/Python-${PY_VERSION}.tgz && \
+    tar -xvf Python-${PY_VERSION}.tgz && \
+    cd Python-${PY_VERSION} && \
+    ./configure --enable-optimizations && \
+    make altinstall && \
+# Get python major version i.e.: 3.9 from 3.9.13
+    export PY_MAJOR=$(echo ${PY_VERSION%.*}) && \
+    rm -f /usr/bin/python3 && ln -s /usr/local/bin/python${PY_MAJOR} /usr/bin/python3 && \
+    rm -f /usr/bin/pip3 && ln -s /usr/local/bin/pip${PY_MAJOR} /usr/bin/pip3 && \
+    python3 -m pip install --upgrade pip && \
+    cd $WDIR && \
+    rm -rf Python-${PY_VERSION}.tgz Python-${PY_VERSION} && \
+    unset PY_MAJOR
+
+# start the setup
+WORKDIR ${WDIR}

--- a/docker/cmsmon-py/README.md
+++ b/docker/cmsmon-py/README.md
@@ -1,0 +1,19 @@
+### cmsmon-py
+
+- Builds python3 version according to the latest LCG release python3 version, i.e. `/cvmfs/sft.cern.ch/lcg/releases/Python/`
+- Includes both python2 (`/usr/bin/python`) and python3 (`/usr/bin/python3`)
+- You can make default python as python3 (be careful, `yum` will not work then, because it requires `/usr/bin/python` as python2):
+```shell
+rm -f /usr/bin/python && ln -s /usr/bin/python3 /usr/bin/python
+rm -f /usr/bin/pip && ln -s /usr/bin/python3 /usr/bin/pip
+```
+
+#### How to build and push
+
+```shell
+# docker image prune -a OR docker system prune -f -a
+docker_registry=registry.cern.ch/cmsmonitoring
+py_version=3.9.13
+docker build --build-arg PY_VERSION="$py_version" -t "${docker_registry}/cmsmon-py:${py_version}" .
+docker push "${docker_registry}/cmsmon-py:${py_version}"
+```

--- a/docker/cmsmon-rucio-ds/Dockerfile
+++ b/docker/cmsmon-rucio-ds/Dockerfile
@@ -1,43 +1,49 @@
-FROM registry.cern.ch/cmsmonitoring/cmsmon-hadoop-base:20220401-1-spark3
+FROM python:3.9 as builder
+MAINTAINER Ceyhun Uzunoglu ceyhunuzngl@gmail.com
+
 
 ENV WDIR=/data
 WORKDIR $WDIR
 
-ENV HADOOP_CONF_DIR=/etc/hadoop/conf
-ENV PATH="${PATH}:/usr/hdp/hadoop/bin/hadoop:/usr/hdp/spark3/bin:/usr/hdp/sqoop/bin:${WDIR}/CMSSpark/bin"
-# CMSMonitoring folder is in WDIR
-ENV PYTHONPATH "${PYTHONPATH}:${WDIR}:${WDIR}/CMSSpark/src/python"
-
-ENV PYSPARK_PYTHON=/usr/bin/python3
-ENV PYSPARK_DRIVER_PYTHON=/usr/bin/python3
-
-# Steps:
-#   - Remove hbase, not needed
-#   - Install python3
-#   - Install python libs and specifically stomp.py==7.0.0 which is latest working version with StompAMQ7
-#   - Install and create stomp.py v7.0.0 zip file to send to Spark workers,
-#         because Spark nodes have old version of it (v3 or v4)
-#   - Clone only src/python/CMSMonitoring folder of CMSMoinitoring repo using svn and zip it,
-#         zip file will be used to send specific CMSMonitoring folder to Spark workers with '--py-files'.
-#   - Clone CMSSpark repo which includes Spark job and bash script to run both Spark job and Sqoop imports
-RUN yum remove -y hbase-bin-2.3 && \
-    yum update -y && \
-    yum install -y svn python3 && \
-    python3 -m pip install --upgrade pip && \
-    pip3 install --no-cache-dir pandas click pyspark stomp.py==7.0.0 && \
-    pip3 install --no-cache-dir -t stomp-v700 https://github.com/jasonrbriggs/stomp.py/archive/refs/tags/v7.0.0.zip && \
+# Create zip files of stomp.py and CMSMonitoring modules to submit Spark workers
+RUN apt-get update -y && \
+    apt-get install -y zip subversion && \
+#   Install python stomp.py==7.0.0 module which is the latest working version with StompAMQ7
+    pip install --no-cache-dir -t stomp-v700 https://github.com/jasonrbriggs/stomp.py/archive/refs/tags/v7.0.0.zip && \
+#   Create zip file to send to Spark workers, because workers have old version of it (v3 or v4)
     cd stomp-v700 && \
     zip -r ../stomp-v700.zip . && \
     cd .. && \
     rm -rf stomp-v700 && \
+#   Clone only src/python/CMSMonitoring folder of CMSMoinitoring repo using svn and zip it,
+#   zip file will be used to send specific CMSMonitoring folder to Spark workers with '--py-files'.
     svn export https://github.com/dmwm/CMSMonitoring.git/branches/master/src/python/CMSMonitoring && \
     zip -r CMSMonitoring.zip CMSMonitoring/* && \
-    git clone https://github.com/dmwm/CMSSpark.git && \
-    yum clean all &&  rm -rf /var/cache/yum && \
-    rm -f /usr/bin/python && ln -s /usr/bin/python3.6 /usr/bin/python && \
-    hadoop-set-default-conf.sh analytix && source hadoop-setconf.sh analytix 3.2 spark3
+    git clone https://github.com/dmwm/CMSSpark.git
+
+FROM registry.cern.ch/cmsmonitoring/cmsmon-hadoop-base:spark3-20220606
+MAINTAINER Ceyhun Uzunoglu ceyhunuzngl@gmail.com
+
+ENV WDIR=/data
+ENV HADOOP_CONF_DIR=/etc/hadoop/conf
+ENV PATH="${PATH}:/usr/hdp/hadoop/bin/hadoop:/usr/hdp/spark3/bin:/usr/hdp/sqoop/bin:${WDIR}/CMSSpark/bin"
+
+# CMSMonitoring folder is in WDIR
+ENV PYTHONPATH "${PYTHONPATH}:${WDIR}:${WDIR}/CMSSpark/src/python"
+
+# LCG101 uses this cvmfs python
+ENV PYSPARK_PYTHON=/cvmfs/sft.cern.ch/lcg/releases/Python/3.9.6-b0f98/x86_64-centos7-gcc8-opt/bin/python3
+
+# Local
+ENV PYSPARK_DRIVER_PYTHON=/usr/bin/python
 
 WORKDIR $WDIR
+
+COPY --from=builder /data $WDIR
+
+RUN mkdir -p $WDIR/logs && \
+    pip install --no-cache-dir pandas click pyspark stomp.py==7.0.0 && \
+    hadoop-set-default-conf.sh analytix && source hadoop-setconf.sh analytix 3.2 spark3
 
 # Run crond
 CMD ["crond", "-n", "-s", "&"]

--- a/docker/condor-cpu-eff/Dockerfile
+++ b/docker/condor-cpu-eff/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsmonitoring/cmsmon-hadoop-base:20220401-1-spark3
+FROM registry.cern.ch/cmsmonitoring/cmsmon-hadoop-base:spark3-20220606
 MAINTAINER Ceyhun Uzunoglu ceyhunuzngl@gmail.com
 
 # set working directory
@@ -10,12 +10,14 @@ ENV LC_ALL=en_US.utf-8 LANG=en_US.utf-8
 ENV HADOOP_CONF_DIR=/etc/hadoop/conf
 ENV PATH="${PATH}:${WDIR}:/usr/hdp/hadoop/bin/hadoop:/usr/hdp/spark3/bin:/usr/hdp/sqoop/bin:${WDIR}/CMSSpark/bin"
 ENV PYTHONPATH "${PYTHONPATH}:${WDIR}/CMSSpark/src/python"
-ENV PYSPARK_PYTHON=/usr/bin/python3 PYSPARK_DRIVER_PYTHON=/usr/bin/python3
 
-RUN yum remove -y hbase-bin-2.3 && \
-    yum update -y && yum install -y python3 && yum clean all && rm -rf /var/cache/yum && \
-    python3 -m pip install --upgrade pip && pip3 install --no-cache-dir pandas pyspark click && \
-    rm -f /usr/bin/python && ln -s /usr/bin/python3.6 /usr/bin/python && \
+# LCG101 uses this cvmfs python
+ENV PYSPARK_PYTHON=/cvmfs/sft.cern.ch/lcg/releases/Python/3.9.6-b0f98/x86_64-centos7-gcc8-opt/bin/python3
+
+# Local
+ENV PYSPARK_DRIVER_PYTHON=/usr/bin/python
+
+RUN pip install --no-cache-dir pandas pyspark click && \
     git clone https://github.com/dmwm/CMSSpark.git && \
     hadoop-set-default-conf.sh analytix && source hadoop-setconf.sh analytix 3.2 spark3
 

--- a/docker/http-exporter/Dockerfile
+++ b/docker/http-exporter/Dockerfile
@@ -12,6 +12,6 @@ RUN mkdir /build
 ARG CGO_ENABLED=0
 RUN go mod tidy && go build -o /build/http_exporter -ldflags="-s -w -extldflags -static" http_exporter.go
 
-FROM alpine:3.15.4
+FROM alpine:3.16
 RUN mkdir /data
 COPY --from=go-builder /build/http_exporter /data/

--- a/docker/karma/Dockerfile
+++ b/docker/karma/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.0.0-alpine as nodejs-builder
+FROM node:18.2.0-alpine as nodejs-builder
 RUN apk add make git
 RUN git clone https://github.com/prymitive/karma.git
 RUN mkdir -p /src/ui
@@ -8,7 +8,7 @@ RUN apk add make git
 RUN cp -R karma/ui /src
 RUN make -C /src/ui build
 
-FROM golang:1.18.1-alpine as go-builder
+FROM golang:1.18.3-alpine as go-builder
 RUN apk add make git
 RUN git clone https://github.com/prymitive/karma.git
 RUN mkdir -p /src

--- a/docker/kerberos/Dockerfile
+++ b/docker/kerberos/Dockerfile
@@ -1,4 +1,4 @@
-FROM cern/cc7-base:20220401-1.x86_64
+FROM cern/cc7-base:20220601-1.x86_64
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 RUN yum install -y sudo krb5-workstation krb5-libs pam_krb5 && yum clean all && rm -rf /var/cache/yum
 # Install latest kubectl

--- a/docker/loki/Dockerfile
+++ b/docker/loki/Dockerfile
@@ -5,6 +5,6 @@ RUN apt-get update && apt-get install -y unzip
 RUN curl -ksLO https://github.com/grafana/loki/releases/download/v2.5.0/loki-linux-amd64.zip && \
     unzip loki-linux-amd64.zip && mv loki-linux-amd64 loki
 
-FROM alpine:3.15
+FROM alpine:3.16
 RUN mkdir -p /data
 COPY --from=go-builder /go/loki /data/

--- a/docker/promxy/Dockerfile
+++ b/docker/promxy/Dockerfile
@@ -7,6 +7,6 @@ WORKDIR $WDIR
 ENV VER=v0.0.75
 RUN curl -ksLO https://github.com/jacksontj/promxy/releases/download/${VER}/promxy-${VER}-linux-amd64 && mv promxy-${VER}-linux-amd64 promxy && chmod +x /data/promxy
 
-FROM alpine:3.15.4
+FROM alpine:3.16
 RUN mkdir -p /data
 COPY --from=go-builder /data/promxy /data/

--- a/docker/sqoop/Dockerfile
+++ b/docker/sqoop/Dockerfile
@@ -23,24 +23,26 @@ RUN go build monit.go && go build hdfs_exporter.go && cp monit hdfs_exporter $WD
 WORKDIR $WDIR
 
 # get amtool
-RUN curl -ksLO https://github.com/prometheus/alertmanager/releases/download/v0.20.0/alertmanager-0.20.0.linux-amd64.tar.gz
-RUN tar xfz alertmanager-0.20.0.linux-amd64.tar.gz && mv alertmanager-0.20.0.linux-amd64/amtool $WDIR/ && rm -rf alertmanager-0.20.0.linux-amd64*
+RUN curl -ksLO https://github.com/prometheus/alertmanager/releases/download/v0.24.0/alertmanager-0.24.0.linux-amd64.tar.gz
+RUN tar xfz alertmanager-0.24.0.linux-amd64.tar.gz && mv alertmanager-0.24.0.linux-amd64/amtool $WDIR/ && rm -rf alertmanager-0.24.0.linux-amd64*
 
 
-FROM registry.cern.ch/cmsmonitoring/cmsmon-hadoop-base:20220401-1-spark2
+FROM registry.cern.ch/cmsmonitoring/cmsmon-hadoop-base:spark2-20220606
 # Do not use spark3, it requires additional settings
 MAINTAINER Ceyhun Uzunoglu ceyhunuzngl@gmail.com
 
 ENV WDIR=/data
 WORKDIR $WDIR
 
-RUN yum remove -y hbase-bin-2.3 && mkdir -p $WDIR/sqoop/log
 COPY --from=go-builder /data/amtool /data
 COPY --from=go-builder /data/hdfs_exporter /data
 COPY --from=go-builder /data/monit /data
 COPY --from=go-builder /data/CMSMonitoring/sqoop /data/sqoop
 
 WORKDIR $WDIR/sqoop
-RUN crontab cronjobs.txt && ln -s /etc/cmsdb/cmsr_cstring && ln -s /etc/cmsdb/lcgr_cstring
+RUN mkdir -p $WDIR/sqoop/log && \
+# Create symbolic link of below files in $WDIR/sqoop directory
+    ln -s /etc/cmsdb/cmsr_cstring && ln -s /etc/cmsdb/lcgr_cstring && \
+    crontab cronjobs.txt
 
 WORKDIR $WDIR

--- a/kubernetes/monitoring/crons/cron-kerberos.yaml
+++ b/kubernetes/monitoring/crons/cron-kerberos.yaml
@@ -13,7 +13,7 @@ spec:
           serviceAccountName: kerberos-account
           containers:
           - name: kerberos
-            image: registry.cern.ch/cmsmonitoring/kerberos:20220421
+            image: registry.cern.ch/cmsmonitoring/kerberos:20220605
             args:
             - /bin/sh
             - -c

--- a/kubernetes/monitoring/services/cmsmon-rucio-ds.yaml
+++ b/kubernetes/monitoring/services/cmsmon-rucio-ds.yaml
@@ -63,7 +63,7 @@ spec:
       hostname: cmsmon-rucio-ds
       containers:
         - name: cmsmon-rucio-ds
-          image: registry.cern.ch/cmsmonitoring/cmsmon-rucio-ds:20220418
+          image: registry.cern.ch/cmsmonitoring/cmsmon-rucio-ds:20220606
           imagePullPolicy: Always
           env:
             - name: MY_NODE_NAME

--- a/kubernetes/monitoring/services/condor-cpu-eff.yaml
+++ b/kubernetes/monitoring/services/condor-cpu-eff.yaml
@@ -58,7 +58,7 @@ spec:
       hostname: condor-cpu-eff
       containers:
         - name: condor-cpu-eff
-          image: registry.cern.ch/cmsmonitoring/condor_cpu_eff:20220419
+          image: registry.cern.ch/cmsmonitoring/condor_cpu_eff:20220606
           imagePullPolicy: Always
           env:
             - name: MY_NODE_NAME

--- a/kubernetes/monitoring/services/hdfs-exporter-eos.yaml
+++ b/kubernetes/monitoring/services/hdfs-exporter-eos.yaml
@@ -45,7 +45,7 @@ spec:
       spec:
         containers:
         - name: hdfs-exporter-eos
-          image: registry.cern.ch/cmsmonitoring/sqoop:sqoop-0.0.7
+          image: registry.cern.ch/cmsmonitoring/sqoop:sqoop-0.0.8
           command:
           - /bin/sh
           - /data/setup-and-run/setup-and-run.sh

--- a/kubernetes/monitoring/services/http-exp-wmstatssrv.yaml
+++ b/kubernetes/monitoring/services/http-exp-wmstatssrv.yaml
@@ -48,7 +48,7 @@ spec:
           - "600"
           - -verbose
           name: http-exp-wmstatssrv
-          image: registry.cern.ch/cmsmonitoring/http-exporter:20220420
+          image: registry.cern.ch/cmsmonitoring/http-exporter:20220605
           ports:
           - containerPort: 18009
           volumeMounts:

--- a/kubernetes/monitoring/services/http-exporter-arucio.yaml
+++ b/kubernetes/monitoring/services/http-exporter-arucio.yaml
@@ -46,7 +46,7 @@ spec:
           - "600"
           - -verbose
           name: http-exporter-arucio
-          image: registry.cern.ch/cmsmonitoring/http-exporter:20220420
+          image: registry.cern.ch/cmsmonitoring/http-exporter:20220605
           ports:
           - containerPort: 18012
           volumeMounts:

--- a/kubernetes/monitoring/services/http-exporter-cric.yaml
+++ b/kubernetes/monitoring/services/http-exporter-cric.yaml
@@ -42,7 +42,7 @@ spec:
           - "monitoring"
           - -verbose
           name: http-exporter-cric
-          image: registry.cern.ch/cmsmonitoring/http-exporter:20220420
+          image: registry.cern.ch/cmsmonitoring/http-exporter:20220605
           ports:
           - containerPort: 18004
           env:

--- a/kubernetes/monitoring/services/http-exporter-dmytro.yaml
+++ b/kubernetes/monitoring/services/http-exporter-dmytro.yaml
@@ -42,6 +42,6 @@ spec:
           - "monitoring"
           - -verbose
           name: http-exporter-dmytro
-          image: registry.cern.ch/cmsmonitoring/http-exporter:20220420
+          image: registry.cern.ch/cmsmonitoring/http-exporter:20220605
           ports:
           - containerPort: 18010

--- a/kubernetes/monitoring/services/http-exporter-mcm.yaml
+++ b/kubernetes/monitoring/services/http-exporter-mcm.yaml
@@ -44,7 +44,7 @@ spec:
           - "monitoring"
           - -verbose
           name: http-exporter-mcm
-          image: registry.cern.ch/cmsmonitoring/http-exporter:20220420
+          image: registry.cern.ch/cmsmonitoring/http-exporter:20220605
           ports:
           - containerPort: 18006
           volumeMounts:

--- a/kubernetes/monitoring/services/http-exporter-mss.yaml
+++ b/kubernetes/monitoring/services/http-exporter-mss.yaml
@@ -42,6 +42,6 @@ spec:
           - "monitoring"
           - -verbose
           name: http-exporter-mss
-          image: registry.cern.ch/cmsmonitoring/http-exporter:20220420
+          image: registry.cern.ch/cmsmonitoring/http-exporter:20220605
           ports:
           - containerPort: 18003

--- a/kubernetes/monitoring/services/http-exporter-rucio.yaml
+++ b/kubernetes/monitoring/services/http-exporter-rucio.yaml
@@ -44,6 +44,6 @@ spec:
           - "600"
           - -verbose
           name: http-exporter-rucio
-          image: registry.cern.ch/cmsmonitoring/http-exporter:20220420
+          image: registry.cern.ch/cmsmonitoring/http-exporter:20220605
           ports:
           - containerPort: 18011

--- a/kubernetes/monitoring/services/http-exporter-unified.yaml
+++ b/kubernetes/monitoring/services/http-exporter-unified.yaml
@@ -42,6 +42,6 @@ spec:
           - "monitoring"
           - -verbose
           name: http-exporter-unified
-          image: registry.cern.ch/cmsmonitoring/http-exporter:20220420
+          image: registry.cern.ch/cmsmonitoring/http-exporter:20220605
           ports:
           - containerPort: 18005

--- a/kubernetes/monitoring/services/http-exporter-wmstats.yaml
+++ b/kubernetes/monitoring/services/http-exporter-wmstats.yaml
@@ -46,7 +46,7 @@ spec:
           - "600"
           - -verbose
           name: http-exporter-wmstats
-          image: registry.cern.ch/cmsmonitoring/http-exporter:20220420
+          image: registry.cern.ch/cmsmonitoring/http-exporter:20220605
           ports:
           - containerPort: 18008
           volumeMounts:

--- a/kubernetes/monitoring/services/http-exporter.yaml
+++ b/kubernetes/monitoring/services/http-exporter.yaml
@@ -42,6 +42,6 @@ spec:
           - "monitoring"
           - -verbose
           name: http-sub
-          image: registry.cern.ch/cmsmonitoring/http-exporter:20220420
+          image: registry.cern.ch/cmsmonitoring/http-exporter:20220605
           ports:
           - containerPort: 18000

--- a/kubernetes/monitoring/services/karma.yaml
+++ b/kubernetes/monitoring/services/karma.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
       - name: karma
-        image: registry.cern.ch/cmsmonitoring/karma:20220421
+        image: registry.cern.ch/cmsmonitoring/karma:20220605
 #         imagePullPolicy: Always
         env:
         - name: ALERTMANAGER_URI

--- a/kubernetes/monitoring/services/sqoop.yaml
+++ b/kubernetes/monitoring/services/sqoop.yaml
@@ -21,7 +21,7 @@ spec:
           - /data/sqoop/log
           - "7"
           - "7200"
-          image: registry.cern.ch/cmsmonitoring/sqoop:sqoop-0.0.7
+          image: registry.cern.ch/cmsmonitoring/sqoop:sqoop-0.0.8
           name: sqoop
           volumeMounts:
           - name: sqoop-secrets


### PR DESCRIPTION
Service updates and dockerfile improvements

- `cmsmon-hadoop-base` image is arranged to use python3.9. `condor-cpu-eff` and `cmsmon-rucio-ds` images arranged accordingly. 
- Other monitoring dockerfiles also updated with new `cern/cc7-base:20220601-1` base image.

fyi @leggerf @brij01 