### PR TITLE
Add main CMSSpark cronjobs to k8s

### DIFF
--- a/kubernetes/monitoring/cron-hdfs/cmsmon-crab-pop.yaml
+++ b/kubernetes/monitoring/cron-hdfs/cmsmon-crab-pop.yaml
@@ -1,0 +1,84 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: cmsmon-crab-pop
+  namespace: cron-hdfs
+  labels:
+    app: cmsmon-crab-pop
+data:
+  run.sh: |
+    #!/bin/bash
+    # Get env variables, since cron's process environment is different than shell's one
+    . /etc/environment
+    # Run and print all results(except for Spark logs) to stdout
+    /data/CMSSpark/bin/cron4crab_popularity.sh \
+      --keytab /etc/secrets/keytab --output /eos/user/c/cmsmonit/www/crabPop/data \
+      --p1=5001 --p2=5101 --host=$MY_NODE_NAME --wdir=$WDIR 2>&1
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cmsmon-crab-pop
+  namespace: cron-hdfs
+spec:
+  schedule: "30 20 04 * *"
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            app: cmsmon-crab-pop
+        spec:
+          restartPolicy: Never
+          hostname: cmsmon-crab-pop
+          containers:
+            - name: cmsmon-crab-pop
+              image: registry.cern.ch/cmsmonitoring/cmsmon-hdfs:20220904
+              imagePullPolicy: Always
+              args:
+                - /bin/bash
+                - -c
+                - export >/etc/environment; /data/cronjob/run.sh
+              env:
+                - name: MY_NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
+              ports:
+                - containerPort: 5001 # spark.driver.port 5001
+                  name: port-1
+                - containerPort: 5101 # spark.driver.blockManager.port 5101
+                  name: port-2
+              resources:
+                limits:
+                  cpu: 2000m
+                  memory: 6Gi
+                requests:
+                  cpu: 500m
+                  memory: 750Mi
+              stdin: true
+              tty: true
+              volumeMounts:
+                - name: cmsmon-crab-pop-secrets
+                  mountPath: /etc/secrets
+                  readOnly: true
+                - name: eos # EOS access
+                  mountPath: /eos
+                  mountPropagation: HostToContainer
+                - name: cronjobs-configmap
+                  mountPath: /data/cronjob
+          volumes:
+            - name: cmsmon-crab-pop-secrets
+              secret:
+                secretName: cmsmon-crab-pop-secrets
+            - name: eos
+              hostPath:
+                path: /var/eos
+            - name: cronjobs-configmap
+              configMap:
+                name: cmsmon-crab-pop
+                defaultMode: 0555 # rx
+

--- a/kubernetes/monitoring/cron-hdfs/cmsmon-crab-uu.yaml
+++ b/kubernetes/monitoring/cron-hdfs/cmsmon-crab-uu.yaml
@@ -1,0 +1,84 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: cmsmon-crab-uu
+  namespace: cron-hdfs
+  labels:
+    app: cmsmon-crab-uu
+data:
+  run.sh: |
+    #!/bin/bash
+    # Get env variables, since cron's process environment is different than shell's one
+    . /etc/environment
+    # Run and print all results(except for Spark logs) to stdout
+    /data/CMSSpark/bin/cron4crab_unique_users.sh \
+      --keytab /etc/secrets/keytab --output /eos/user/c/cmsmonit/www/crab_uu \
+      --p1=5001 --p2=5101 --host=$MY_NODE_NAME --wdir=$WDIR 2>&1
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cmsmon-crab-uu
+  namespace: cron-hdfs
+spec:
+  schedule: "02 15 27 * *"
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            app: cmsmon-crab-uu
+        spec:
+          restartPolicy: Never
+          hostname: cmsmon-crab-uu
+          containers:
+            - name: cmsmon-crab-uu
+              image: registry.cern.ch/cmsmonitoring/cmsmon-hdfs:20220904
+              imagePullPolicy: Always
+              args:
+                - /bin/bash
+                - -c
+                - export >/etc/environment; /data/cronjob/run.sh
+              env:
+                - name: MY_NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
+              ports:
+                - containerPort: 5001 # spark.driver.port
+                  name: port-1
+                - containerPort: 5101 # spark.driver.blockManager.port
+                  name: port-2
+              resources:
+                limits:
+                  cpu: 2000m
+                  memory: 6Gi
+                requests:
+                  cpu: 500m
+                  memory: 750Mi
+              stdin: true
+              tty: true
+              volumeMounts:
+                - name: cmsmon-crab-uu-secrets
+                  mountPath: /etc/secrets
+                  readOnly: true
+                - name: eos # EOS access
+                  mountPath: /eos
+                  mountPropagation: HostToContainer
+                - name: cronjobs-configmap
+                  mountPath: /data/cronjob
+          volumes:
+            - name: cmsmon-crab-uu-secrets
+              secret:
+                secretName: cmsmon-crab-uu-secrets
+            - name: eos
+              hostPath:
+                path: /var/eos
+            - name: cronjobs-configmap
+              configMap:
+                name: cmsmon-crab-uu
+                defaultMode: 0555 # rx
+

--- a/kubernetes/monitoring/cron-hdfs/cmsmon-eos-data.yaml
+++ b/kubernetes/monitoring/cron-hdfs/cmsmon-eos-data.yaml
@@ -1,0 +1,84 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: cmsmon-eos-data
+  namespace: cron-hdfs
+  labels:
+    app: cmsmon-eos-data
+data:
+  run.sh: |
+    #!/bin/bash
+    # Get env variables, since cron's process environment is different than shell's one
+    . /etc/environment
+    # Run and print all results(except for Spark logs) to stdout
+    /data/CMSSpark/bin/cron4eos_dataset.sh \
+      --keytab /etc/secrets/keytab --output /eos/user/c/cmsmonit/www/EOS/data \
+      --p1=5001 --p2=5101 --host=$MY_NODE_NAME --wdir=$WDIR 2>&1
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cmsmon-eos-data
+  namespace: cron-hdfs
+spec:
+  schedule: "10 17 24 * *"
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            app: cmsmon-eos-data
+        spec:
+          restartPolicy: Never
+          hostname: cmsmon-eos-data
+          containers:
+            - name: cmsmon-eos-data
+              image: registry.cern.ch/cmsmonitoring/cmsmon-hdfs:20220904
+              imagePullPolicy: Always
+              args:
+                - /bin/bash
+                - -c
+                - export >/etc/environment; /data/cronjob/run.sh
+              env:
+                - name: MY_NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
+              ports:
+                - containerPort: 5001 # spark.driver.port
+                  name: port-1
+                - containerPort: 5101 # spark.driver.blockManager.port
+                  name: port-2
+              resources:
+                limits:
+                  cpu: 2000m
+                  memory: 6Gi
+                requests:
+                  cpu: 500m
+                  memory: 750Mi
+              stdin: true
+              tty: true
+              volumeMounts:
+                - name: cmsmon-eos-data-secrets
+                  mountPath: /etc/secrets
+                  readOnly: true
+                - name: eos # EOS access
+                  mountPath: /eos
+                  mountPropagation: HostToContainer
+                - name: cronjobs-configmap
+                  mountPath: /data/cronjob
+          volumes:
+            - name: cmsmon-eos-data-secrets
+              secret:
+                secretName: cmsmon-eos-data-secrets
+            - name: eos
+              hostPath:
+                path: /var/eos
+            - name: cronjobs-configmap
+              configMap:
+                name: cmsmon-eos-data
+                defaultMode: 0555 # rx
+

--- a/kubernetes/monitoring/cron-hdfs/cmsmon-gen-crsg.yaml
+++ b/kubernetes/monitoring/cron-hdfs/cmsmon-gen-crsg.yaml
@@ -1,0 +1,84 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: cmsmon-gen-crsg
+  namespace: cron-hdfs
+  labels:
+    app: cmsmon-gen-crsg
+data:
+  run.sh: |
+    #!/bin/bash
+    # Get env variables, since cron's process environment is different than shell's one
+    . /etc/environment
+    # Run and print all results(except for Spark logs) to stdout
+    /data/CMSSpark/bin/cron4gen_crsg_plots.sh \
+      --keytab /etc/secrets/keytab --output /eos/user/c/cmsmonit/www/EventCountPlots \
+      --p1=5001 --p2=5101 --host=$MY_NODE_NAME --wdir=$WDIR 2>&1
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cmsmon-gen-crsg
+  namespace: cron-hdfs
+spec:
+  schedule: "00 14 05 * *"
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            app: cmsmon-gen-crsg
+        spec:
+          restartPolicy: Never
+          hostname: cmsmon-gen-crsg
+          containers:
+            - name: cmsmon-gen-crsg
+              image: registry.cern.ch/cmsmonitoring/cmsmon-hdfs:20220904
+              imagePullPolicy: Always
+              args:
+                - /bin/bash
+                - -c
+                - export >/etc/environment; /data/cronjob/run.sh
+              env:
+                - name: MY_NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
+              ports:
+                - containerPort: 5001 # spark.driver.port
+                  name: port-1
+                - containerPort: 5101 # spark.driver.blockManager.port
+                  name: port-2
+              resources:
+                limits:
+                  cpu: 2000m
+                  memory: 6Gi
+                requests:
+                  cpu: 500m
+                  memory: 750Mi
+              stdin: true
+              tty: true
+              volumeMounts:
+                - name: cmsmon-gen-crsg-secrets
+                  mountPath: /etc/secrets
+                  readOnly: true
+                - name: eos # EOS access
+                  mountPath: /eos
+                  mountPropagation: HostToContainer
+                - name: cronjobs-configmap
+                  mountPath: /data/cronjob
+          volumes:
+            - name: cmsmon-gen-crsg-secrets
+              secret:
+                secretName: cmsmon-gen-crsg-secrets
+            - name: eos
+              hostPath:
+                path: /var/eos
+            - name: cronjobs-configmap
+              configMap:
+                name: cmsmon-gen-crsg
+                defaultMode: 0555 # rx
+

--- a/kubernetes/monitoring/cron-hdfs/cmsmon-hpc-cms.yaml
+++ b/kubernetes/monitoring/cron-hdfs/cmsmon-hpc-cms.yaml
@@ -1,0 +1,84 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: cmsmon-hpc-cms
+  namespace: cron-hdfs
+  labels:
+    app: cmsmon-hpc-cms
+data:
+  run.sh: |
+    #!/bin/bash
+    # Get env variables, since cron's process environment is different than shell's one
+    . /etc/environment
+    # Run and print all results(except for Spark logs) to stdout
+    /data/CMSSpark/bin/cron4hpc_at_cms.sh \
+      --keytab /etc/secrets/keytab --output /eos/user/c/cmsmonit/www/hpc \
+      --p1=5001 --p2=5101 --host=$MY_NODE_NAME --wdir=$WDIR 2>&1
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cmsmon-hpc-cms
+  namespace: cron-hdfs
+spec:
+  schedule: "00 15 03 * *"
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            app: cmsmon-hpc-cms
+        spec:
+          restartPolicy: Never
+          hostname: cmsmon-hpc-cms
+          containers:
+            - name: cmsmon-hpc-cms
+              image: registry.cern.ch/cmsmonitoring/cmsmon-hdfs:20220904
+              imagePullPolicy: Always
+              args:
+                - /bin/bash
+                - -c
+                - export >/etc/environment; /data/cronjob/run.sh
+              env:
+                - name: MY_NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
+              ports:
+                - containerPort: 5001 # spark.driver.port
+                  name: port-1
+                - containerPort: 5101 # spark.driver.blockManager.port
+                  name: port-2
+              resources:
+                limits:
+                  cpu: 2000m
+                  memory: 6Gi
+                requests:
+                  cpu: 500m
+                  memory: 750Mi
+              stdin: true
+              tty: true
+              volumeMounts:
+                - name: cmsmon-hpc-cms-secrets
+                  mountPath: /etc/secrets
+                  readOnly: true
+                - name: eos # EOS access
+                  mountPath: /eos
+                  mountPropagation: HostToContainer
+                - name: cronjobs-configmap
+                  mountPath: /data/cronjob
+          volumes:
+            - name: cmsmon-hpc-cms-secrets
+              secret:
+                secretName: cmsmon-hpc-cms-secrets
+            - name: eos
+              hostPath:
+                path: /var/eos
+            - name: cronjobs-configmap
+              configMap:
+                name: cmsmon-hpc-cms
+                defaultMode: 0555 # rx
+

--- a/kubernetes/monitoring/cron-hdfs/cmsmon-hpc-usage.yaml
+++ b/kubernetes/monitoring/cron-hdfs/cmsmon-hpc-usage.yaml
@@ -1,0 +1,85 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: cmsmon-hpc-usage
+  namespace: cron-hdfs
+  labels:
+    app: cmsmon-hpc-usage
+data:
+  run.sh: |
+    #!/bin/bash
+    # Get env variables, since cron's process environment is different than shell's one
+    . /etc/environment
+    # Run and print all results(except for Spark logs) to stdout
+    /data/CMSSpark/bin/cron4hpc_usage.sh \
+      --keytab /etc/secrets/keytab --output /eos/user/c/cmsmonit/www/hpc_usage \
+      --url https://cmsdatapop.web.cern.ch/cmsdatapop/hpc_usage \
+      --p1=5001 --p2=5101 --host=$MY_NODE_NAME --wdir=$WDIR --iterative 2>&1
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cmsmon-hpc-usage
+  namespace: cron-hdfs
+spec:
+    schedule: "43 13 * * *"
+    concurrencyPolicy: Forbid
+    failedJobsHistoryLimit: 1
+    jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            app: cmsmon-hpc-usage
+        spec:
+          restartPolicy: Never
+          hostname: cmsmon-hpc-usage
+          containers:
+            - name: cmsmon-hpc-usage
+              image: registry.cern.ch/cmsmonitoring/cmsmon-hdfs:20220904
+              imagePullPolicy: Always
+              args:
+                - /bin/bash
+                - -c
+                - export >/etc/environment; /data/cronjob/run.sh
+              env:
+                - name: MY_NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
+              ports:
+                - containerPort: 5001 # spark.driver.port
+                  name: port-1
+                - containerPort: 5101 # spark.driver.blockManager.port
+                  name: port-2
+              resources:
+                limits:
+                  cpu: 2000m
+                  memory: 6Gi
+                requests:
+                  cpu: 500m
+                  memory: 750Mi
+              stdin: true
+              tty: true
+              volumeMounts:
+                - name: cmsmon-hpc-usage-secrets
+                  mountPath: /etc/secrets
+                  readOnly: true
+                - name: eos # EOS access
+                  mountPath: /eos
+                  mountPropagation: HostToContainer
+                - name: cronjobs-configmap
+                  mountPath: /data/cronjob
+          volumes:
+            - name: cmsmon-hpc-usage-secrets
+              secret:
+                secretName: cmsmon-hpc-usage-secrets
+            - name: eos
+              hostPath:
+                path: /var/eos
+            - name: cronjobs-configmap
+              configMap:
+                name: cmsmon-hpc-usage
+                defaultMode: 0555 # rx
+

--- a/kubernetes/monitoring/cron-hdfs/cmsmon-hs06-cputime.yaml
+++ b/kubernetes/monitoring/cron-hdfs/cmsmon-hs06-cputime.yaml
@@ -1,0 +1,84 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: cmsmon-hs06-cputime
+  namespace: cron-hdfs
+  labels:
+    app: cmsmon-hs06-cputime
+data:
+  run.sh: |
+    #!/bin/bash
+    # Get env variables, since cron's process environment is different than shell's one
+    . /etc/environment
+    # Run and print all results(except for Spark logs) to stdout
+    /data/CMSSpark/bin/cron4hs06_cputime_plot.sh \
+      --keytab /etc/secrets/keytab --output /eos/user/c/cmsmonit/www/hs06cputime \
+      --p1=5001 --p2=5101 --host=$MY_NODE_NAME --wdir=$WDIR 2>&1
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cmsmon-hs06-cputime
+  namespace: cron-hdfs
+spec:
+  schedule: "30 14 19 * *"
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            app: cmsmon-hs06-cputime
+        spec:
+          restartPolicy: Never
+          hostname: cmsmon-hs06-cputime
+          containers:
+            - name: cmsmon-hs06-cputime
+              image: registry.cern.ch/cmsmonitoring/cmsmon-hdfs:20220904
+              imagePullPolicy: Always
+              args:
+                - /bin/bash
+                - -c
+                - export >/etc/environment; /data/cronjob/run.sh
+              env:
+                - name: MY_NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
+              ports:
+                - containerPort: 5001 # spark.driver.port
+                  name: port-1
+                - containerPort: 5101 # spark.driver.blockManager.port
+                  name: port-2
+              resources:
+                limits:
+                  cpu: 2000m
+                  memory: 6Gi
+                requests:
+                  cpu: 500m
+                  memory: 750Mi
+              stdin: true
+              tty: true
+              volumeMounts:
+                - name: cmsmon-hs06-cputime-secrets
+                  mountPath: /etc/secrets
+                  readOnly: true
+                - name: eos # EOS access
+                  mountPath: /eos
+                  mountPropagation: HostToContainer
+                - name: cronjobs-configmap
+                  mountPath: /data/cronjob
+          volumes:
+            - name: cmsmon-hs06-cputime-secrets
+              secret:
+                secretName: cmsmon-hs06-cputime-secrets
+            - name: eos
+              hostPath:
+                path: /var/eos
+            - name: cronjobs-configmap
+              configMap:
+                name: cmsmon-hs06-cputime
+                defaultMode: 0555 # rx
+

--- a/kubernetes/monitoring/cron-hdfs/cmsmon-rucio-daily-stat.yaml
+++ b/kubernetes/monitoring/cron-hdfs/cmsmon-rucio-daily-stat.yaml
@@ -1,0 +1,88 @@
+# cron4rucio_datasets_daily_stats.sh for k8s
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: cmsmon-rucio-daily-stat
+  namespace: cron-hdfs
+  labels:
+    app: cmsmon-rucio-daily-stat
+data:
+  run.sh: |
+    #!/bin/bash
+    # Get env variables, since cron's process environment is different than shell's one
+    . /etc/environment
+    # Run and print all results(except for Spark logs) to stdout
+    /data/CMSSpark/bin/cron4rucio_datasets_daily_stats.sh \
+      --keytab /etc/secrets/keytab \
+      --amq /etc/secrets/amq-creds.json \
+      --cmsmonitoring /data/CMSMonitoring.zip \
+      --stomp /data/stomp-v700.zip \
+      --p1=5001 --p2=5101 --host=$MY_NODE_NAME --wdir=$WDIR 2>&1
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cmsmon-rucio-daily-stat
+  namespace: cron-hdfs
+spec:
+  # Run cron job every day at 8am, only once for any failure
+  schedule: "0 8 * * *"
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            app: cmsmon-rucio-daily-stat
+        spec:
+          restartPolicy: Never
+          hostname: cmsmon-rucio-daily-stat
+          containers:
+            - name: cmsmon-rucio-daily-stat
+              image: registry.cern.ch/cmsmonitoring/cmsmon-hdfs:20220904
+              imagePullPolicy: Always
+              args:
+                - /bin/bash
+                - -c
+                - export >/etc/environment; /data/cronjob/run.sh
+              env:
+                - name: MY_NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
+              ports:
+                - containerPort: 5001 # spark.driver.port
+                  name: port-1
+                - containerPort: 5101 # spark.driver.blockManager.port
+                  name: port-2
+              resources:
+                limits:
+                  cpu: 2000m
+                  memory: 6Gi
+                requests:
+                  cpu: 500m
+                  memory: 750Mi
+              stdin: true
+              tty: true
+              volumeMounts:
+                - name: cmsmon-rucio-daily-stat-secrets
+                  mountPath: /etc/secrets
+                  readOnly: true
+                - name: eos # EOS access
+                  mountPath: /eos
+                  mountPropagation: HostToContainer
+                - name: cronjobs-configmap
+                  mountPath: /data/cronjob
+          volumes:
+            - name: cmsmon-rucio-daily-stat-secrets
+              secret:
+                secretName: cmsmon-rucio-daily-stat-secrets
+            - name: eos
+              hostPath:
+                path: /var/eos
+            - name: cronjobs-configmap
+              configMap:
+                name: cmsmon-rucio-daily-stat
+                defaultMode: 0555 # rx

--- a/kubernetes/monitoring/cron-hdfs/cmsmon-rucio-daily.yaml
+++ b/kubernetes/monitoring/cron-hdfs/cmsmon-rucio-daily.yaml
@@ -1,0 +1,78 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: cmsmon-rucio-daily
+  namespace: cron-hdfs
+  labels:
+    app: cmsmon-rucio-daily
+data:
+  run.sh: |
+    #!/bin/bash
+    # Get env variables, since cron's process environment is different than shell's one
+    . /etc/environment
+    # Run and print all results(except for Spark logs) to stdout
+    /data/CMSSpark/bin/cron4rucio_ds_summary.sh \
+      --keytab /etc/secrets/keytab --output /cms/rucio_daily \
+      --p1=5001 --p2=5101 --host=$MY_NODE_NAME --wdir=$WDIR 2>&1
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cmsmon-rucio-daily
+  namespace: cron-hdfs
+spec:
+  schedule: "07 08 * * *"
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            app: cmsmon-rucio-daily
+        spec:
+          restartPolicy: Never
+          hostname: cmsmon-rucio-daily
+          containers:
+            - name: cmsmon-rucio-daily
+              image: registry.cern.ch/cmsmonitoring/cmsmon-hdfs:20220904
+              imagePullPolicy: Always
+              args:
+                - /bin/bash
+                - -c
+                - export >/etc/environment; /data/cronjob/run.sh
+              env:
+                - name: MY_NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
+              ports:
+                - containerPort: 5001 # spark.driver.port
+                  name: port-1
+                - containerPort: 5101 # spark.driver.blockManager.port
+                  name: port-2
+              resources:
+                limits:
+                  cpu: 2000m
+                  memory: 6Gi
+                requests:
+                  cpu: 500m
+                  memory: 750Mi
+              stdin: true
+              tty: true
+              volumeMounts:
+                - name: cmsmon-rucio-daily-secrets
+                  mountPath: /etc/secrets
+                  readOnly: true
+                - name: cronjobs-configmap
+                  mountPath: /data/cronjob
+          volumes:
+            - name: cmsmon-rucio-daily-secrets
+              secret:
+                secretName: cmsmon-rucio-daily-secrets
+            - name: cronjobs-configmap
+              configMap:
+                name: cmsmon-rucio-daily
+                defaultMode: 0555 # rx
+

--- a/kubernetes/monitoring/cron-hdfs/services.yaml
+++ b/kubernetes/monitoring/cron-hdfs/services.yaml
@@ -190,11 +190,11 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: cmsmon-rucio-data-ds
+  name: cmsmon-rucio-daily-stat
   namespace: cron-hdfs
 spec:
   selector:
-    app: cmsmon-rucio-data-ds
+    app: cmsmon-rucio-daily-stat
   type: NodePort
   ports:
     - name: port-1 # spark.driver.port


### PR DESCRIPTION
This PR includes several Kubernetes CronJob yaml files (not including dbs_condor, aggregation, which are still being refactored)
Schedules and outputs are set according to cronjobs which are running in production. 

Apply only after ensuring that services are created.
#1198 