### PR TITLE
Bump loki version and change logging level to warn

### DIFF
--- a/docker/loki/Dockerfile
+++ b/docker/loki/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:latest as go-builder
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 
 RUN apt-get update && apt-get install -y unzip
-RUN curl -ksLO https://github.com/grafana/loki/releases/download/v2.5.0/loki-linux-amd64.zip && \
+RUN curl -ksLO https://github.com/grafana/loki/releases/download/v2.6.1/loki-linux-amd64.zip && \
     unzip loki-linux-amd64.zip && mv loki-linux-amd64 loki
 
 FROM alpine:3.16

--- a/docker/promtail/Dockerfile
+++ b/docker/promtail/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:latest as go-builder
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 
 RUN apt-get update && apt-get install -y unzip
-RUN curl -ksLO https://github.com/grafana/loki/releases/download/v2.2.0/promtail-linux-amd64.zip && \
+RUN curl -ksLO https://github.com/grafana/loki/releases/download/v2.6.1/promtail-linux-amd64.zip && \
     unzip promtail-linux-amd64.zip && mv promtail-linux-amd64 promtail
 
 FROM debian:stable-slim

--- a/kubernetes/cmsweb/monitoring/loki.yaml
+++ b/kubernetes/cmsweb/monitoring/loki.yaml
@@ -39,6 +39,8 @@ spec:
         - /data/loki
         - -config.file
         - /etc/secrets/loki-config.yaml
+        - -log.level
+        - warn
         ports:
         - containerPort: 3100
         volumeMounts:


### PR DESCRIPTION
- Changed logging level to warn as discussed in `CMSKUBERNETES-178`
- Bumped the versions. It seems that no change affects current config and deployment: https://grafana.com/docs/loki/v2.6.x/upgrading/

fyi @muhammadimranfarooqi 