### PR TITLE
Add create_cluster_cron.sh and deploy-cron.sh for monitoring-vm-cron cluster

### DIFF
--- a/kubernetes/monitoring/create_cluster_cron.sh
+++ b/kubernetes/monitoring/create_cluster_cron.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
-# Creates Kubernetes cluster using openstack templates
+# Creates Kubernetes cluster using openstack templates for CRON
 # Please
 #   - find a latest kubernetes template and use it:
 #     * 'openstack coe cluster template list'
 #     * 'openstack coe cluster template show kubernetes-1.22.9-1 -f yaml'
 #   - Define your master and node counts
 #   - Define your master and node FLAVORS: 'openstack flavor list'
-#   - Define EOS enabled or not, default NOT.
+#   - Define EOS enabled or not, default is TRUE.
 #   - Define ingress controller, default NGINX; it can be traefik too!
 #
 
@@ -20,7 +20,7 @@ if [ "$1" == "-h" ] || [ "$1" == "-help" ] || [ "$1" == "--help" ] || [ "$1" == 
     exit 0
 fi
 echo "Creating cluster => NameSpace: ${namespace} , Name: ${name} , Template: ${template}"
-echo "Check if EOS enabled! HA clusters do not need but others may need."
+echo "Check if EOS enabled! CRON cluster needs it."
 
 sleep 10
 
@@ -29,14 +29,14 @@ openstack --os-project-name "$namespace" coe cluster create "$name" \
     --cluster-template "$template" \
     --master-count 1 \
     --master-flavor m2.large \
-    --node-count 3 \
+    --node-count 2 \
     --flavor m2.xlarge \
     --merge-labels \
     --labels cinder_csi_enabled="true" \
     --labels logging_include_internal="true" \
     --labels logging_http_destination="http://monit-logs.cern.ch:10012/" \
     --labels logging_installer=helm \
-    --labels eos_enabled="false" \
+    --labels eos_enabled="true" \
     --labels monitoring_enabled="true" \
     --labels logging_producer="cmswebk8s" \
     --labels ingress_controller="nginx" \
@@ -49,10 +49,10 @@ openstack --os-project-name "$namespace" coe cluster create "$name" \
 # openstack flavor list
 # openstack coe cluster delete "name of the cluster"
 # openstack coe cluster template list
-# ./deploy-ha.sh ha1 deploy-all
 # openstack coe cluster list
 # openstack coe cluster config "name of the cluster"
 # openstack server set --property landb-alias=YOUR-CLUSTER-ALIAS--load-0- [MINION-0]
 # openstack server set --property landb-alias=YOUR-CLUSTER-ALIAS--load-1- [MINION-1]
 # openstack server set --property landb-alias=YOUR-CLUSTER-ALIAS--load-2- [MINION-2]
-# k get volumeattachment
+# Check /eos/cms is there
+# k create -f https://gitlab.cern.ch/kubernetes/automation/charts/cern/raw/master/eosxd/examples/eos-client-example.yaml

--- a/kubernetes/monitoring/create_cluster_ha.sh
+++ b/kubernetes/monitoring/create_cluster_ha.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Creates Kubernetes cluster using openstack templates for HA
+# Please
+#   - find a latest kubernetes template and use it:
+#     * 'openstack coe cluster template list'
+#     * 'openstack coe cluster template show kubernetes-1.22.9-1 -f yaml'
+#   - Define your master and node counts
+#   - Define your master and node FLAVORS: 'openstack flavor list'
+#   - Define EOS enabled or not, default NOT.
+#   - Define ingress controller, default NGINX; it can be traefik too!
+#
+
+namespace=${OS_PROJECT_NAME:-"CMS Web"}
+name=$1
+template=${2:-"kubernetes-1.22.9-1"}
+
+usage="create_cluster.sh <name> <template_name, if not provided will use $template>"
+if [ "$1" == "-h" ] || [ "$1" == "-help" ] || [ "$1" == "--help" ] || [ "$1" == "help" ] || [ "$1" == "" ]; then
+    echo "$usage"
+    exit 0
+fi
+echo "Creating cluster => NameSpace: ${namespace} , Name: ${name} , Template: ${template}"
+echo "Check if EOS enabled! HA clusters do not need but others may need."
+
+sleep 10
+
+openstack --os-project-name "$namespace" coe cluster create "$name" \
+    --keypair cloud \
+    --cluster-template "$template" \
+    --master-count 1 \
+    --master-flavor m2.large \
+    --node-count 3 \
+    --flavor m2.xlarge \
+    --merge-labels \
+    --labels cinder_csi_enabled="true" \
+    --labels logging_include_internal="true" \
+    --labels logging_http_destination="http://monit-logs.cern.ch:10012/" \
+    --labels logging_installer=helm \
+    --labels eos_enabled="false" \
+    --labels monitoring_enabled="true" \
+    --labels logging_producer="cmswebk8s" \
+    --labels ingress_controller="nginx" \
+    --labels cern_enabled="true" \
+    --labels keystone_auth_enabled="true" \
+    --labels logging_type="http"
+
+# Ref: https://cms-http-group.docs.cern.ch/k8s_cluster/cmsweb-deployment/
+#                -- Helpful commands --
+# READ the DOC: https://cmsmonit-docs.web.cern.ch/k8s/cluster_upgrades/

--- a/kubernetes/monitoring/deploy-cron.sh
+++ b/kubernetes/monitoring/deploy-cron.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+# shellcheck disable=SC2181
+set -e
+##H Usage: deploy-cron.sh ACTION
+##H
+##H Examples:
+##H    --- If CMSKubernetes, cmsmon-configs and secrets repos are in same directory ---
+##H    deploy-cron.sh status
+##H    deploy-cron.sh deploy-secrets
+##H    deploy-cron.sh deploy-all
+##H    deploy-cron.sh clean-services
+##H    --- Else ---
+##H    export SECRETS_D=$SOMEDIR/secrets; export CONFIGS_D=$SOMEDIR/cmsmon-configs; deploy-cron.sh status
+##H
+##H Attention: this script depends on deploy-secrets.sh
+##H
+##H Actions:
+##H   help             show this help
+##H   clean-all        cleanup all services secrets cronjobs accounts
+##H   clean-services   cleanup services
+##H   clean-secrets    cleanup secrets
+##H   clean-storages   cleanup storages
+##H   status           check status of all cluster
+##H   deploy-all       deploy everything
+##H   deploy-secrets   deploy secrets
+##H   deploy-services  deploy services
+##H
+##H Environments:
+##H   SECRETS_D        defines secrets repository local path. (default CMSKubernetes parent dir)
+##H   CONFIGS_D        defines cmsmon-configs repository local path. (default CMSKubernetes parent dir)
+
+unset script_dir action cluster sdir cdir deploy_secrets_sh
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+
+# help definition
+if [ "$1" == "-h" ] || [ "$1" == "-help" ] || [ "$1" == "--help" ] || [ "$1" == "help" ] || [ "$1" == "" ]; then
+    grep "^##H" <"$0" | sed -e "s,##H,,g"
+    exit 1
+fi
+
+action=$1
+sdir=${SECRETS_D:-"${script_dir}/../../../secrets"}
+cdir=${CONFIGS_D:-"${script_dir}/../../../cmsmon-configs"}
+
+# deploy-secrets.sh temporary file
+deploy_secrets_sh="$script_dir"/__temp-deploy-secrets__.sh
+
+if [[ -z $action ]]; then
+    echo "action is not defined. action:${action}. Exiting with help message..."
+    grep "^##H" <"$0" | sed -e "s,##H,,g"
+    exit 1
+fi
+
+echo "will continue with following values:"
+echo "OS_PROJECT_NAME:${OS_PROJECT_NAME}, action: ${action}, secrets:${sdir}, cmsmon-configs:${cdir}"
+
+# ------------------------------------------ CHECKS -----------------------------------------------
+# Check status of the cluster
+function cluster_check() {
+    echo -e "\n*** check secrets"
+    kubectl get secrets -A | grep -E "default  *|http *|alerts *" | grep Opaque
+    echo -e "\n*** check svc"
+    kubectl get svc -A | grep -E "default  *|http *|alerts *"
+    echo -e "\n*** node status"
+    kubectl top node
+    echo -e "\n*** pods status"
+    kubectl top pods --sort-by=memory -A | grep -E "default  *|http *|alerts *"
+    kubectl get pods -A | grep -E "default  *|http *|alerts *"
+}
+# =================================================================================================
+
+# -------------------------------------- PREPARE deploy-secrets.sh -------------------------------
+# Create temporary deploy-secrets.sh with correct sdir and cdir
+function create_temp_deploy_secrets_sh() {
+    echo "secrets dir: ${sdir}, cmsmon-configs dir: ${cdir}"
+    #
+    if [ ! -e "$script_dir"/deploy-secrets.sh ] || [ ! -d "$sdir" ] || [ ! -d "$cdir" ]; then
+        echo "Please check if [deploy-secrets.sh:${script_dir}], [secrets:${sdir}], [cmsmon-configs:${cdir}] exist"
+        exit 1
+    fi
+    #
+    sed -e "s,cdir=cmsmon-configs.*,cdir=${cdir},g" \
+        -e "s,sdir=secrets.*,sdir=${sdir},g" \
+        "$script_dir"/deploy-secrets.sh >"$deploy_secrets_sh"
+    chmod +x "$deploy_secrets_sh"
+}
+
+# Delete temporary deploy-secrets.sh
+function rm_temp_deploy_secrets_sh() {
+    rm "$deploy_secrets_sh"
+}
+# =================================================================================================
+
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+function deploy_secrets() {
+    create_temp_deploy_secrets_sh
+    # hdfs
+    "$deploy_secrets_sh" hdfs proxy-secrets
+    "$deploy_secrets_sh" hdfs robot-secrets
+    "$deploy_secrets_sh" hdfs rucio-daily-stats-secrets
+    "$deploy_secrets_sh" hdfs condor-cpu-eff-secrets
+    "$deploy_secrets_sh" hdfs hpc-usage-secrets
+    "$deploy_secrets_sh" hdfs cron-size-quotas-secrets
+    "$deploy_secrets_sh" hdfs cron-spark-jobs-secrets
+    #
+    rm_temp_deploy_secrets_sh
+}
+function clean_secrets() {
+    # hdfs
+    kubectl -n hdfs --ignore-not-found=true delete secret proxy-secrets
+    kubectl -n hdfs --ignore-not-found=true delete secret robot-secrets
+    kubectl -n hdfs --ignore-not-found=true delete secret rucio-daily-stats-secrets
+    kubectl -n hdfs --ignore-not-found=true delete secret condor-cpu-eff-secrets
+    kubectl -n hdfs --ignore-not-found=true delete secret hpc-usage-secrets
+    kubectl -n hdfs --ignore-not-found=true delete secret cron-size-quotas-secrets
+    kubectl -n hdfs --ignore-not-found=true delete secret cron-spark-jobs-secrets
+}
+
+function deploy_services() {
+    # default
+    kubectl -n default apply -f services/pushgateway.yaml
+    # hdfs
+    kubectl -n hdfs apply -f crons/cron-proxy.yaml
+    kubectl -n hdfs apply -f services/cmsmon-hpc-usage.yaml
+    kubectl -n hdfs apply -f services/cmsmon-rucio-ds.yaml
+    kubectl -n hdfs apply -f services/condor-cpu-eff.yaml
+    kubectl -n hdfs apply -f services/cron-size-quotas.yaml
+    kubectl -n hdfs apply -f services/cron-spark-jobs.yaml
+}
+function clean_services() {
+    # default
+    kubectl -n default --ignore-not-found=true delete -f services/pushgateway.yaml
+    # hdfs
+    kubectl -n hdfs --ignore-not-found=true delete -f crons/cron-proxy.yaml
+    kubectl -n hdfs --ignore-not-found=true delete -f services/cmsmon-hpc-usage.yaml
+    kubectl -n hdfs --ignore-not-found=true delete -f services/cmsmon-rucio-ds.yaml
+    kubectl -n hdfs --ignore-not-found=true delete -f services/condor-cpu-eff.yaml
+    kubectl -n hdfs --ignore-not-found=true delete -f services/cron-size-quotas.yaml
+    kubectl -n hdfs --ignore-not-found=true delete -f services/cron-spark-jobs.yaml
+}
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MAIN ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+namespaces="hdfs"
+deploy_all() {
+    for _ns in $namespaces; do
+        if ! kubectl get ns | grep -q $_ns; then
+            kubectl create namespace $_ns
+        fi
+    done
+    deploy_secrets
+    deploy_services
+}
+
+clean_all() {
+    clean_services
+    sleep 10
+    clean_secrets
+    for _ns in $namespaces; do
+        if kubectl get ns | grep -q $_ns; then
+            kubectl --ignore-not-found=true delete namespace $_ns
+        fi
+    done
+
+}
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Main routine, perform action requested on command line.
+case ${action:-help} in
+"deploy-all")       deploy_all                            ;;
+"deploy-secrets")   deploy_secrets                        ;;
+"deploy-services")  deploy_services                       ;;
+"status")           cluster_check                         ;;
+"clean-all")        clean_all                             ;;
+"clean-services")   clean_services                        ;;
+"clean-secrets")    clean_secrets                         ;;
+"help")             grep "^##H" <"$0" | sed -e "s,##H,,g" ;;
+*)                  grep "^##H" <"$0" | sed -e "s,##H,,g" ;;
+esac


### PR DESCRIPTION
- New cluster `monitoring-vm-cron` is created to run our cron jobs that we are currently running in main cluster.
- It requires proxy and pushgateway additionally. This pushgateway will be added to HA prometheuses as a new target.
- New `cluster_create_cron.sh` used in cluster creation.
- New `deploy-cron.sh` is created.
- And some cosmetic changes for other scripts.

Services are not deployed yet. We are waiting Cloud Infrastructure team to enable `/eos/cms` in magnum eosxd pods, which is not available currently. It will be a hack for our cluster. It is because we did not want to wait prospected k8s template version to include `/eos/cms`, which can be `kubernetes-1.24 or 1.25` (informal hearing).