### PR TITLE
Fix ReqMgr2MS configuration file names in PyPi run.sh

### DIFF
--- a/docker/pypi/reqmgr2ms-monitor/run.sh
+++ b/docker/pypi/reqmgr2ms-monitor/run.sh
@@ -4,7 +4,7 @@
 srv=`echo $USER | sed -e "s,_,,g"`
 STATEDIR=/data/srv/state/$srv
 LOGDIR=/data/srv/logs/$srv
-CFGFILE=/etc/secrets/config.py
+CFGFILE=/etc/secrets/config-monitor.py
 
 mkdir -p /data/srv/logs/$srv
 mkdir -p /data/srv/state/$srv

--- a/docker/pypi/reqmgr2ms-output/run.sh
+++ b/docker/pypi/reqmgr2ms-output/run.sh
@@ -4,7 +4,7 @@
 srv=`echo $USER | sed -e "s,_,,g"`
 STATEDIR=/data/srv/state/$srv
 LOGDIR=/data/srv/logs/$srv
-CFGFILE=/etc/secrets/config.py
+CFGFILE=/etc/secrets/config-output.py
 
 mkdir -p /data/srv/logs/$srv
 mkdir -p /data/srv/state/$srv

--- a/docker/pypi/reqmgr2ms-rulecleaner/run.sh
+++ b/docker/pypi/reqmgr2ms-rulecleaner/run.sh
@@ -4,7 +4,7 @@
 srv=`echo $USER | sed -e "s,_,,g"`
 STATEDIR=/data/srv/state/$srv
 LOGDIR=/data/srv/logs/$srv
-CFGFILE=/etc/secrets/config.py
+CFGFILE=/etc/secrets/config-ruleCleaner.py
 
 mkdir -p /data/srv/logs/$srv
 mkdir -p /data/srv/state/$srv

--- a/docker/pypi/reqmgr2ms-transferor/run.sh
+++ b/docker/pypi/reqmgr2ms-transferor/run.sh
@@ -4,7 +4,7 @@
 srv=`echo $USER | sed -e "s,_,,g"`
 STATEDIR=/data/srv/state/$srv
 LOGDIR=/data/srv/logs/$srv
-CFGFILE=/etc/secrets/config.py
+CFGFILE=/etc/secrets/config-transferor.py
 
 mkdir -p /data/srv/logs/$srv
 mkdir -p /data/srv/state/$srv

--- a/docker/pypi/reqmgr2ms-unmerged/run.sh
+++ b/docker/pypi/reqmgr2ms-unmerged/run.sh
@@ -4,7 +4,7 @@
 srv=`echo $USER | sed -e "s,_,,g"`
 STATEDIR=/data/srv/state/$srv
 LOGDIR=/data/srv/logs/$srv
-CFGFILE=/etc/secrets/config.py
+CFGFILE=/etc/secrets/config-unmerged.py
 
 mkdir -p /data/srv/logs/$srv
 mkdir -p /data/srv/state/$srv


### PR DESCRIPTION
While trying to test the PyPi-based WMCore images discussed in this WMCore ticket:
https://github.com/dmwm/WMCore/issues/11354#issuecomment-1319168170

I noticed that all of the Microservices PODs fail to start (`CrashLoopBackOff`) and inspecting the logs, this is what is returned:
```
amaltaro@lxplus8s19:~/private/cmsweb-deploy/CMSKubernetes/kubernetes/cmsweb $ kubectl logs ms-transferor-7558cb86f6-hsb6t -n dmwm
...
/usr/local/bin/wmc-httpd: /etc/secrets/config.py: invalid configuration file
tail: cannot open '/data/srv/logs/reqmgr2ms/*.log' for reading: No such file or directory
```

With these changes we should be able to start those microservices successfully. I haven't tested it though because I think a new docker image is required(?)

@vkuznet can you please review and merge it? Thanks