### PR TITLE
Fix kube-state-metrics prom job conf

### DIFF
--- a/kubernetes/cmsweb/monitoring/prometheus/services/prometheus.yaml
+++ b/kubernetes/cmsweb/monitoring/prometheus/services/prometheus.yaml
@@ -51,13 +51,10 @@ scrape_configs:
 #             cluster: "be"
 
   - job_name: cern-magnum-kube-state-metrics
-    honor_timestamps: true
     scrape_interval: 1m
     scrape_timeout: 1m
-    metrics_path: /metrics
-    scheme: http
     static_configs:
-      - targets: [cern-magnum-kube-state-metrics.kube-system.svc.cluster.local:8080]
+      - targets: [ "cern-magnum-kube-state-metrics.kube-system.svc.cluster.local:8080" ]
 
   - job_name: "nginx-ingress-controller"
     kubernetes_sd_configs:


### PR DESCRIPTION
Fix for kube-state metrics, test6 prometheus, which has this conf, provides these metrics now.