### PR TITLE
Update deploy-secrets.sh for use with cmsweb-testX k8s clusters

### DIFF
--- a/kubernetes/cmsweb/scripts/deploy-secrets.sh
+++ b/kubernetes/cmsweb/scripts/deploy-secrets.sh
@@ -113,6 +113,13 @@ fi
 
 if [ -d $secretdir ] && [ -n "$(ls $secretdir)" ]; then
     for fname in $secretdir/*; do
+	# replace BASE_URL hostname in service config file with current cluster name
+	if [[ $fname == *config*.py ]]; then
+            if [[ $cluster_name == cmsweb-test[0-9]* ]]; then
+		echo "Updating config file $fname for the $cluster_name cluster."
+                sed -i "s/TEST_CLUSTER_NAME/$cluster_name/" $fname
+            fi
+	fi
         if [[ $fname == *.encrypted ]]; then
             if [[ $fname == *.json* ]]; then
                 $HOME/bin/sops --output-type json -d $fname > $secretdir/$(basename $fname .encrypted)


### PR DESCRIPTION
Adds logic to check if deploy-secrets.sh is being used in a cmsweb-testX cluster and modifies the configuration files from services_config according to the test cluster name.

Depends on merging this branch from services_config that includes `TEST_CLUSTER_NAME`: https://gitlab.cern.ch/cmsweb-k8s/services_config/-/tree/test-cleanup/reqmgr2 