### PR TITLE
Increase mem limit to 5g of condor-cpu-eff pod

### DIFF
--- a/kubernetes/monitoring/services/condor-cpu-eff.yaml
+++ b/kubernetes/monitoring/services/condor-cpu-eff.yaml
@@ -80,7 +80,7 @@ spec:
           resources:
             limits:
               cpu: 2000m
-              memory: 2Gi
+              memory: 5Gi
             requests:
               cpu: 1000m
               memory: 750Mi


### PR DESCRIPTION
2g memory limit is not enough while writing results to EOS. Max limit is increased to 5g.