### PR TITLE
Deploy cert-checker to monitoring cluster to check all certs keytabs

### DIFF
--- a/kubernetes/monitoring/deploy-secrets.sh
+++ b/kubernetes/monitoring/deploy-secrets.sh
@@ -6,6 +6,7 @@
 ##H        alertmanager-secrets
 ##H        auth-secrets
 ##H        cern-certificates
+##H        cert-checker-secrets
 ##H        cron-size-quotas-secrets
 ##H        cron-spark-jobs-secrets
 ##H        condor-cpu-eff-secrets
@@ -166,6 +167,15 @@ elif [ "$secret" == "sqoop-secrets" ]; then
     c_files=`ls $cdir/sqoop/ | awk '{ORS=" " ; print "--from-file="D"/"$1""}' D=$cdir/sqoop | sed "s, $,,g"`
     rucio_f=`ls $sdir/rucio/ | awk '{ORS=" " ; print "--from-file="D"/"$1""}' D=$sdir/rucio | sed "s, $,,g"`
     files="${s_files} ${c_files} ${rucio_f}"
+elif [ "$secret" == "cert-checker-secrets" ]; then
+    robot_s="--from-file=${sdir}/robot/robotcert.pem --from-file=${sdir}/robot/robotkey.pem"
+    nats_s="--from-file=${sdir}/nats-cluster/server.pem --from-file=${sdir}/nats-cluster/server-key.pem"
+    training_s="--from-file=${sdir}/cms-training/robot-training-cert.pem --from-file=${sdir}/cms-training/robot-training-key.pem"
+    cms_mon_s="--from-file=${sdir}/cmsmon-auth/tls.crt --from-file=${sdir}/cmsmon-auth/tls.key"
+    cmsmonit_k="--from-file=cmsmonit_keytab=${sdir}/cmsmonit-keytab/keytab"
+    cmspopdb_k="--from-file=cmspopdb_keytab=${sdir}/cmspopdb-keytab/keytab"
+    sqoop_k="--from-file=sqoop_keytab=${sdir}/sqoop/keytab"
+    files="${robot_s} ${nats_s} ${training_s} ${cms_mon_s} ${cmsmonit_k} ${cmspopdb_k} ${sqoop_k}"
 fi
 echo "files: \"$files\""
 #echo "literals: $literals"

--- a/kubernetes/monitoring/services/cert-checker.yaml
+++ b/kubernetes/monitoring/services/cert-checker.yaml
@@ -1,0 +1,103 @@
+# Ref: kubernetes/cmsweb/services/cert-checker.yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: cert-checker
+  namespace: http
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8888
+      protocol: TCP
+      name: http
+  selector:
+    app: cert-checker
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: cert-checker
+  namespace: http
+  labels:
+    app: cert-checker
+data:
+  configs.json: |
+    [
+      {"cert": "/etc/secrets/robotcert.pem", "ckey": "/etc/secrets/robotkey.pem"},
+      {"cert": "/etc/secrets/server.pem", "ckey": "/etc/secrets/server-key.pem"},
+      {"cert": "/etc/secrets/robot-training-cert.pem", "ckey": "/etc/secrets/robot-training-key.pem"},
+      {"cert": "/etc/secrets/tls.crt", "ckey": "/etc/secrets/tls.key"},
+      {"cert": "/etc/secrets/tls.crt", "ckey": "/etc/secrets/tls.key"},
+      {"keytab": "/etc/secrets/cmsmonit_keytab"},
+      {"keytab": "/etc/secrets/cmspopdb_keytab"},
+      {"keytab": "/etc/secrets/sqoop_keytab"}
+    ]
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  labels:
+    app: cert-checker
+  name: cert-checker
+  namespace: http
+spec:
+  selector:
+    matchLabels:
+      app: cert-checker
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: cert-checker
+        env: k8s #k8s#
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: "8888"
+    spec:
+      containers:
+        - image: registry.cern.ch/cmsmonitoring/cert-checker #imagetag
+          name: cert-checker
+          imagePullPolicy: Always
+          command:
+            - /data/cert-checker
+            - -config
+            - /etc/config/configs.json
+            - -team
+            - "cmsmon"
+            - -httpPort
+            - "8888"
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: 8888
+            initialDelaySeconds: 3
+            periodSeconds: 600
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "300m"
+          ports:
+            - containerPort: 8888
+          volumeMounts:
+            - name: robot-secrets
+              mountPath: /etc/robots
+              readOnly: true
+            - name: cert-checker-secrets
+              mountPath: /etc/secrets
+              readOnly: true
+            - name: cert-checker-configmap
+              mountPath: /etc/config
+      volumes:
+        - name: robot-secrets
+          secret:
+            secretName: robot-secrets
+        - name: cert-checker-secrets
+          secret:
+            secretName: cert-checker-secrets
+        - name: cert-checker-configmap
+          configMap:
+            name: cert-checker


### PR DESCRIPTION
Cert-checker implementation to check all monitoring certificates and keytabs. Deployed in cmsmonitnew-cluster-vef5nqhek4nf-node-0:30901 . Metrics: `cert_valid_sec` , `keytab_valid_sec`.

Used repo: https://github.com/vkuznet/cert-checker with some modifications in https://github.com/vkuznet/cert-checker/pull/1.