### PR TITLE
Adjust WMCore MS manifest files to work with RPM and pypi images

### DIFF
--- a/kubernetes/cmsweb/services/reqmgr2ms-monitor.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-monitor.yaml
@@ -86,7 +86,7 @@ spec:
         runAsGroup: 1000
         fsGroup: 2000
       containers:
-      - image: registry.cern.ch/cmsweb/reqmgr2ms #imagetag
+      - image: registry.cern.ch/cmsweb/reqmgr2ms-monitor #imagetag
         name: ms-monitor
         lifecycle:
           postStart:
@@ -124,6 +124,9 @@ spec:
         - /bin/bash
         - /opt/setup-certs-and-run/setup-certs-and-run.sh
         volumeMounts:
+        - name: rucio-secrets
+          mountPath: /opt/rucio/etc
+          readOnly: true
         - name: proxy-secrets
           mountPath: /etc/proxy
           readOnly: true
@@ -185,6 +188,9 @@ spec:
 #        image: busybox:1.28
 #        command: ['sh', '-c', 'until nslookup couchdb.couchdb; do echo "Waiting for couchdb"; sleep 10; done;']
       volumes:
+      - name: rucio-secrets
+        secret:
+          secretName: rucio-secrets
       - name: proxy-secrets
         secret:
           secretName: proxy-secrets

--- a/kubernetes/cmsweb/services/reqmgr2ms-output.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-output.yaml
@@ -86,7 +86,7 @@ spec:
         runAsGroup: 1000
         fsGroup: 2000
       containers:
-      - image: registry.cern.ch/cmsweb/reqmgr2ms #imagetag
+      - image: registry.cern.ch/cmsweb/reqmgr2ms-output #imagetag
         name: ms-output
         lifecycle:
           postStart:
@@ -124,6 +124,9 @@ spec:
         - /bin/bash
         - /opt/setup-certs-and-run/setup-certs-and-run.sh
         volumeMounts:
+        - name: rucio-secrets
+          mountPath: /opt/rucio/etc
+          readOnly: true
         - name: proxy-secrets
           mountPath: /etc/proxy
           readOnly: true
@@ -185,6 +188,9 @@ spec:
         image: busybox:1.28
         command: ['sh', '-c', 'until nslookup ms-output-mongo.dmwm; do echo "Waiting for ms-output-mongo"; sleep 10; done;']
       volumes:
+      - name: rucio-secrets
+        secret:
+          secretName: rucio-secrets
       - name: proxy-secrets
         secret:
           secretName: proxy-secrets

--- a/kubernetes/cmsweb/services/reqmgr2ms-rulecleaner.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-rulecleaner.yaml
@@ -86,7 +86,7 @@ spec:
         runAsGroup: 1000
         fsGroup: 2000
       containers:
-      - image: registry.cern.ch/cmsweb/reqmgr2ms #imagetag
+      - image: registry.cern.ch/cmsweb/reqmgr2ms-rulecleaner #imagetag
         name: ms-rulecleaner
         lifecycle:
           postStart:
@@ -124,6 +124,9 @@ spec:
         - /bin/bash
         - /opt/setup-certs-and-run/setup-certs-and-run.sh
         volumeMounts:
+        - name: rucio-secrets
+          mountPath: /opt/rucio/etc
+          readOnly: true
         - name: proxy-secrets
           mountPath: /etc/proxy
           readOnly: true
@@ -185,6 +188,9 @@ spec:
 #        image: busybox:1.28
 #        command: ['sh', '-c', 'until nslookup couchdb.couchdb; do echo "Waiting for couchdb"; sleep 10; done;']
       volumes:
+      - name: rucio-secrets
+        secret:
+          secretName: rucio-secrets
       - name: proxy-secrets
         secret:
           secretName: proxy-secrets

--- a/kubernetes/cmsweb/services/reqmgr2ms-transferor.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-transferor.yaml
@@ -86,7 +86,7 @@ spec:
         runAsGroup: 1000
         fsGroup: 2000
       containers:
-      - image: registry.cern.ch/cmsweb/reqmgr2ms #imagetag
+      - image: registry.cern.ch/cmsweb/reqmgr2ms-transferor #imagetag
         name: ms-transferor
         lifecycle:
           postStart:

--- a/kubernetes/cmsweb/services/reqmgr2ms-unmerged-t1.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-unmerged-t1.yaml
@@ -124,6 +124,9 @@ spec:
         - /bin/bash
         - /opt/setup-certs-and-run/setup-certs-and-run.sh
         volumeMounts:
+        - name: rucio-secrets
+          mountPath: /opt/rucio/etc
+          readOnly: true
         - name: proxy-secrets-ms-unmerged
           mountPath: /etc/proxy
           readOnly: true
@@ -181,6 +184,9 @@ spec:
 #PROD#  securityContext:
 #PROD#    allowPrivilegeEscalation: false
       volumes:
+      - name: rucio-secrets
+        secret:
+          secretName: rucio-secrets
       - name: proxy-secrets-ms-unmerged
         secret:
           secretName: proxy-secrets-ms-unmerged

--- a/kubernetes/cmsweb/services/reqmgr2ms-unmerged-t2t3.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-unmerged-t2t3.yaml
@@ -124,6 +124,9 @@ spec:
         - /bin/bash
         - /opt/setup-certs-and-run/setup-certs-and-run.sh
         volumeMounts:
+        - name: rucio-secrets
+          mountPath: /opt/rucio/etc
+          readOnly: true
         - name: proxy-secrets-ms-unmerged
           mountPath: /etc/proxy
           readOnly: true
@@ -181,6 +184,9 @@ spec:
 #PROD#  securityContext:
 #PROD#    allowPrivilegeEscalation: false
       volumes:
+      - name: rucio-secrets
+        secret:
+          secretName: rucio-secrets
       - name: proxy-secrets-ms-unmerged
         secret:
           secretName: proxy-secrets-ms-unmerged

--- a/kubernetes/cmsweb/services/reqmgr2ms-unmerged-t2t3us.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-unmerged-t2t3us.yaml
@@ -124,6 +124,9 @@ spec:
         - /bin/bash
         - /opt/setup-certs-and-run/setup-certs-and-run.sh
         volumeMounts:
+        - name: rucio-secrets
+          mountPath: /opt/rucio/etc
+          readOnly: true
         - name: proxy-secrets-ms-unmerged
           mountPath: /etc/proxy
           readOnly: true
@@ -181,6 +184,9 @@ spec:
 #PROD#  securityContext:
 #PROD#    allowPrivilegeEscalation: false
       volumes:
+      - name: rucio-secrets
+        secret:
+          secretName: rucio-secrets
       - name: proxy-secrets-ms-unmerged
         secret:
           secretName: proxy-secrets-ms-unmerged

--- a/kubernetes/cmsweb/services/t0_reqmon-tasks.yaml
+++ b/kubernetes/cmsweb/services/t0_reqmon-tasks.yaml
@@ -72,7 +72,7 @@ spec:
         runAsGroup: 1000
         fsGroup: 2000
       containers:
-      - image: registry.cern.ch/cmsweb/t0_reqmon #imagetag
+      - image: registry.cern.ch/cmsweb/reqmon #imagetag
         name: t0reqmon-tasks
 #PROD#  resources:
 #PROD#    requests:

--- a/kubernetes/cmsweb/services/t0_reqmon.yaml
+++ b/kubernetes/cmsweb/services/t0_reqmon.yaml
@@ -87,7 +87,7 @@ spec:
         runAsGroup: 1000
         fsGroup: 2000
       containers:
-      - image: registry.cern.ch/cmsweb/t0_reqmon #imagetag
+      - image: registry.cern.ch/cmsweb/reqmon #imagetag
         name: t0reqmon
 #PROD#  resources:
 #PROD#    requests:

--- a/kubernetes/cmsweb/services/workqueue.yaml
+++ b/kubernetes/cmsweb/services/workqueue.yaml
@@ -83,7 +83,7 @@ spec:
         runAsGroup: 1000
         fsGroup: 2000
       containers:
-      - image: registry.cern.ch/cmsweb/workqueue #imagetag
+      - image: registry.cern.ch/cmsweb/global-workqueue #imagetag
         name: workqueue
 #PROD#  resources:
 #PROD#    requests:

--- a/kubernetes/cmsweb/services/workqueue.yaml
+++ b/kubernetes/cmsweb/services/workqueue.yaml
@@ -110,6 +110,9 @@ spec:
         - /bin/bash
         - /opt/setup-certs-and-run/setup-certs-and-run.sh
         volumeMounts:
+        - name: rucio-secrets
+          mountPath: /opt/rucio/etc
+          readOnly: true
         - name: proxy-secrets
           mountPath: /etc/proxy
           readOnly: true
@@ -171,6 +174,9 @@ spec:
 #        image: busybox:1.28
 #        command: ['sh', '-c', 'until nslookup couchdb.couchdb; do echo "Waiting for couchdb"; sleep 10; done;']
       volumes:
+      - name: rucio-secrets
+        secret:
+          secretName: rucio-secrets
       - name: proxy-secrets
         secret:
           secretName: proxy-secrets


### PR DESCRIPTION
Adjust WMCore k8s manifest files to have common names for RPM based and PyPi based images (deployment procedure).