### PR TITLE
Some more changes to helm charts after the removal of helpers.tpl and some chart version upgrades to remove the persistent error messages.

### DIFF
--- a/helm/dbs2go-global-r/Chart.yaml
+++ b/helm/dbs2go-global-r/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/dbs2go-global-r/templates/deployment.yaml
+++ b/helm/dbs2go-global-r/templates/deployment.yaml
@@ -2,9 +2,9 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "dbs2go-global-r.fullname" . }}
+  name: dbs2go-global-r
   labels:
-    {{- include "dbs2go-global-r.labels" . | nindent 4 }}
+    app: dbs2go-global-r
   namespace: dbs
 spec:
   {{- if not .Values.autoscaling.enabled }}
@@ -16,7 +16,7 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      {{- include "dbs2go-global-r.selectorLabels" . | nindent 6 }}
+      app: dbs2go-global-r
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -24,7 +24,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "dbs2go-global-r.selectorLabels" . | nindent 8 }}
+        app: dbs2go-global-r
         env: k8s-{{.Values.environment}}
         job: dbs2go-global-r
     spec:
@@ -32,7 +32,6 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      #serviceAccountName: {{ include "dbs2go-global-r.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm/dbs2go-global-r/templates/service.yaml
+++ b/helm/dbs2go-global-r/templates/service.yaml
@@ -1,9 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "dbs2go-global-r.fullname" . }}
-  labels:
-    {{- include "dbs2go-global-r.labels" . | nindent 4 }}
+  name: dbs2go-global-r
+  namespace: dbs
 spec:
   selector:
     app: dbs2go-global-r

--- a/helm/dbs2go-global-w/Chart.yaml
+++ b/helm/dbs2go-global-w/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/dbs2go-global-w/templates/deployment.yaml
+++ b/helm/dbs2go-global-w/templates/deployment.yaml
@@ -2,9 +2,9 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "dbs2go-global-w.fullname" . }}
+  name: dbs2go-global-w
   labels:
-    {{- include "dbs2go-global-w.labels" . | nindent 4 }}
+    app: dbs2go-global-w
   namespace: dbs
 spec:
   {{- if not .Values.autoscaling.enabled }}
@@ -16,7 +16,7 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      {{- include "dbs2go-global-w.selectorLabels" . | nindent 6 }}
+      app: dbs2go-global-r
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -24,7 +24,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "dbs2go-global-w.selectorLabels" . | nindent 8 }}
+        app: dbs2go-global-r
         env: k8s-{{.Values.environment}}
         job: dbs2go-global-w
     spec:
@@ -32,7 +32,6 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "dbs2go-global-w.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm/dbs2go-global-w/templates/deployment.yaml
+++ b/helm/dbs2go-global-w/templates/deployment.yaml
@@ -16,7 +16,7 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      app: dbs2go-global-r
+      app: dbs2go-global-w
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -24,7 +24,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        app: dbs2go-global-r
+        app: dbs2go-global-w
         env: k8s-{{.Values.environment}}
         job: dbs2go-global-w
     spec:

--- a/helm/dbs2go-global-w/templates/service.yaml
+++ b/helm/dbs2go-global-w/templates/service.yaml
@@ -1,9 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "dbs2go-global-w.fullname" . }}
-  labels:
-    {{- include "dbs2go-global-w.labels" . | nindent 4 }}
+  name: dbs2go-global-w
+  namespace: dbs
 spec:
   selector:
     app: dbs2go-global-w

--- a/helm/dbs2go-phys03-r/Chart.yaml
+++ b/helm/dbs2go-phys03-r/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/dbs2go-phys03-r/templates/deployment.yaml
+++ b/helm/dbs2go-phys03-r/templates/deployment.yaml
@@ -2,9 +2,9 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "dbs2go-phys03-r.fullname" . }}
+  name: dbs2go-phys03-r
   labels:
-    {{- include "dbs2go-phys03-r.labels" . | nindent 4 }}
+    app: dbs2go-phys03-r
   namespace: dbs
 spec:
   {{- if not .Values.autoscaling.enabled }}
@@ -16,7 +16,7 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      {{- include "dbs2go-phys03-r.selectorLabels" . | nindent 6 }}
+      app: dbs2go-phys03-r
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -24,7 +24,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "dbs2go-phys03-r.selectorLabels" . | nindent 8 }}
+        app: dbs2go-phys03-r
         env: k8s-{{.Values.environment}}
         job: dbs2go-phys03-r
     spec:
@@ -32,7 +32,6 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "dbs2go-phys03-r.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
@@ -108,6 +107,12 @@ spec:
       - name: proxy-secrets
         secret:
           secretName: proxy-secrets
+      - name: robot-secrets
+        secret:
+          secretName: robot-secrets
+      - name: hmac-secrets
+        secret:
+          secretName: hmac-secrets
       - name: secrets
         secret:
           secretName: dbs2go-phys03-r-secrets
@@ -117,18 +122,6 @@ spec:
       - name: token-secrets
         secret:
           secretName: token-secrets   
-      - name: robot-secrets
-        secret:
-          secretName: robot-secrets
-      - name: hmac-secrets
-        secret:
-          secretName: hmac-secrets
-      - name: etc-grid-security
-        hostPath:
-            path: /etc/grid-security
-      - name: setup-certs-and-run
-        configMap:
-          name: {{ include "dbs2go-phys03-r.fullname" . }}
       {{- if or (eq (toString $environment) "prod") (eq (toString $environment) "preprod") }}
       - name: logs
         persistentVolumeClaim:

--- a/helm/dbs2go-phys03-r/templates/service.yaml
+++ b/helm/dbs2go-phys03-r/templates/service.yaml
@@ -1,9 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "dbs2go-phys03-r.fullname" . }}
-  labels:
-    {{- include "dbs2go-phys03-r.labels" . | nindent 4 }}
+  name: dbs2go-phys03-r
+  namespace: dbs
 spec:
   selector:
     app: dbs2go-phys03-r

--- a/helm/dbs2go-phys03-w/Chart.yaml
+++ b/helm/dbs2go-phys03-w/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/dbs2go-phys03-w/templates/deployment.yaml
+++ b/helm/dbs2go-phys03-w/templates/deployment.yaml
@@ -32,7 +32,6 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "dbs2go-phys03-w.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm/dbs2go-phys03-w/templates/deployment.yaml
+++ b/helm/dbs2go-phys03-w/templates/deployment.yaml
@@ -2,9 +2,9 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "dbs2go-phys03-w.fullname" . }}
+  name: dbs2go-phys03-w
   labels:
-    {{- include "dbs2go-phys03-w.labels" . | nindent 4 }}
+    app: dbs2go-phys03-w
   namespace: dbs
 spec:
   {{- if not .Values.autoscaling.enabled }}
@@ -16,7 +16,7 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      {{- include "dbs2go-phys03-w.selectorLabels" . | nindent 6 }}
+      app: dbs2go-phys03-w
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -24,7 +24,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "dbs2go-phys03-w.selectorLabels" . | nindent 8 }}
+        app: dbs2go-phys03-w
         env: k8s-{{.Values.environment}}
         job: dbs2go-phys03-w
     spec:

--- a/helm/dbs2go-phys03-w/templates/service.yaml
+++ b/helm/dbs2go-phys03-w/templates/service.yaml
@@ -1,9 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "dbs2go-phys03-w.fullname" . }}
-  labels:
-    {{- include "dbs2go-phys03-w.labels" . | nindent 4 }}
+  name: dbs2go-phys03-w
+  namespace: dbs
 spec:
   selector:
     app: dbs2go-phys03-w

--- a/helm/dbs2go/Chart.yaml
+++ b/helm/dbs2go/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
```
[apervaiz@lxplus8s16 helm]$ k get pods -n dbs
NAME                               READY   STATUS      RESTARTS   AGE
cron-proxy-27846725--1-w27qd       0/1     Completed   0          15h
cron-proxy-27847085--1-vz5p4       0/1     Completed   0          9h
cron-proxy-27847445--1-kf2jn       0/1     Completed   0          3h20m
cron-token-27847605--1-8d7fv       0/1     Completed   0          40m
cron-token-27847635--1-w92dc       0/1     Completed   0          10m
dbs2go-global-r-c64959f5c-7lhr4    2/2     Running     0          93s
dbs2go-global-r-c64959f5c-fs7kr    2/2     Running     0          93s
dbs2go-global-r-c64959f5c-gqlfg    0/2     Pending     0          93s
dbs2go-global-r-c64959f5c-mp9zj    0/2     Pending     0          93s
dbs2go-global-r-c64959f5c-mspjk    2/2     Running     0          93s
dbs2go-global-w-5fbf4ff47b-67wws   2/2     Running     0          84s
dbs2go-global-w-5fbf4ff47b-qtvzw   2/2     Running     0          84s
dbs2go-global-w-5fbf4ff47b-wkdfh   2/2     Running     0          84s
dbs2go-phys03-r-74f9d9dd4d-dgj2b   2/2     Running     0          29m
dbs2go-phys03-r-74f9d9dd4d-hnvp9   2/2     Running     0          3m37s
dbs2go-phys03-r-74f9d9dd4d-tv5sc   2/2     Running     0          29m
dbs2go-phys03-r-74f9d9dd4d-vmtgj   2/2     Running     0          29m
dbs2go-phys03-r-74f9d9dd4d-zgrsz   2/2     Running     0          29m
dbs2go-phys03-w-797fc7b78-jq8wp    2/2     Running     0          9s
dbs2go-phys03-w-797fc7b78-n29zc    2/2     Running     0          9s
dbs2go-phys03-w-797fc7b78-qbcls    2/2     Running     0          9s
[apervaiz@lxplus8s16 helm]$

```