### PR TITLE
Create monit mongo for rucio dataset monitoring

### DIFF
--- a/docker/monit-mongo/Dockerfile
+++ b/docker/monit-mongo/Dockerfile
@@ -1,0 +1,7 @@
+ARG MONGODBVER=5.0.9
+FROM mongo:$MONGODBVER
+MAINTAINER Ceyhun Uzunoglu ceyhunuzngl@gmail.com
+
+# Default paths
+ADD mongo.conf /config/mongo.conf
+ADD ensure-users.js /docker-entrypoint-initdb.d/ensure-users.js

--- a/docker/monit-mongo/README.md
+++ b/docker/monit-mongo/README.md
@@ -1,0 +1,13 @@
+## monit-mongo
+
+Refs for the JS and conf files: https://phoenixnap.com/kb/kubernetes-mongodb
+#### How to build and push
+
+```shell
+# docker image prune -a OR docker system prune -f -a
+
+mongodbver=5.0.9
+docker_registry=registry.cern.ch/cmsmonitoring
+docker build --build-arg MONGODBVER=${mongodbver} -t "${docker_registry}/monit-mongo:${mongodbver}" .
+docker push "${docker_registry}/monit-mongo:${mongodbver}"
+```

--- a/docker/monit-mongo/ensure-users.js
+++ b/docker/monit-mongo/ensure-users.js
@@ -1,0 +1,50 @@
+const targetDbStr = 'test';
+const rootUser = process.env["$MONGO_ROOT_USERNAME"];
+const rootPass = process.env["MONGO_ROOT_PASSWORD"];
+const usersStr = process.env["MONGO_USERS_LIST"];
+
+const adminDb = db.getSiblingDB('admin');
+adminDb.auth(rootUser, rootPass);
+print('Successfully authenticated admin user');
+
+const targetDb = db.getSiblingDB(targetDbStr);
+
+const customRoles = adminDb
+  .getRoles({rolesInfo: 1, showBuiltinRoles: false})
+  .map(role => role.role)
+  .filter(Boolean);
+
+usersStr
+  .trim()
+  .split(';')
+  .map(s => s.split(':'))
+  .forEach(user => {
+    const username = user[0];
+    const rolesStr = user[1];
+    const password = user[2];
+
+    if (!rolesStr || !password) {
+      return;
+    }
+
+    const roles = rolesStr.split(',');
+    const userDoc = {
+      user: username,
+      pwd: password,
+    };
+
+    userDoc.roles = roles.map(role => {
+      if (!~customRoles.indexOf(role)) {
+        return role;
+      }
+      return {role: role, db: 'admin'};
+    });
+
+    try {
+      targetDb.createUser(userDoc);
+    } catch (err) {
+      if (!~err.message.toLowerCase().indexOf('duplicate')) {
+        throw err;
+      }
+    }
+  });

--- a/docker/monit-mongo/mongo.conf
+++ b/docker/monit-mongo/mongo.conf
@@ -1,0 +1,2 @@
+storage:
+  dbPath: /data/db

--- a/kubernetes/monitoring/services/mongo/README.md
+++ b/kubernetes/monitoring/services/mongo/README.md
@@ -1,0 +1,47 @@
+## Mongo standalone deployment with 1 replica for **test**
+
+Deployment can be done with kustomize:
+```
+# to default ns
+kubectl apply -k .
+
+# to different namespace, for example `mongo` namespace
+kubectl create ns mongo
+kubectl -n mongo apply -k .
+```
+
+References:
+- https://phoenixnap.com/kb/kubernetes-mongodb
+
+### Connect to Mongo Compass
+```shell
+# [DEGRADED]
+mongodb://admin:password@cuzunogl-jhpbqba52z6h-node-0:32000
+```
+
+### Login to mongo client
+```shell
+apt-get update
+apt-get install nano
+
+# Service name is monit-mongo
+# Headless FQDN definition: <StatefulSet name>-<sequence number>.<Service name>.<Namespace name>.svc.cluster.local
+mongo --host mongodb-0.mongodb.monit-mongo.svc.cluster.local --port 27017 -u admin -p password
+show dbs
+use rucio
+show collections
+db.createCollection("datasets")
+ctrl-z
+
+# Create a test json
+cat test.json
+{ "_id" : 1, "dataset" : "test1", "rse" : "FNAL", "size" : 592}
+{ "_id" : 2, "dataset" : "test2", "rse" : "CERN", "size" : 800}
+
+# Use mongoimport cli
+mongoimport --host mongodb-0.mongodb.monit-mongo.svc.cluster.local --port 27017 -u admin -p password \
+    --authenticationDatabase admin --db rucio --collection datasets --file test.json --type=json
+
+# "--authenticationDatabase admin" should be used since we're using admin user to connect "rucio" db.
+
+```

--- a/kubernetes/monitoring/services/mongo/monit-mongo.yaml
+++ b/kubernetes/monitoring/services/mongo/monit-mongo.yaml
@@ -1,0 +1,117 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongodb
+  namespace: monit-mongo
+  labels:
+    app: mongodb
+spec:
+  clusterIP: None
+  selector:
+    app: mongodb
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mongodb
+  namespace: monit-mongo
+spec:
+  serviceName: mongodb
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mongodb
+  template:
+    metadata:
+      namespace: monit-mongo
+      labels:
+        app: mongodb
+        selector: mongodb
+    spec:
+      containers:
+      - name: mongodb
+        image: registry.cern.ch/cmsmonitoring/monit-mongo:5.0.9
+        args: [ "--dbpath","/data/db" ]
+        livenessProbe:
+          exec:
+            command:
+              - mongo
+              - --disableImplicitSessions
+              - --eval
+              - "db.adminCommand('ping')"
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 6
+        readinessProbe:
+          exec:
+            command:
+              - mongo
+              - --disableImplicitSessions
+              - --eval
+              - "db.adminCommand('ping')"
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 6
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 4Gi
+          requests:
+            cpu: 250m
+            memory: 200Mi
+        env:
+          - name: MONGO_ROOT_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: monit-mongo-secrets
+                key: MONGO_ROOT_USERNAME
+                optional: false
+          - name: MONGO_ROOT_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: monit-mongo-secrets
+                key: MONGO_ROOT_PASSWORD
+                optional: false
+          - name: MONGO_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: monit-mongo-secrets
+                key: MONGO_USERNAME
+                optional: false
+          - name: MONGO_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: monit-mongo-secrets
+                key: MONGO_PASSWORD
+                optional: false
+          - name: MONGO_USERS_LIST
+            valueFrom:
+              secretKeyRef:
+                name: monit-mongo-secrets
+                key: MONGO_USERS_LIST
+                optional: false
+          - name: MONGO_INITDB_ROOT_USERNAME_FILE # Required by MongoDB
+            value: /etc/secrets/MONGO_INITDB_ROOT_USERNAME_FILE
+          - name: MONGO_INITDB_ROOT_PASSWORD_FILE # Required by MongoDB
+            value: /etc/secrets/MONGO_INITDB_ROOT_PASSWORD_FILE
+        volumeMounts:
+        - name: monit-mongo-secrets
+          mountPath: /etc/secrets
+          readOnly: true
+        - name: monit-mongo-data
+          mountPath: /data/db
+      volumes:
+        - name: monit-mongo-secrets
+          secret:
+            secretName: monit-mongo-secrets
+            defaultMode: 0444
+        - name: monit-mongo-data
+          emptyDir: {}
+
+# References
+#  - https://devopscube.com/deploy-mongodb-kubernetes/
+#  - https://phoenixnap.com/kb/kubernetes-mongodb


### PR DESCRIPTION
Created for Rucio dataset monitoring test MongoDB instance. Migrated from CMSMonitoring dev branch.

 This is a working test deployment with 1 MongoDB instance which is deployed as `StatefulSet`. If we'll continue with this custom solution in production, I'll deploy it as 1 primary, 1 replica instances as `StatefulSet` with other prod requirements like persistent volumes, static dns in k8s cluster, etc. 

- Secrets are arranged and new secret is created in the gitlab repository (MR opened). @vkuznet  I will migrate it to "sops/age" soon.
- mongo-test-client is just for test
- There will be 2 additional services in future: 1st to serve jquery datatable (golang will serve static index.html file), 2nd to run `mongoimport` cron.

fyi @dynamic-entropy 