### PR TITLE
Refactor and centralize rucio dataset monitoring

### DIFF
--- a/docker/cmsmon-spark/README.md
+++ b/docker/cmsmon-spark/README.md
@@ -19,7 +19,7 @@ Installs:
 ```shell
 # docker image prune -a OR docker system prune -f -a
 docker_registry=registry.cern.ch/cmsmonitoring
-image_tag=20220904
-docker build -t "${docker_registry}/cmsmon-hdfs:${image_tag}" .
-docker push "${docker_registry}/cmsmon-hdfs:${image_tag}"
+image_tag=v0.0.0.test
+docker build -t "${docker_registry}/cmsmon-spark:${image_tag}" .
+docker push "${docker_registry}/cmsmon-spark:${image_tag}"
 ```

--- a/docker/rucio-dataset-monitoring/Dockerfile-rucio-mon-goweb
+++ b/docker/rucio-dataset-monitoring/Dockerfile-rucio-mon-goweb
@@ -8,7 +8,8 @@ ENV WDIR=/data
 # build
 WORKDIR $GOPATH/src/github.com/dmwm
 RUN git clone https://github.com/dmwm/CMSMonitoring.git && cd CMSMonitoring && git checkout tags/$CMSMON_TAG -b build
-WORKDIR $GOPATH/src/github.com/dmwm/CMSMonitoring/src/go/rucio-dataset-monitoring
+WORKDIR $GOPATH/src/github.com/dmwm/CMSMonitoring/rucio-dataset-monitoring
+
 RUN mkdir -p $WDIR && make && cp -r rucio-dataset-monitoring static config.json $WDIR
 
 FROM gcr.io/distroless/base

--- a/docker/rucio-dataset-monitoring/Dockerfile-spark2mng
+++ b/docker/rucio-dataset-monitoring/Dockerfile-spark2mng
@@ -1,16 +1,16 @@
-# cmsmon-spark2mng
+# spark2mng
 FROM mongo as builder
 FROM registry.cern.ch/cmsmonitoring/cmsmon-hadoop-base:spark3-latest
 MAINTAINER Ceyhun Uzunoglu ceyhunuzngl@gmail.com
 
 # tag to use
-ARG CMSSPARK_TAG=0.0.0
+ENV CMSMON_TAG=rgo-0.0.0
 ENV WDIR=/data
 WORKDIR $WDIR
 
 ENV HADOOP_CONF_DIR=/etc/hadoop/conf
-ENV PATH="${PATH}:/usr/hdp/hadoop/bin/hadoop:/usr/hdp/spark3/bin:/usr/hdp/sqoop/bin:${WDIR}/CMSSpark/bin"
-ENV PYTHONPATH "${PYTHONPATH}:${WDIR}:${WDIR}/CMSSpark/src/python:${WDIR}/CMSMonitoring/src/python"
+ENV PATH="${PATH}:/usr/hdp/hadoop/bin/hadoop:/usr/hdp/spark3/bin:/usr/hdp/sqoop/bin:${WDIR}/CMSMonitoring/rucio-dataset-monitoring/spark"
+ENV PYTHONPATH "${PYTHONPATH}:${WDIR}:${WDIR}/CMSMonitoring/src/python:${WDIR}/CMSMonitoring/rucio-dataset-monitoring/spark"
 
 # How to find: source LCG102 hadoop setup, which python, ln -ls python, voila!
 ENV PYSPARK_PYTHON=/cvmfs/sft.cern.ch/lcg/releases/Python/3.9.12-9a1bc/x86_64-centos7-gcc8-opt/bin/python3
@@ -21,11 +21,12 @@ COPY --from=builder /usr/bin/mongoimport $WDIR
 COPY --from=builder /usr/bin/mongosh $WDIR
 
 RUN mkdir -p $WDIR/logs && \
-    git clone https://github.com/dmwm/CMSSpark.git && cd CMSSpark && git checkout tags/$CMSSPARK_TAG -b build && cd .. && \
-    git clone https://github.com/dmwm/CMSMonitoring.git && \
+    git clone https://github.com/dmwm/CMSMonitoring.git && cd CMSMonitoring && git checkout tags/$CMSMON_TAG -b build && cd .. && \
     zip -r CMSMonitoring.zip CMSMonitoring/src/python/CMSMonitoring/* && \
     pip install --no-cache-dir stomp.py==7.0.0 click pyspark pandas numpy schema seaborn matplotlib plotly && \
     hadoop-set-default-conf.sh analytix && source hadoop-setconf.sh analytix 3.2 spark3
+
+WORKDIR $WDIR
 
 # Run crond
 CMD ["crond", "-n", "-s", "&"]

--- a/docker/rucio-dataset-monitoring/README.md
+++ b/docker/rucio-dataset-monitoring/README.md
@@ -1,4 +1,8 @@
-## cmsmon-rucio-mon-goweb
+# rucio-mon-goweb and spark2mng
+
+Build by dmwm/CMSMonitoring GH workflows
+
+## rucio-mon-goweb
 
 Notes:
 - Built by github wf

--- a/kubernetes/monitoring/services/datasetmon/rucio-mon-goweb.yaml
+++ b/kubernetes/monitoring/services/datasetmon/rucio-mon-goweb.yaml
@@ -1,11 +1,11 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: cmsmon-rucio-mon-goweb
+  name: rucio-mon-goweb
   namespace: datasetmon
 spec:
   selector:
-    app: cmsmon-rucio-mon-goweb
+    app: rucio-mon-goweb
   type: NodePort
   ports:
     - port: 8080
@@ -16,10 +16,10 @@ spec:
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: cmsmon-rucio-mon-goweb
+  name: rucio-mon-goweb
   namespace: datasetmon
   labels:
-    app: cmsmon-rucio-mon-goweb
+    app: rucio-mon-goweb
 data:
   config.json: |
     {
@@ -49,22 +49,22 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   labels:
-    app: cmsmon-rucio-mon-goweb
-  name: cmsmon-rucio-mon-goweb
+    app: rucio-mon-goweb
+  name: rucio-mon-goweb
   namespace: datasetmon
 spec:
   selector:
     matchLabels:
-      app: cmsmon-rucio-mon-goweb
+      app: rucio-mon-goweb
   replicas: 1
   template:
     metadata:
       labels:
-        app: cmsmon-rucio-mon-goweb
+        app: rucio-mon-goweb
     spec:
       containers:
-      - name: cmsmon-rucio-mon-goweb
-        image: registry.cern.ch/cmsmonitoring/cmsmon-rucio-mon-goweb:rgo-0.0.1
+      - name: rucio-mon-goweb
+        image: registry.cern.ch/cmsmonitoring/rucio-mon-goweb:rgo-0.0.1
         imagePullPolicy: Always
         args:
           - /data/rucio-dataset-monitoring
@@ -97,4 +97,4 @@ spec:
           defaultMode: 0444
       - name: configmap-config-json
         configMap:
-          name: cmsmon-rucio-mon-goweb
+          name: rucio-mon-goweb

--- a/kubernetes/monitoring/services/datasetmon/spark2mng.yaml
+++ b/kubernetes/monitoring/services/datasetmon/spark2mng.yaml
@@ -1,11 +1,11 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: cmsmon-rucio-spark2mng
+  name: spark2mng
   namespace: datasetmon
 spec:
   selector:
-    app: cmsmon-rucio-spark2mng
+    app: spark2mng
   type: NodePort
   ports:
     - name: port-0 # spark.driver.port
@@ -22,16 +22,16 @@ spec:
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: cm-cmsmon-rucio-spark2mng
+  name: cm-spark2mng
   namespace: datasetmon
   labels:
-    app: cmsmon-rucio-spark2mng
+    app: spark2mng
 data:
   run_spark2hdfs.sh: |
     #!/bin/bash
     . /etc/environment
     echo "Starting run_spark2hdfs.sh ..."
-    /data/CMSSpark/bin/datasetmon/cron4rucio_spark2hdfs.sh \
+    /data/CMSMonitoring/rucio-dataset-monitoring/spark/cron4rucio_spark2hdfs.sh \
       --keytab /etc/secrets/keytab --hdfs /tmp/cmsmonit/prod \
       --p1 $CMSMON_RUCIO_SPARK2MNG_SERVICE_PORT_PORT_0 \
       --p2 $CMSMON_RUCIO_SPARK2MNG_SERVICE_PORT_PORT_1 \
@@ -40,7 +40,7 @@ data:
     #!/bin/bash
     . /etc/environment
     echo "Starting run_hdfs2mongo.sh ... "
-    /data/CMSSpark/bin/datasetmon/cron4rucio_hdfs2mongo.sh \
+    /data/CMSMonitoring/rucio-dataset-monitoring/spark/cron4rucio_hdfs2mongo.sh \
       --keytab /etc/secrets/keytab --hdfs /tmp/cmsmonit/prod \
       --mongohost "mongodb-0.mongodb.datasetmon.svc.cluster.local" \
       --mongoport "27017" \
@@ -53,7 +53,7 @@ data:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: cmsmon-rucio-spark2mng
+  name: spark2mng
   namespace: datasetmon
 spec:
   # UTC
@@ -66,13 +66,13 @@ spec:
       template:
         metadata:
           labels:
-            app: cmsmon-rucio-spark2mng
+            app: spark2mng
         spec:
           restartPolicy: Never
-          hostname: cmsmon-rucio-spark2mng
+          hostname: spark2mng
           containers:
-            - name: cmsmon-rucio-spark2mng
-              image: registry.cern.ch/cmsmonitoring/cmsmon-spark2mng:v0.4.0.14
+            - name: spark2mng
+              image: registry.cern.ch/cmsmonitoring/spark2mng:rgo-0.0.1
               imagePullPolicy: Always
               command: [ "/bin/bash", "-c" ]
               args:
@@ -136,5 +136,5 @@ spec:
                 defaultMode: 0444
             - name: cronjobs-configmap
               configMap:
-                name: cm-cmsmon-rucio-spark2mng
+                name: cm-spark2mng
                 defaultMode: 0777


### PR DESCRIPTION
Renaming and tag changes for both "spark to mongo" and go web services of rucio dataset monitoring services.