### PR TITLE
Fix config filename matching in deploy-secrets.sh

### DIFF
--- a/kubernetes/cmsweb/scripts/deploy-secrets.sh
+++ b/kubernetes/cmsweb/scripts/deploy-secrets.sh
@@ -113,8 +113,8 @@ fi
 
 if [ -d $secretdir ] && [ -n "$(ls $secretdir)" ]; then
     for fname in $secretdir/*; do
-	# replace BASE_URL hostname in service config file with current cluster name
-	if [[ $fname == *config*.py ]]; then
+	# replace CLUSTER_NAME in service config file with current cluster name
+	if [[ $fname == */config*.py ]]; then
             if [[ $cluster_name == cmsweb-test[0-9]* ]]; then
 		echo "Updating config file $fname for the $cluster_name cluster."
                 sed -i "s/TEST_CLUSTER_NAME/$cluster_name/" $fname


### PR DESCRIPTION
The if logic on L117 was matching any file in the config directory.

```
Key file: /tmp/egough/sops/dmwm-keys.txt
Updating config file /afs/cern.ch/user/e/egough/services_config/reqmgr2/config.py for the cmsweb-test8 cluster.
Updating config file /afs/cern.ch/user/e/egough/services_config/reqmgr2/ReqMgr2Secrets.py for the cmsweb-test8 cluster.
Decrypted file /afs/cern.ch/user/e/egough/services_config/reqmgr2/ReqMgr2Secrets.py
secret/reqmgr2-secrets created
```

This PR resolves the issue.

```
Updating config file /afs/cern.ch/user/e/egough/services_config/reqmgr2/config.py for the cmsweb-test8 cluster.
Decrypted file /afs/cern.ch/user/e/egough/services_config/reqmgr2/ReqMgr2Secrets.py
secret/reqmgr2-secrets configured
```
