### PR TITLE
Call sops throught its absolute path

### DIFF
--- a/kubernetes/cmsweb/scripts/deploy-secrets.sh
+++ b/kubernetes/cmsweb/scripts/deploy-secrets.sh
@@ -79,9 +79,9 @@ fi
        for fname in $secretdir/*; do
          if [[ $fname == *.encrypted ]]; then
   	    if [[ $fname == *.json* ]]; then
-               sops --output-type json -d $fname > $secretdir/$(basename $fname .encrypted)
+               $HOME/bin/sops --output-type json -d $fname > $secretdir/$(basename $fname .encrypted)
             else
-	       sops -d $fname > $secretdir/$(basename $fname .encrypted)
+	       $HOME/bin/sops -d $fname > $secretdir/$(basename $fname .encrypted)
             fi
          fi
        done
@@ -118,9 +118,9 @@ fi
         	for fname in $secretdir/*; do
            	  if [[ $fname == *.encrypted ]]; then
                      if [[ $fname == *.json* ]]; then
-                        sops --output-type json -d $fname > $secretdir/$(basename $fname .encrypted)
+                        $HOME/bin/sops --output-type json -d $fname > $secretdir/$(basename $fname .encrypted)
                      else
-                        sops -d $fname > $secretdir/$(basename $fname .encrypted)
+                        $HOME/bin/sops -d $fname > $secretdir/$(basename $fname .encrypted)
 		     fi
 	            fname=$secretdir/$(basename $fname .encrypted)
 		    echo "Decrypted file $fname"
@@ -134,7 +134,7 @@ fi
         if [ "$ns" == "dbs" ]; then
 		for fname in $conf/dbs/*; do
                   if [[ $fname == *.encrypted ]]; then
-                    sops -d $fname > $conf/dbs/$(basename $fname .encrypted)
+                    $HOME/bin/sops -d $fname > $conf/dbs/$(basename $fname .encrypted)
                   fi
                 done
         	if [ -f $conf/dbs/DBSSecrets.py ]; then


### PR DESCRIPTION
Otherwise it could be that sops don't show up in the path and this script fails to copy the secrets file (while the configuration gets properly updated), something like:
```
Key file: /tmp/amaltaro/sops/dmwm-keys.txt
./scripts/deploy-secrets.sh: line 123: sops: command not found
Decrypted file /afs/cern.ch/user/a/amaltaro/private/cmsweb-deploy/services_config/reqmgr2-tasks/ReqMgr2Secrets.py
secret/reqmgr2-tasks-secrets configured
...
```