### PR TITLE
Create cmsmon-hdfs docker image which will be used in cronjobs

### DIFF
--- a/docker/cmsmon-hdfs/Dockerfile
+++ b/docker/cmsmon-hdfs/Dockerfile
@@ -1,0 +1,47 @@
+FROM python:3.9 as builder
+MAINTAINER Ceyhun Uzunoglu ceyhunuzngl@gmail.com
+
+# tag to use
+ARG CMSSPARK_TAG=0.0.0
+ENV WDIR=/data
+WORKDIR $WDIR
+
+# Create zip files of stomp.py and CMSMonitoring modules to submit Spark workers
+RUN apt-get update -y && \
+    apt-get install -y zip subversion && \
+#   Install python stomp.py==7.0.0 module which is the latest working version with StompAMQ7
+    pip install --no-cache-dir -t stomp-v700 https://github.com/jasonrbriggs/stomp.py/archive/refs/tags/v7.0.0.zip && \
+#   Create zip file to send to Spark workers, because workers have old version of it (v3 or v4)
+    cd stomp-v700 && \
+    zip -r ../stomp-v700.zip . && \
+    cd .. && \
+    rm -rf stomp-v700 && \
+#   Clone only src/python/CMSMonitoring folder of CMSMonitoring repo using svn and zip it,
+#   zip file will be used to send specific CMSMonitoring folder to Spark workers with '--py-files'.
+    svn export https://github.com/dmwm/CMSMonitoring.git/branches/master/src/python/CMSMonitoring && \
+    zip -r CMSMonitoring.zip CMSMonitoring/* && \
+    git clone https://github.com/dmwm/CMSSpark.git && cd CMSSpark && git checkout tags/$CMSSPARK_TAG -b build && cd ..
+
+FROM registry.cern.ch/cmsmonitoring/cmsmon-hadoop-base:spark3-latest
+MAINTAINER Ceyhun Uzunoglu ceyhunuzngl@gmail.com
+
+ENV WDIR=/data
+ENV HADOOP_CONF_DIR=/etc/hadoop/conf
+ENV PATH="${PATH}:/usr/hdp/hadoop/bin/hadoop:/usr/hdp/spark3/bin:/usr/hdp/sqoop/bin:${WDIR}/CMSSpark/bin"
+
+# CMSMonitoring folder is in WDIR
+ENV PYTHONPATH "${PYTHONPATH}:${WDIR}:${WDIR}/CMSSpark/src/python"
+
+# LCG102 uses this cvmfs python
+ENV PYSPARK_PYTHON=/cvmfs/sft.cern.ch/lcg/releases/Python/3.9.6-b0f98/x86_64-centos7-gcc8-opt/bin/python3
+
+# Local
+ENV PYSPARK_DRIVER_PYTHON=/usr/bin/python
+
+WORKDIR $WDIR
+
+COPY --from=builder /data $WDIR
+
+RUN mkdir -p $WDIR/logs && \
+    pip install --no-cache-dir stomp.py==7.0.0 click pyspark pandas numpy seaborn matplotlib plotly && \
+    hadoop-set-default-conf.sh analytix && source hadoop-setconf.sh analytix 3.2 spark3

--- a/docker/cmsmon-hdfs/README.md
+++ b/docker/cmsmon-hdfs/README.md
@@ -1,0 +1,25 @@
+## cmsmon-hdfs
+
+Base docker image to run all Hadoop/Spark K8s CronJobs
+
+- Analytix cluster 3.2, spark3 and python3.9 will be used. 
+- Base image already contains sqoop.
+
+Installs:
+
+- stomp.py==7.0.0 and creates its zip for spark-submit `--py-files` (spark nodes don't have this version yet)
+- Only src/python/CMSMonitoring folder of dmwm/CMSMonitoring repo and creates its zip for spark-submit `--py-files` (WDIR should be in path)
+- dmwm/CMSSpark
+- Other PY modules: click pyspark pandas numpy seaborn matplotlib plotly
+
+##### Image is built by GH workflow in CMSSpark repository
+
+#### Manual build and push
+
+```shell
+# docker image prune -a OR docker system prune -f -a
+docker_registry=registry.cern.ch/cmsmonitoring
+image_tag=20220904
+docker build -t "${docker_registry}/cmsmon-hdfs:${image_tag}" .
+docker push "${docker_registry}/cmsmon-hdfs:${image_tag}"
+```


### PR DESCRIPTION
This docker image will be used as common image in all K8s CronJobs of monitoring. It will be added to CMSSpark GH workflow to be built&pushed via git tag.