### PR TITLE
Prepare prometheuses for https targets using proxy

### DIFF
--- a/kubernetes/monitoring/services/ha/prometheus-ha1.yaml
+++ b/kubernetes/monitoring/services/ha/prometheus-ha1.yaml
@@ -53,6 +53,8 @@ spec:
           - name: prometheus-secrets
             mountPath: /etc/prometheus
             readOnly: true
+          - name: proxy-secrets
+            mountPath: /etc/proxy
         volumes:
         - name: prometheus-secrets
           secret:
@@ -60,3 +62,6 @@ spec:
         - name: prometheus-volume
           persistentVolumeClaim:
             claimName: prometheus-volume-claim
+        - name: proxy-secrets
+          secret:
+            secretName: proxy-secrets

--- a/kubernetes/monitoring/services/ha/prometheus-ha2.yaml
+++ b/kubernetes/monitoring/services/ha/prometheus-ha2.yaml
@@ -53,6 +53,8 @@ spec:
           - name: prometheus-secrets
             mountPath: /etc/prometheus
             readOnly: true
+          - name: proxy-secrets
+            mountPath: /etc/proxy
         volumes:
         - name: prometheus-secrets
           secret:
@@ -60,3 +62,6 @@ spec:
         - name: prometheus-volume
           persistentVolumeClaim:
             claimName: prometheus-volume-claim
+        - name: proxy-secrets
+          secret:
+            secretName: proxy-secrets

--- a/kubernetes/monitoring/services/prometheus.yaml
+++ b/kubernetes/monitoring/services/prometheus.yaml
@@ -53,6 +53,8 @@ spec:
           - name: prometheus-secrets
             mountPath: /etc/prometheus
             readOnly: true
+          - name: proxy-secrets
+            mountPath: /etc/proxy
         volumes:
         - name: prometheus-secrets
           secret:
@@ -61,3 +63,6 @@ spec:
           persistentVolumeClaim:
             claimName: prom-volume-claim
 #             claimName: prometheus-volume-claim
+        - name: proxy-secrets
+          secret:
+            secretName: proxy-secrets


### PR DESCRIPTION
For `cherrypy` targets, we need to use proxy because of cmsweb***.cern.ch. This PR should be considered together with [cmsmon-configs for cherrypy targets](https://gitlab.cern.ch/cmsmonitoring/cmsmon-configs/-/merge_requests/33). Now we will have proxy crons in default ns too. 

Already deployed and accessible from HA1 prom https://cms-monitoring.cern.ch/ha1/prometheus/targets?search=#pool-dmwm-cherrypy