### PR TITLE
Use reqmon PyPi package to build t0_reqmon docker image

### DIFF
--- a/docker/pypi/t0_reqmon/Dockerfile
+++ b/docker/pypi/t0_reqmon/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20221129
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 ENV TAG=2.1.4
-RUN pip install t0_reqmon==$TAG
+RUN pip install reqmon==$TAG
 ENV WDIR=/data
 ENV USER=_t0_reqmon
 RUN useradd ${USER} && install -o ${USER} -d ${WDIR}

--- a/kubernetes/cmsweb/services/t0_reqmon-tasks.yaml
+++ b/kubernetes/cmsweb/services/t0_reqmon-tasks.yaml
@@ -72,7 +72,7 @@ spec:
         runAsGroup: 1000
         fsGroup: 2000
       containers:
-      - image: registry.cern.ch/cmsweb/reqmon #imagetag
+      - image: registry.cern.ch/cmsweb/t0_reqmon #imagetag
         name: t0reqmon-tasks
 #PROD#  resources:
 #PROD#    requests:

--- a/kubernetes/cmsweb/services/t0_reqmon.yaml
+++ b/kubernetes/cmsweb/services/t0_reqmon.yaml
@@ -87,7 +87,7 @@ spec:
         runAsGroup: 1000
         fsGroup: 2000
       containers:
-      - image: registry.cern.ch/cmsweb/reqmon #imagetag
+      - image: registry.cern.ch/cmsweb/t0_reqmon #imagetag
         name: t0reqmon
 #PROD#  resources:
 #PROD#    requests:


### PR DESCRIPTION
Related to https://github.com/dmwm/WMCore/issues/11390
and rolling back a change from: https://github.com/dmwm/CMSKubernetes/pull/1261

As Valentin noticed, the `t0_reqmon` service - Pypi-based - fails to start up because it actually has the `reqmon` log instead of `t0reqmon` one, which is defined by the `run.sh` script.

@vkuznet please let me know what you think.