### PR TITLE
Improve docker hadoop base image to be build in GH

### DIFF
--- a/docker/cmsmon-hadoop-base/Dockerfile-spark3
+++ b/docker/cmsmon-hadoop-base/Dockerfile-spark3
@@ -1,5 +1,6 @@
 # cmsmon-hadoop-base:spark3-YYYYMMDD
-FROM gitlab-registry.cern.ch/linuxsupport/cc7-base:20220801-1.x86_64
+# Build by CMSSpark GH actions
+FROM gitlab-registry.cern.ch/db/cerndb-infra-hadoop-conf:latest-hdp3
 MAINTAINER Ceyhun Uzunoglu ceyhunuzngl@gmail.com
 
 # Should be full such that includes minor version
@@ -7,44 +8,14 @@ ARG PY_VERSION=3.9.13
 
 ENV WDIR=/data
 WORKDIR $WDIR
-ADD http://repository.egi.eu/sw/production/cas/1/current/repo-files/EGI-trustanchors.repo /etc/yum.repos.d/egi.repo
-ADD http://linuxsoft.cern.ch/wlcg/wlcg-centos7.repo /etc/yum.repos.d/wlcg-centos7.repo
-ADD hadoop.repo /etc/yum.repos.d/hadoop.repo
-ADD epel.repo /etc/yum.repos.d/epel.repo
-ADD slc7-cernonly.repo /etc/yum.repos.d/slc7-cernonly.repo
-ADD RPM-GPG-KEY-wlcg /etc/pki/rpm-gpg/RPM-GPG-KEY-wlcg
-
 ENV PATH $PATH:/usr/hdp/hadoop/bin:/usr/hdp/sqoop/bin
 ENV PATH $PATH:/data
 
-# add necessary RPMs for cmsweb deployment
-RUN yum -y update && \
-    yum install -y  \
-        cern-get-certificate fetch-crl \
-        git-core zip unzip which file bzip2 e2fsprogs e2fsprogs-libs compat-libstdc++-33 \
-        CERN-CA-certs ca-certificates dummy-ca-certs ca-policy-lcg ca-policy-egi-core \
-        ca_EG-GRID ca_CERN-GridCA ca_CERN-LCG-IOTA-CA ca_CERN-Root-2 \
-        wlcg-voms-cms krb5-workstation krb5-libs pam_krb5 myproxy voms-clients-cpp voms-clients-java \
-        sudo openssl openssl-devel openssl-libs openssh openssh-clients python-backports-ssl_match_hostname \
-        cmake voms voms-devel globus-gsi-credential-devel globus-gsi-cert-utils-devel \
-        globus-common-devel globus-gsi-sysconfig globus-gsi-sysconfig-devel globus-gsi-callback-devel \
-        globus-gsi-openssl-error globus-gsi-proxy-ssl globus-openssl-module \
-        shibboleth log4shib xmltooling-schemas opensaml-schemas \
-        perl-Thread-Queue zsh tk freetype perl-ExtUtils-Embed fontconfig \
-        perl-Test-Harness perl-Data-Dumper perl-Digest-MD5 perl-Switch perl-Env \
-        libX11-devel libX11 libXmu libSM libICE libXcursor libXext libXrandr libXft \
-        mesa-libGLU mesa-libGL libXi libXinerama libXft-devel libXrender libXpm \
-        libXpm-devel libXext-devel mesa-libGLU-devel \
-        libaio libaio-devel net-tools lsof bind-utils initscripts patch \
-        voms-devel globus-gsi-credential-devel globus-gsi-cert-utils-devel \
-        globus-common-devel globus-gsi-sysconfig-devel globus-gsi-callback-devel \
-        oracle-instantclient-tnsnames.ora HEP_OSlibs python-pip libffi-devel \
-        gcc bzip2-devel zlib-devel wget make \
-        hadoop-bin-3.2 \
-        spark-bin-3.2 \
-        sqoop-bin-1.4 \
-        cern-hadoop-xrootd-connector  \
-        cern-hadoop-config && \
+# add necessary RPMs
+RUN yum install -y fetch-crl git-core zip unzip which file bzip2 sudo openssl openssl-devel openssl-libs openssh \
+        wget make openssh-clients python-backports-ssl_match_hostname cmake shibboleth log4shib xmltooling-schemas \
+        opensaml-schemas libaio libaio-devel net-tools lsof bind-utils initscripts patch python-pip libffi-devel gcc \
+        bzip2-devel zlib-devel && \
     yum clean all && rm -rf /var/cache/yum && \
 # Build Python3
     wget https://www.python.org/ftp/python/${PY_VERSION}/Python-${PY_VERSION}.tgz && \


### PR DESCRIPTION
Starting to use `gitlab-registry.cern.ch/db/cerndb-infra-hadoop-conf:latest-hdp3` as base image to be able to build `cmsmon-hadoop-base` image in GitHub actions. 

**Advantage**: CERN hadoop team updates this image when there is a new release. We just need to trigger GH actions in CMSSpark.
**Disadvantage**: Image size 2x compared with our previous image(1GB vs 2GB). May be we can request them to create new images like `slim`. We don't need lots of libraries they are installing like yum installed python3. Because, its version is 3.6, we need 3.9 versions to run in K8s environment which does not have access to `cvmfs` and we build our own python3. 

TL;DR: we can build all our spark/hadoop images via GH actions.  Ref https://github.com/dmwm/CMSSpark/pull/105