### PR TITLE
Update WMCore microservices docker image name

### DIFF
--- a/kubernetes/cmsweb/services/reqmgr2ms-monitor.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-monitor.yaml
@@ -86,7 +86,7 @@ spec:
         runAsGroup: 1000
         fsGroup: 2000
       containers:
-      - image: registry.cern.ch/cmsweb/reqmgr2ms #imagetag
+      - image: registry.cern.ch/cmsweb/reqmgr2ms-monitor #imagetag
         name: ms-monitor
         lifecycle:
           postStart:

--- a/kubernetes/cmsweb/services/reqmgr2ms-output.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-output.yaml
@@ -86,7 +86,7 @@ spec:
         runAsGroup: 1000
         fsGroup: 2000
       containers:
-      - image: registry.cern.ch/cmsweb/reqmgr2ms #imagetag
+      - image: registry.cern.ch/cmsweb/reqmgr2ms-output #imagetag
         name: ms-output
         lifecycle:
           postStart:

--- a/kubernetes/cmsweb/services/reqmgr2ms-transferor.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-transferor.yaml
@@ -86,7 +86,7 @@ spec:
         runAsGroup: 1000
         fsGroup: 2000
       containers:
-      - image: registry.cern.ch/cmsweb/reqmgr2ms #imagetag
+      - image: registry.cern.ch/cmsweb/reqmgr2ms-transferor #imagetag
         name: ms-transferor
         lifecycle:
           postStart:


### PR DESCRIPTION
Changes related to the WMCore migration to pypi packaging, currently being discussed in:
https://github.com/dmwm/WMCore/issues/11354

This should not be merged until we can properly test these new docker image.