### PR TITLE
WMCore review of the resource requirements

### DIFF
--- a/kubernetes/cmsweb/services/reqmgr2.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2.yaml
@@ -98,10 +98,10 @@ spec:
               - sudo chmod 0777 /data/srv/logs/reqmgr2; sudo chown _reqmgr2:_reqmgr2 /data/srv/logs/reqmgr2
         resources:
           requests:
-            memory: "512Mi"
+            memory: "2Gi"
             cpu: "200m"
           limits:
-            memory: "3Gi"
+            memory: "4Gi"
             cpu: "1000m"
         livenessProbe:
           exec:

--- a/kubernetes/cmsweb/services/reqmgr2ms-monitor.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-monitor.yaml
@@ -97,10 +97,10 @@ spec:
               - sudo chmod 0777 /data/srv/logs/reqmgr2ms; sudo chown _reqmgr2ms:_reqmgr2ms /data/srv/logs/reqmgr2ms
         resources:
           requests:
-            memory: "256Mi"
+            memory: "250Mi"
             cpu: "100m"
           limits:
-            memory: "3Gi"
+            memory: "500Mi"
             cpu: "1000m"
         livenessProbe:
           exec:

--- a/kubernetes/cmsweb/services/reqmgr2ms-output.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-output.yaml
@@ -97,10 +97,10 @@ spec:
               - sudo chmod 0777 /data/srv/logs/reqmgr2ms; sudo chown _reqmgr2ms:_reqmgr2ms /data/srv/logs/reqmgr2ms
         resources:
           requests:
-            memory: "256Mi"
+            memory: "250Mi"
             cpu: "100m"
           limits:
-            memory: "3Gi"
+            memory: "750Mi"
             cpu: "1000m"
         livenessProbe:
           exec:

--- a/kubernetes/cmsweb/services/reqmgr2ms-rulecleaner.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-rulecleaner.yaml
@@ -97,10 +97,10 @@ spec:
               - sudo chmod 0777 /data/srv/logs/reqmgr2ms; sudo chown _reqmgr2ms:_reqmgr2ms /data/srv/logs/reqmgr2ms
         resources:
           requests:
-            memory: "256Mi"
+            memory: "250Mi"
             cpu: "200m"
           limits:
-            memory: "3Gi"
+            memory: "750Mi"
             cpu: "1000m"
         livenessProbe:
           exec:

--- a/kubernetes/cmsweb/services/reqmgr2ms-transferor.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-transferor.yaml
@@ -97,10 +97,10 @@ spec:
               - sudo chmod 0777 /data/srv/logs/reqmgr2ms; sudo chown _reqmgr2ms:_reqmgr2ms /data/srv/logs/reqmgr2ms
         resources:
           requests:
-            memory: "256Mi"
+            memory: "200Mi"
             cpu: "100m"
           limits:
-            memory: "3Gi"
+            memory: "500Mi"
             cpu: "1000m"
         livenessProbe:
           exec:

--- a/kubernetes/cmsweb/services/reqmgr2ms-unmerged-t1.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-unmerged-t1.yaml
@@ -97,10 +97,10 @@ spec:
               - sudo chmod 0777 /data/srv/logs/reqmgr2ms; sudo chown _reqmgr2ms:_reqmgr2ms /data/srv/logs/reqmgr2ms
         resources:
           requests:
-            memory: "256Mi"
+            memory: "250Mi"
             cpu: "200m"
           limits:
-            memory: "3Gi"
+            memory: "750Mi"
             cpu: "1000m"
         livenessProbe:
           exec:

--- a/kubernetes/cmsweb/services/reqmgr2ms-unmerged-t2t3.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-unmerged-t2t3.yaml
@@ -97,10 +97,10 @@ spec:
               - sudo chmod 0777 /data/srv/logs/reqmgr2ms; sudo chown _reqmgr2ms:_reqmgr2ms /data/srv/logs/reqmgr2ms
         resources:
           requests:
-            memory: "256Mi"
+            memory: "250Mi"
             cpu: "200m"
           limits:
-            memory: "3Gi"
+            memory: "750Mi"
             cpu: "1000m"
         livenessProbe:
           exec:

--- a/kubernetes/cmsweb/services/reqmgr2ms-unmerged-t2t3us.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-unmerged-t2t3us.yaml
@@ -97,10 +97,10 @@ spec:
               - sudo chmod 0777 /data/srv/logs/reqmgr2ms; sudo chown _reqmgr2ms:_reqmgr2ms /data/srv/logs/reqmgr2ms
         resources:
           requests:
-            memory: "256Mi"
+            memory: "500Mi"
             cpu: "200m"
           limits:
-            memory: "3Gi"
+            memory: "1Gi"
             cpu: "1000m"
         livenessProbe:
           exec:

--- a/kubernetes/cmsweb/services/reqmon-tasks.yaml
+++ b/kubernetes/cmsweb/services/reqmon-tasks.yaml
@@ -67,10 +67,10 @@ spec:
         name: reqmon-tasks
         resources:
           requests:
-            memory: "4Gi"
-            cpu: "500m"
+            memory: "3Gi"
+            cpu: "300m"
           limits:
-            memory: "8Gi"
+            memory: "5Gi"
             cpu: "1000m"
         livenessProbe:
           exec:

--- a/kubernetes/cmsweb/services/reqmon.yaml
+++ b/kubernetes/cmsweb/services/reqmon.yaml
@@ -93,7 +93,7 @@ spec:
             cpu: "1"
           limits:
             memory: "8Gi"
-            cpu: "3"
+            cpu: "2"
         livenessProbe:
           exec:
             command:

--- a/kubernetes/cmsweb/services/t0_reqmon-tasks.yaml
+++ b/kubernetes/cmsweb/services/t0_reqmon-tasks.yaml
@@ -76,11 +76,11 @@ spec:
         name: t0reqmon-tasks
         resources:
           requests:
-            memory: "512Mi"
-            cpu: "200m"
+            memory: "750Mi"
+            cpu: "300m"
           limits:
-            memory: "5Gi"
-            cpu: "1500m"
+            memory: "3Gi"
+            cpu: "1000m"
         livenessProbe:
           exec:
             command:

--- a/kubernetes/cmsweb/services/t0_reqmon.yaml
+++ b/kubernetes/cmsweb/services/t0_reqmon.yaml
@@ -91,11 +91,11 @@ spec:
         name: t0reqmon
         resources:
           requests:
-            memory: "4Gi"
+            memory: "3Gi"
             cpu: "1"
           limits:
             memory: "8Gi"
-            cpu: "3"
+            cpu: "2"
         livenessProbe:
           exec:
             command:


### PR DESCRIPTION
This PR provides an update to the resource requirements for all the WMCore services (based on the current snapshot of the system). This also considers some margin for unexpected extra load.

For reference, further information retrieved from all the monitoring tools are provided below
"""
*** Overview of the WM system with around 30k active requests (new to non-archived)
* ReqMgr2 around 2GB (peaks at 3GB)
* ReqMgr2-tasks around 200MB (peaks at 4GB)

* ReqMon around 3.5GB (peaks at 6GB)
* ReqMon-tasks around 3GB (peaks at 3.5GB)

* T0Reqmon around 2.3GB (peaks at 2.8GB)
* T0Reqmon-tasks around 700MB (peaks at 800MB)

* MSMonitor around 190MB (peaks at 210MB)
* MSOutput around 300MB (peaks at 320MB)
* MSRuleCleaner around 250MB (peaks at 310MB)
* MSTransferor around 160MB (peaks at 180MB)
* MSUnmerged-T1 around 270MB (peaks at 290MB)
* MSUnmerged-T2T2 around 250MB (peaks at 290MB)
* MSUnmerged-T2T3US around 450MB (peaks at 470MB)

* WorkQueue around 400MB (peaks at 1GB) - low load in terms of GQE (~35k!)
* WorkQueue-tasks is no longer used
"""