### PR TITLE
Solved monitor script execution bug for newdqmgui

### DIFF
--- a/docker/newdqmgui/run.sh
+++ b/docker/newdqmgui/run.sh
@@ -6,7 +6,7 @@ source $VO_CMS_SW_DIR/cmsset_default.sh
 
 # Run kerberos configuration
 if [ -f /home/cmsusr/monitor.sh ]; then
-    /home/cmsusr/monitor.sh
+    bash /home/cmsusr/monitor.sh
 fi
 
 # Run the service


### PR DESCRIPTION
The execution was getting "Permission: denied", with bash this problem is solved.