### PR TITLE
Add cmsmon-rucio-ds CronJob

### DIFF
--- a/kubernetes/monitoring/cron-hdfs/cmsmon-rucio-data-ds.yaml
+++ b/kubernetes/monitoring/cron-hdfs/cmsmon-rucio-data-ds.yaml
@@ -1,0 +1,91 @@
+# cron4rucio_datasets_daily_stats.sh for k8s
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: cmsmon-rucio-data-ds
+  namespace: cron-hdfs
+  labels:
+    app: cmsmon-rucio-data-ds
+data:
+  run.sh: |
+    #!/bin/bash
+    # Get env variables, since cron's process environment is different than shell's one
+    . /etc/environment
+    # Run and print all results(except for Spark logs) to stdout
+    /data/CMSSpark/bin/cron4rucio_datasets_daily_stats.sh \
+      --keytab /etc/secrets/keytab \
+      --cmsr /etc/secrets/cmsr_cstring \
+      --rucio /etc/secrets/rucio \
+      --amq /etc/secrets/amq-creds.json \
+      --cmsmonitoring /data/CMSMonitoring.zip \
+      --stomp /data/stomp-v700.zip \
+      --eos /eos/user/c/cmsmonit/www/rucio_daily_ds_stats \
+      --p1=5001 --p2=5101 --host=$MY_NODE_NAME --wdir=$WDIR 2>&1
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cmsmon-rucio-data-ds
+  namespace: cron-hdfs
+spec:
+  # Run cron job every day at 7am, only once for any failure
+  schedule: "0 7 * * *"
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            app: cmsmon-rucio-data-ds
+        spec:
+          restartPolicy: Never
+          hostname: cmsmon-rucio-data-ds
+          containers:
+            - name: cmsmon-rucio-data-ds
+              image: registry.cern.ch/cmsmonitoring/cmsmon-hdfs:20220904
+              imagePullPolicy: Always
+              args:
+                - /bin/bash
+                - -c
+                - export >/etc/environment; /data/cronjob/run.sh
+              env:
+                - name: MY_NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
+              ports:
+                - containerPort: 5001 # spark.driver.port
+                  name: port-1
+                - containerPort: 5101 # spark.driver.blockManager.port
+                  name: port-2
+              resources:
+                limits:
+                  cpu: 2000m
+                  memory: 6Gi
+                requests:
+                  cpu: 500m
+                  memory: 750Mi
+              stdin: true
+              tty: true
+              volumeMounts:
+                - name: cmsmon-rucio-data-ds-secrets
+                  mountPath: /etc/secrets
+                  readOnly: true
+                - name: eos # EOS access
+                  mountPath: /eos
+                  mountPropagation: HostToContainer
+                - name: cronjobs-configmap
+                  mountPath: /data/cronjob
+          volumes:
+            - name: cmsmon-rucio-data-ds-secrets
+              secret:
+                secretName: cmsmon-rucio-data-ds-secrets
+            - name: eos
+              hostPath:
+                path: /var/eos
+            - name: cronjobs-configmap
+              configMap:
+                name: cmsmon-rucio-data-ds
+                defaultMode: 0555 # rx


### PR DESCRIPTION
This is a K8s `CronJob` to execute `cron4rucio_datasets_daily_stats.sh`  from CMSSpark with all required parameters ready for production. 

#1198 