### PR TITLE
Update sqoop pod for the new refactoring requirements

### DIFF
--- a/kubernetes/monitoring/deploy-secrets.sh
+++ b/kubernetes/monitoring/deploy-secrets.sh
@@ -147,7 +147,8 @@ elif [ "$secret" == "rucio-daily-stats-secrets" ]; then
 elif [ "$secret" == "sqoop-secrets" ]; then
     s_files=`ls $sdir/sqoop/ | awk '{ORS=" " ; print "--from-file="D"/"$1""}' D=$sdir/sqoop | sed "s, $,,g"`
     c_files=`ls $cdir/sqoop/ | awk '{ORS=" " ; print "--from-file="D"/"$1""}' D=$cdir/sqoop | sed "s, $,,g"`
-    files="${s_files} ${c_files}"
+    rucio_f=`ls $sdir/rucio/ | awk '{ORS=" " ; print "--from-file="D"/"$1""}' D=$sdir/rucio | sed "s, $,,g"`
+    files="${s_files} ${c_files} ${rucio_f}"
 fi
 echo "files: \"$files\""
 #echo "literals: $literals"

--- a/kubernetes/monitoring/services/sqoop.yaml
+++ b/kubernetes/monitoring/services/sqoop.yaml
@@ -4,36 +4,48 @@ metadata:
   name: sqoop
   namespace: sqoop
   labels:
-     app: sqoop
+    app: sqoop
 spec:
-   replicas: 1
-   selector:
-     matchLabels:
-       app: sqoop
-   template:
-      metadata:
-         labels:
-           app: sqoop
-      spec:
-        containers:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sqoop
+  template:
+    metadata:
+      labels:
+        app: sqoop
+    spec:
+      containers:
         - args:
-          - /data/sqoop/daemon.sh
-          - /data/sqoop/log
-          - "7"
-          - "7200"
-          image: registry.cern.ch/cmsmonitoring/sqoop:sqoop-0.0.8
+            - /data/sqoop/daemon.sh
+            - /data/sqoop/log
+            - "7"
+            - "7200"
+          image: registry.cern.ch/cmsmonitoring/sqoop:sqoop-0.1.0
           name: sqoop
+          env:
+            - name: CMSSQOOP_ENV
+              value: prod
+            - name: CMSSQOOP_CONFIGS
+              value: /data/sqoop/configs.json
+          # DEV TEST: secure testing which writes results to test dirs
+          # - name: CMSSQOOP_ENV
+          #   value: dev
+          # - name: CMSSQOOP_CONFIGS
+          #   value: /data/sqoop/configs-dev.json
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - "sh"
+                  - "-c"
+                  - >
+                    export > /etc/environment;
           volumeMounts:
-          - name: sqoop-secrets
-            mountPath: /etc/cmsdb
-            readOnly: true
-          - name: rucio-secrets
-            mountPath: /etc/secrets
-            readOnly: true
-        volumes:
+            - name: sqoop-secrets
+              mountPath: /etc/secrets
+              readOnly: true
+      volumes:
         - name: sqoop-secrets
           secret:
             secretName: sqoop-secrets
-        - name: rucio-secrets
-          secret:
-            secretName: rucio-secrets


### PR DESCRIPTION
It will be arranged after full tests. 
May be we can remove ConfigMap(HDFS out paths configs of the sqoop dumps) or we can keep it to show extended test possibilities. I am not sure, will consider later.