### PR TITLE
Create a helm chart for cmsmonitoring spark running cronjobs

### DIFF
--- a/helm/cmsmon-cron/.helmignore
+++ b/helm/cmsmon-cron/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/cmsmon-cron/Chart.yaml
+++ b/helm/cmsmon-cron/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: cmsmon-cron
+description: A Helm chart for k8s CMSSpark cronjobs
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/helm/cmsmon-cron/README.md
+++ b/helm/cmsmon-cron/README.md
@@ -1,0 +1,25 @@
+This Helm chart provides all-in-one template for CMSSpark cronjobs. 
+
+### Notes
+Go template language provides a range block, which is actively used in this template. It allows `values.yaml` to have a dictionary containing multiple cronjob configurations. <br> Provided key naming has to be followed, e.g. "0", "1", "2" ... These keys are used as indexes to increment NodePorts of each CronJob service.
+
+Each CronJob runs a bash script specified in *command* field. Arguments have to be provided as a YAML multiline string. Both fields are then concatenated with common cronjob arguments in _helpers.tpl and included as a complete argument for the `/bin/bash -c` in CronJob.
+
+Depending on the `test.enabled` parameter value, `cronjob.yaml` or `test-job.yaml` will be deployed. **Output directories for testing have to be provided individually.** **Some cronjobs don't support --test flag.**
+
+Some CronJobs may need EOS access. This can be specified with `eosEnabled: true` individually in the same field as `name` and `schedule`.
+
+
+### Testing 
+If `test.enabled` parameter is set to true, `--test` flag will be added as an argument for each CronJob. Moreover, each CronJob will be deployed as a Job and executed right after deployment without waiting for the schedule time to be reached. 
+
+Following command can be used to deploy in test mode using `--set`
+
+```
+helm install cmsmon-cron cmsmon-cron/ --set test.enabled=true --debug
+```
+
+### TODO
+- [ ] Migrate Google's [spark-on-k8s-operator](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator)
+- [ ] Convert to Ingress
+- [ ] Utilize Chart in FluxCD pipeline

--- a/helm/cmsmon-cron/templates/NOTES.txt
+++ b/helm/cmsmon-cron/templates/NOTES.txt
@@ -1,0 +1,17 @@
+Display running pods:
+kubectl get pods -n cron-hdfs
+
+Show the logs:
+kubectl logs <pod_name> -n cron-hdfs
+
+Show command and arguments:
+kubectl describe pod <pod_name> -n cron-hdfs
+
+Connect to the container:
+kubectl exec --stdin --tty <pod_name> -n cron-hdfs -- /bin/bash 
+
+List the charts:
+helm list
+
+Uninstall the chart:
+helm uninstall <NAME>

--- a/helm/cmsmon-cron/templates/_helpers.tpl
+++ b/helm/cmsmon-cron/templates/_helpers.tpl
@@ -1,0 +1,69 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cmsmon-cron.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cmsmon-cron.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cmsmon-cron.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "cmsmon-cron.labels" -}}
+helm.sh/chart: {{ include "cmsmon-cron.chart" . }}
+{{ include "cmsmon-cron.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "cmsmon-cron.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cmsmon-cron.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cmsmon-cron.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "cmsmon-cron.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Compile CronJob run command with all parameters
+*/}}
+{{- define "cmsmon-cron.run" -}}
+{{ $.cron.command }} {{ $.cron.args }} --p1=${{ $.cron.name | upper | replace "-" "_" }}_SERVICE_PORT_PORT_1 --p2=${{ $.cron.name | upper | replace "-" "_" }}_SERVICE_PORT_PORT_2 --host=$MY_NODE_NAME --wdir=$WDIR {{ if and (eq $.Values.test.enabled true) (eq $.cron.testFlagExists true) }}--test{{ end }} 2>&1
+{{- end }}

--- a/helm/cmsmon-cron/templates/cronjob.yaml
+++ b/helm/cmsmon-cron/templates/cronjob.yaml
@@ -1,0 +1,69 @@
+{{- if eq false .Values.test.enabled -}}
+{{- range $i, $cron := .Values.cronjob.crons }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ $cron.name }}
+  namespace: cron-hdfs
+spec:
+  schedule: {{ $cron.schedule | quote }}
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            app: {{ $cron.name }}
+        spec:
+          restartPolicy: Never
+          hostname: {{ $cron.name }}
+          containers:
+            - name: {{ $cron.name }}
+              image: {{ $.Values.cronjob.repository }}
+              imagePullPolicy: {{ $.Values.image.pullPolicy }}
+              command: ["/bin/bash", "-c"]
+              args:
+                - export >/etc/environment;
+                  source /etc/environment;{{ include "cmsmon-cron.run" (dict "cron" $cron "Values" $.Values) | trim | nindent 18 }}
+              env:
+                - name: MY_NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
+              ports:
+                - containerPort: {{ add 32501 (mul 2 $i)}} # spark.driver.port
+                  name: port-1
+                - containerPort: {{ add 32502 (mul 2 $i)}} # spark.driver.blockManager.port
+                  name: port-2
+              resources:
+                limits:
+                  cpu: 2000m
+                  memory: 6Gi
+                requests:
+                  cpu: 500m
+                  memory: 750Mi
+              stdin: true
+              tty: true
+              volumeMounts:
+                - name: {{ $cron.name }}-secrets
+                  mountPath: /etc/secrets
+                  readOnly: true
+                {{- with $cron.eosEnabled}}
+                - name: eos # EOS access
+                  mountPath: /eos
+                  mountPropagation: HostToContainer
+                {{- end}}
+          volumes:
+            - name: {{ $cron.name }}-secrets
+              secret:
+                secretName: {{ $cron.name }}-secrets
+            {{- with $cron.eosEnabled}}
+            - name: eos
+              hostPath:
+                path: /var/eos
+            {{- end}}
+{{- end}}
+{{- end}}

--- a/helm/cmsmon-cron/templates/service.yaml
+++ b/helm/cmsmon-cron/templates/service.yaml
@@ -1,0 +1,23 @@
+{{- range $i, $cron := .Values.cronjob.crons }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $cron.name }}
+  namespace: cron-hdfs
+spec:
+  selector:
+    app: {{ $cron.name }}
+  type: NodePort
+  ports:
+    - name: port-1
+      nodePort: {{ add 32501 (mul 2 $i)}}
+      port: {{ add 32501 (mul 2 $i)}}
+      protocol: TCP
+      targetPort: {{ add 32501 (mul 2 $i)}}
+    - name: port-2
+      nodePort: {{ add 32502 (mul 2 $i)}}
+      port: {{ add 32502 (mul 2 $i)}}
+      protocol: TCP
+      targetPort: {{ add 32502 (mul 2 $i)}}
+{{- end}}

--- a/helm/cmsmon-cron/templates/test-job.yaml
+++ b/helm/cmsmon-cron/templates/test-job.yaml
@@ -1,0 +1,66 @@
+{{- if eq true .Values.test.enabled -}}
+{{- range $i, $cron := .Values.cronjob.crons }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $cron.name }}
+  namespace: cron-hdfs
+  labels:
+    app: {{ $cron.name }}
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app: {{ $cron.name }}
+    spec:
+      restartPolicy: Never
+      hostname: {{ $cron.name }}
+      containers:
+        - name: {{ $cron.name }}
+          image: {{ $.Values.cronjob.repository }}
+          imagePullPolicy: {{ $.Values.image.pullPolicy }}
+          command: ["/bin/bash", "-c"]
+          args:
+            - export >/etc/environment;
+              source /etc/environment;{{ include "cmsmon-cron.run" (dict "cron" $cron "Values" $.Values) | trim | nindent 18 }}
+          env:
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          ports:
+            - containerPort: {{ add 32501 (mul 2 $i)}} # spark.driver.port
+              name: port-1
+            - containerPort: {{ add 32502 (mul 2 $i)}} # spark.driver.blockManager.port
+              name: port-2
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 6Gi
+            requests:
+              cpu: 500m
+              memory: 750Mi
+          stdin: true
+          tty: true
+          volumeMounts:
+            - name: {{ $cron.name }}-secrets
+              mountPath: /etc/secrets
+              readOnly: true
+            {{- with $cron.eosEnabled}}
+            - name: eos # EOS access
+              mountPath: /eos
+              mountPropagation: HostToContainer
+            {{- end}}
+      volumes:
+        - name: {{ $cron.name }}-secrets
+          secret:
+            secretName: {{ $cron.name }}-secrets
+        {{- with $cron.eosEnabled}}
+        - name: eos
+          hostPath:
+            path: /var/eos
+        {{- end}}
+{{- end}}
+{{- end}}

--- a/helm/cmsmon-cron/values.yaml
+++ b/helm/cmsmon-cron/values.yaml
@@ -1,0 +1,80 @@
+image:
+  pullPolicy: Always
+
+# deploys Job instead of CronJob
+test:
+  enabled: true
+
+cronjob:
+  repository: registry.cern.ch/cmsmonitoring/cmsmon-hdfs:v0.3.6
+  crons:
+    "0":
+      name: cmsmon-rucio-daily
+      schedule: "07 08 * * *"
+      command: /data/CMSSpark/bin/cron4rucio_daily.sh
+      args: |-
+        --keytab /etc/secrets/keytab --output /cms/rucio_daily
+    "1":
+      name: cmsmon-crab-pop
+      eosEnabled: true
+      testFlagExists: true
+      schedule: "30 20 04 * *"
+      command: /data/CMSSpark/bin/cron4crab_popularity.sh
+      args: |-
+        --keytab /etc/secrets/keytab --output /eos/user/c/cmsmonit/www/crabPop/data 
+    "2":
+      name: cmsmon-crab-uu
+      eosEnabled: true
+      testFlagExists: true
+      schedule: "02 15 27 * *"
+      command: /data/CMSSpark/bin/cron4crab_unique_users.sh
+      args: |-
+        --keytab /etc/secrets/keytab --output /eos/user/c/cmsmonit/www/crab_uu
+    "3":
+      name: cmsmon-eos-data
+      eosEnabled: true
+      testFlagExists: true
+      schedule: "10 17 24 * *"
+      command: /data/CMSSpark/bin/cron4eos_dataset.sh
+      args: |-
+        --keytab /etc/secrets/keytab --output /eos/user/c/cmsmonit/www/EOS/data
+    "4":
+      name: cmsmon-gen-crsg
+      eosEnabled: true
+      testFlagExists: true
+      schedule: "00 14 05 * *"
+      command: /data/CMSSpark/bin/cron4gen_crsg_plots.sh
+      args: |-
+        --keytab /etc/secrets/keytab --output /eos/user/c/cmsmonit/www/EventCountPlots
+    "5":
+      name: cmsmon-hpc-cms
+      eosEnabled: true
+      testFlagExists: true
+      schedule: "00 15 03 * *"
+      command: /data/CMSSpark/bin/cron4hpc_at_cms.sh
+      args: |-
+        --keytab /etc/secrets/keytab --output /eos/user/c/cmsmonit/www/hpc
+    "6":
+      name: cmsmon-hpc-usage
+      eosEnabled: true
+      testFlagExists: true
+      schedule: "43 13 * * *"
+      command: /data/CMSSpark/bin/cron4hpc_usage.sh
+      args: |-
+        --keytab /etc/secrets/keytab --output /eos/user/c/cmsmonit/www/hpc_usage --url https://cmsdatapop.web.cern.ch/cmsdatapop/hpc_usage
+    "7":
+      name: cmsmon-hs06-cputime
+      eosEnabled: true
+      testFlagExists: true
+      schedule: "30 14 19 * *"
+      command: /data/CMSSpark/bin/cron4hs06_cputime_plot.sh
+      args: |-
+        --keytab /etc/secrets/keytab --output /eos/user/c/cmsmonit/www/hs06cputime
+    "8":
+      name: cmsmon-rucio-daily-stat
+      eosEnabled: true
+      testFlagExists: true
+      schedule: "0 8 * * *"
+      command: /data/CMSSpark/bin/cron4rucio_datasets_daily_stats.sh
+      args: |-
+        --keytab /etc/secrets/keytab --amq /etc/secrets/amq-creds.json --cmsmonitoring /data/CMSMonitoring.zip --stomp /data/stomp-v700.zip


### PR DESCRIPTION
#1214 @mrceyhun 
This helm chart simplifies deployment of multiple spark running cronjobs.
### Notes:
- Replaced `configMap.yaml`  with a script template in [_helpers.tpl](https://github.com/kyrylogy/CMSKubernetes/blob/3738f28285440bc074c7cdf9e7fbb2f980ce7a17/helm/cmsmon-cron/templates/_helpers.tpl#L65)
Command and arguments for each cronjob can be specified individually in corresponding fields.
- Added [test](https://github.com/kyrylogy/CMSKubernetes/blob/3738f28285440bc074c7cdf9e7fbb2f980ce7a17/helm/cmsmon-cron/values.yaml#L5) field to run cronjobs with `--test` flag
- EOS Access is granted to cronjobs with `eosEnabled` parameter
- **spark.driver** and **spark.driver.blockManager** pulled out to service field
- NodePorts are assigned according to the amount of cronjobs specified 
(However, I suggest looking at https://helm.sh/docs/chart_template_guide/functions_and_pipelines/#using-the-lookup-function to figure out which ports we can use and building on that)
### Install:
For now, directories for test output are not replaced by **test.Enabled** parameter so it should be specified directly in each cronjob.
`helm install crons cmsmon-crons/ --debug`
`helm list`
. . .
`helm uninstall crons`