### PR TITLE
Roll back cvmfs py version because of libffi.so.8 error

### DIFF
--- a/docker/cmsmon-rucio-ds/Dockerfile
+++ b/docker/cmsmon-rucio-ds/Dockerfile
@@ -33,7 +33,7 @@ ENV PATH="${PATH}:/usr/hdp/hadoop/bin/hadoop:/usr/hdp/spark3/bin:/usr/hdp/sqoop/
 ENV PYTHONPATH "${PYTHONPATH}:${WDIR}:${WDIR}/CMSSpark/src/python"
 
 # LCG102 uses this cvmfs python
-ENV PYSPARK_PYTHON=/cvmfs/sft.cern.ch/lcg/releases/Python/3.9.12-9a1bc/x86_64-centos7-gcc8-opt/bin/python3
+ENV PYSPARK_PYTHON=/cvmfs/sft.cern.ch/lcg/releases/Python/3.9.6-b0f98/x86_64-centos7-gcc8-opt/bin/python3
 
 # Local
 ENV PYSPARK_DRIVER_PYTHON=/usr/bin/python

--- a/docker/cmsmon-rucio-spark2mng/Dockerfile
+++ b/docker/cmsmon-rucio-spark2mng/Dockerfile
@@ -10,7 +10,7 @@ ENV PATH="${PATH}:/usr/hdp/hadoop/bin/hadoop:/usr/hdp/spark3/bin:/usr/hdp/sqoop/
 # CMSMonitoring folder is in WDIR
 ENV PYTHONPATH "${PYTHONPATH}:${WDIR}:${WDIR}/CMSSpark/src/python"
 # LCG102 uses this cvmfs python
-ENV PYSPARK_PYTHON=/cvmfs/sft.cern.ch/lcg/releases/Python/3.9.12-9a1bc/x86_64-centos7-gcc8-opt/bin/python3
+ENV PYSPARK_PYTHON=/cvmfs/sft.cern.ch/lcg/releases/Python/3.9.6-b0f98/x86_64-centos7-gcc8-opt/bin/python3
 # Local
 ENV PYSPARK_DRIVER_PYTHON=/usr/bin/python
 


### PR DESCRIPTION
In the Spark jobs which use `df.rdd.mapPartitions(...).toLocalIterator()`, the latest cvmfs Python version produces `libffi.so.8 not found` error even though we installed the `libffi-devel` package. I assume this problem caused by upstream. Until it is fixed, it makes sense to roll-back to previous version which is working fine.
Tested with `cern-cc7:20220601-1` and `cern-cc7:20220801-1` image in cern gitlab registry and it's same problem.

Error logs:
```
Error from python worker:
     ....
     from _ctypes import Union, Structure, Array
  ImportError: libffi.so.8: cannot open shared object file: No such file or directory
  ```