### PR TITLE
Increase polling cycle of liveness probes

### DIFF
--- a/kubernetes/cmsweb/services/reqmgr2ms-monitor.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-monitor.yaml
@@ -111,7 +111,8 @@ spec:
             - -verbose
             - "0"
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
+          timeoutSeconds: 5
         ports:
         - containerPort: 8248
           protocol: TCP

--- a/kubernetes/cmsweb/services/reqmgr2ms-output.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-output.yaml
@@ -111,7 +111,8 @@ spec:
             - -verbose
             - "0"
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
+          timeoutSeconds: 5
         ports:
         - containerPort: 8245
           protocol: TCP

--- a/kubernetes/cmsweb/services/reqmgr2ms-rulecleaner.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-rulecleaner.yaml
@@ -111,7 +111,8 @@ spec:
             - -verbose
             - "0"
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
+          timeoutSeconds: 5
         ports:
         - containerPort: 8244
           protocol: TCP

--- a/kubernetes/cmsweb/services/reqmgr2ms-transferor.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-transferor.yaml
@@ -111,7 +111,8 @@ spec:
             - -verbose
             - "0"
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
+          timeoutSeconds: 5
         ports:
         - containerPort: 8247
           protocol: TCP

--- a/kubernetes/cmsweb/services/reqmgr2ms-unmerged-t1.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-unmerged-t1.yaml
@@ -111,7 +111,8 @@ spec:
             - -verbose
             - "0"
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
+          timeoutSeconds: 5
         ports:
         - containerPort: 8242
           protocol: TCP

--- a/kubernetes/cmsweb/services/reqmgr2ms-unmerged-t2t3.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-unmerged-t2t3.yaml
@@ -111,7 +111,8 @@ spec:
             - -verbose
             - "0"
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
+          timeoutSeconds: 5
         ports:
         - containerPort: 8242
           protocol: TCP

--- a/kubernetes/cmsweb/services/reqmgr2ms-unmerged-t2t3us.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-unmerged-t2t3us.yaml
@@ -111,7 +111,8 @@ spec:
             - -verbose
             - "0"
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
+          timeoutSeconds: 5
         ports:
         - containerPort: 8242
           protocol: TCP

--- a/kubernetes/cmsweb/services/reqmon-tasks.yaml
+++ b/kubernetes/cmsweb/services/reqmon-tasks.yaml
@@ -81,7 +81,8 @@ spec:
             - -verbose
             - "0"
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
+          timeoutSeconds: 5
         command:
         - /bin/bash
         - /opt/setup-certs-and-run/setup-certs-and-run.sh

--- a/kubernetes/cmsweb/services/reqmon.yaml
+++ b/kubernetes/cmsweb/services/reqmon.yaml
@@ -101,7 +101,8 @@ spec:
             - -verbose
             - "0"
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
+          timeoutSeconds: 5
         ports:
         - containerPort: 8249
           protocol: TCP

--- a/kubernetes/cmsweb/services/t0_reqmon-tasks.yaml
+++ b/kubernetes/cmsweb/services/t0_reqmon-tasks.yaml
@@ -90,7 +90,8 @@ spec:
             - -verbose
             - "0"
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
+          timeoutSeconds: 5
         command:
         - /bin/bash
         - /opt/setup-certs-and-run/setup-certs-and-run.sh

--- a/kubernetes/cmsweb/services/t0_reqmon.yaml
+++ b/kubernetes/cmsweb/services/t0_reqmon.yaml
@@ -105,7 +105,8 @@ spec:
             - -verbose
             - "0"
           initialDelaySeconds: 60
-          periodSeconds: 10
+          periodSeconds: 30
+          timeoutSeconds: 5
         ports:
         - containerPort: 8243
           protocol: TCP

--- a/kubernetes/cmsweb/services/t0wmadatasvc.yaml
+++ b/kubernetes/cmsweb/services/t0wmadatasvc.yaml
@@ -105,7 +105,8 @@ spec:
             - -verbose
             - "0"
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
+          timeoutSeconds: 5
         ports:
         - containerPort: 8308
           protocol: TCP

--- a/kubernetes/cmsweb/services/wmstats.yaml
+++ b/kubernetes/cmsweb/services/wmstats.yaml
@@ -98,7 +98,8 @@ spec:
             path: /wmstats2go/healthz
             port: 8360
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
+          timeoutSeconds: 5
         resources:
           requests:
             memory: "256Mi"

--- a/kubernetes/cmsweb/services/workqueue.yaml
+++ b/kubernetes/cmsweb/services/workqueue.yaml
@@ -101,7 +101,8 @@ spec:
             - -verbose
             - "0"
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
+          timeoutSeconds: 5
         ports:
         - containerPort: 8240
           protocol: TCP


### PR DESCRIPTION
This PR increases the timeout from 1 second to 5 seconds for each service and increasing the polling cycle to 30 seconds.

Fixes https://github.com/dmwm/WMCore/issues/10223