### PR TITLE
Consolidate run.sh script for the pypi docker images

### DIFF
--- a/docker/pypi/dmwm-base/run.sh
+++ b/docker/pypi/dmwm-base/run.sh
@@ -65,4 +65,6 @@ done
 export PYTHONPATH=$PYTHONPATH:/etc/secrets:$AUTHDIR/$fname
 
 # start the service
-nohup wmc-httpd -r -d $STATEDIR -l "|rotatelogs $LOGDIR/$srv-%Y%m%d-`hostname -s`.log 86400" $CFGFILE &
+wmc-httpd -r -d $STATEDIR -l "|rotatelogs $LOGDIR/$srv-%Y%m%d-`hostname -s`.log 86400" $CFGFILE
+# hack to keep the container running
+tail -f /etc/hosts

--- a/docker/pypi/dmwm-base/run.sh
+++ b/docker/pypi/dmwm-base/run.sh
@@ -13,14 +13,14 @@ mkdir -p $LOGDIR
 mkdir -p $STATEDIR
 mkdir -p $AUTHDIR
 mkdir -p $CONFIGDIR
-mkdir -p $AUTHDIR/proxy
 mkdir -p $AUTHDIR/../wmcore-auth
 
 # environment variables required to run some of the WMCore services
 export REQMGR_CACHE_DIR=$STATEDIR
 export WMCORE_CACHE_DIR=$STATEDIR
 
-# overwrite host PEM files in /data/srv area
+# overwrite host PEM files in /data/srv area by the robot certificate
+# Note that the proxy file is not required and used
 if [ -f /etc/robots/robotkey.pem ]; then
     sudo cp /etc/robots/robotkey.pem $AUTHDIR/dmwm-service-key.pem
     sudo cp /etc/robots/robotcert.pem $AUTHDIR/dmwm-service-cert.pem
@@ -34,29 +34,10 @@ if [ -e $AUTHDIR/dmwm-service-cert.pem ] && [ -e $AUTHDIR/dmwm-service-key.pem ]
     export X509_USER_KEY=$AUTHDIR/dmwm-service-key.pem
 fi
 
-# overwrite proxy if it is present in /etc/proxy
-if [ -f /etc/proxy/proxy ]; then
-    sudo cp /etc/proxy/proxy $AUTHDIR/proxy/proxy
-    export X509_USER_PROXY=$AUTHDIR/proxy/proxy
-fi
-
 # overwrite header-auth key file with one from secrets
-
 if [ -f /etc/hmac/hmac ]; then
-    if [ -f $AUTHDIR/../header-auth-key ]; then
-        sudo rm $AUTHDIR/../header-auth-key
-    fi
     sudo cp /etc/hmac/hmac $AUTHDIR/../wmcore-auth/header-auth-key
-    sudo chown $USER.$USER $AUTHDIR/../wmcore-auth/header-auth-key
-
-    if [ -f $AUTHDIR/header-auth-key ]; then
-        sudo rm $AUTHDIR/header-auth-key
-    fi
-    sudo cp /etc/hmac/hmac $AUTHDIR/header-auth-key
-    sudo chown $USER.$USER $AUTHDIR/header-auth-key
-    # why do we need this hmac file at /auth directory as well?
-    sudo mkdir -p /auth/wmcore-auth
-    sudo ln -s /data/srv/current/auth/$srv/header-auth-key /auth/wmcore-auth/header-auth-key
+    sudo chown 0600 $USER.$USER $AUTHDIR/../wmcore-auth/header-auth-key
 fi
 
 # use service configuration files from /etc/secrets if they are present
@@ -84,4 +65,4 @@ done
 export PYTHONPATH=$PYTHONPATH:/etc/secrets:$AUTHDIR/$fname
 
 # start the service
-wmc-httpd -r -d $STATEDIR -l "|rotatelogs $LOGDIR/$srv-%Y%m%d-`hostname -s`.log 86400" $CFGFILE
+nohup wmc-httpd -r -d $STATEDIR -l "|rotatelogs $LOGDIR/$srv-%Y%m%d-`hostname -s`.log 86400" $CFGFILE &

--- a/docker/pypi/dmwm-base/run.sh
+++ b/docker/pypi/dmwm-base/run.sh
@@ -4,28 +4,31 @@
 srv=`echo $USER | sed -e "s,_,,g"`
 STATEDIR=/data/srv/state/$srv
 LOGDIR=/data/srv/logs/$srv
+AUTHDIR=/data/srv/current/auth/$srv
+CONFIGDIR=/data/srv/current/config/$srv
 CONFIGFILE=${CONFIGFILE:-config.py}
 CFGFILE=/etc/secrets/$CONFIGFILE
 
-mkdir -p /data/srv/logs/$srv
-mkdir -p /data/srv/state/$srv
-mkdir -p /data/srv/current/auth/$srv
-mkdir -p /data/srv/current/config/$srv
-mkdir -p /data/srv/current/auth/proxy
-mkdir -p /data/srv/current/auth/wmcore-auth
+mkdir -p $LOGDIR
+mkdir -p $STATEDIR
+mkdir -p $AUTHDIR
+mkdir -p $CONFIGDIR
+mkdir -p $AUTHDIR/proxy
+mkdir -p $AUTHDIR/../wmcore-auth
 
-# overwrite host PEM files in /data/srv area
-
-if [ -f /etc/robots/robotkey.pem ]; then
-    sudo cp /etc/robots/robotkey.pem /data/srv/current/auth/$srv/dmwm-service-key.pem
-    sudo cp /etc/robots/robotcert.pem /data/srv/current/auth/$srv/dmwm-service-cert.pem
-    sudo chown $USER.$USER /data/srv/current/auth/$srv/dmwm-service-key.pem
-    sudo chown $USER.$USER /data/srv/current/auth/$srv/dmwm-service-cert.pem
-    sudo chmod 0400 /data/srv/current/auth/$srv/dmwm-service-key.pem
-fi
-AUTHDIR=/data/srv/current/auth/$srv
+# environment variables required to run some of the WMCore services
 export REQMGR_CACHE_DIR=$STATEDIR
 export WMCORE_CACHE_DIR=$STATEDIR
+
+# overwrite host PEM files in /data/srv area
+if [ -f /etc/robots/robotkey.pem ]; then
+    sudo cp /etc/robots/robotkey.pem $AUTHDIR/dmwm-service-key.pem
+    sudo cp /etc/robots/robotcert.pem $AUTHDIR/dmwm-service-cert.pem
+    sudo chown $USER.$USER $AUTHDIR/dmwm-service-key.pem
+    sudo chown $USER.$USER $AUTHDIR/dmwm-service-cert.pem
+    sudo chmod 0400 $AUTHDIR/dmwm-service-key.pem
+fi
+
 if [ -e $AUTHDIR/dmwm-service-cert.pem ] && [ -e $AUTHDIR/dmwm-service-key.pem ]; then
     export X509_USER_CERT=$AUTHDIR/dmwm-service-cert.pem
     export X509_USER_KEY=$AUTHDIR/dmwm-service-key.pem
@@ -33,69 +36,52 @@ fi
 
 # overwrite proxy if it is present in /etc/proxy
 if [ -f /etc/proxy/proxy ]; then
-    export X509_USER_PROXY=/etc/proxy/proxy
-    mkdir -p /data/srv/state/$srv/proxy
-    if [ -f /data/srv/state/$srv/proxy/proxy.cert ]; then
-        rm /data/srv/state/$srv/proxy/proxy.cert
-    fi
-    ln -s /etc/proxy/proxy /data/srv/state/$srv/proxy/proxy.cert
-    if [ -f /data/srv/state/$srv/proxy/proxy.key ]; then
-        rm /data/srv/state/$srv/proxy/proxy.key
-    fi
-    sudo cp /etc/proxy/proxy /data/srv/state/reqmgr2ms/proxy/proxy.key
-    sudo chmod 400 /data/srv/state/reqmgr2ms/proxy/proxy.key
-    mkdir -p /data/srv/current/auth/proxy
-    if [ -f /data/srv/current/auth/proxy/proxy ]; then
-        rm /data/srv/current/auth/proxy/proxy
-    fi
-    ln -s /etc/proxy/proxy /data/srv/current/auth/proxy/proxy
+    sudo cp /etc/proxy/proxy $AUTHDIR/proxy/proxy
+    export X509_USER_PROXY=$AUTHDIR/proxy/proxy
 fi
 
 # overwrite header-auth key file with one from secrets
 
 if [ -f /etc/hmac/hmac ]; then
-    mkdir -p /data/srv/current/auth/wmcore-auth
-    if [ -f /data/srv/current/auth/wmcore-auth/header-auth-key ]; then
-        sudo rm /data/srv/current/auth/wmcore-auth/header-auth-key
+    if [ -f $AUTHDIR/../header-auth-key ]; then
+        sudo rm $AUTHDIR/../header-auth-key
     fi
-    sudo cp /etc/hmac/hmac /data/srv/current/auth/wmcore-auth/header-auth-key
-    sudo chown $USER.$USER /data/srv/current/auth/wmcore-auth/header-auth-key
-    mkdir -p /data/srv/current/auth/$srv
-    if [ -f /data/srv/current/auth/$srv/header-auth-key ]; then
-        sudo rm /data/srv/current/auth/$srv/header-auth-key
+    sudo cp /etc/hmac/hmac $AUTHDIR/../wmcore-auth/header-auth-key
+    sudo chown $USER.$USER $AUTHDIR/../wmcore-auth/header-auth-key
+
+    if [ -f $AUTHDIR/header-auth-key ]; then
+        sudo rm $AUTHDIR/header-auth-key
     fi
-    sudo cp /etc/hmac/hmac /data/srv/current/auth/$srv/header-auth-key
-    sudo chown $USER.$USER /data/srv/current/auth/$srv/header-auth-key
+    sudo cp /etc/hmac/hmac $AUTHDIR/header-auth-key
+    sudo chown $USER.$USER $AUTHDIR/header-auth-key
+    # why do we need this hmac file at /auth directory as well?
     sudo mkdir -p /auth/wmcore-auth
     sudo ln -s /data/srv/current/auth/$srv/header-auth-key /auth/wmcore-auth/header-auth-key
 fi
 
 # use service configuration files from /etc/secrets if they are present
-cdir=/data/srv/current/config/$srv
 files=`ls /etc/secrets`
 for fname in $files; do
     if [ -f /etc/secrets/$fname ]; then
-        if [ -f $cdir/$fname ]; then
-            rm $cdir/$fname
+        if [ -f $CONFIGDIR/$fname ]; then
+            rm $CONFIGDIR/$fname
         fi
-        sudo cp /etc/secrets/$fname $cdir/$fname
-        sudo chown $USER.$USER $cdir/$fname
+        sudo cp /etc/secrets/$fname $CONFIGDIR/$fname
+        sudo chown $USER.$USER $CONFIGDIR/$fname
         if [ "$fname" == "$CONFIGFILE" ]; then
-            CFGFILE=$cdir/$CONFIGFILE
+            CFGFILE=$CONFIGDIR/$CONFIGFILE
         fi
     fi
 done
 files=`ls /etc/secrets`
 for fname in $files; do
-    if [ ! -f $cdir/$fname ]; then
-        sudo cp /etc/secrets/$fname /data/srv/current/auth/$srv/$fname
-        sudo chown $USER.$USER /data/srv/current/auth/$srv/$fname
+    if [ ! -f $CONFIGDIR/$fname ]; then
+        sudo cp /etc/secrets/$fname $AUTHDIR/$fname
+        sudo chown $USER.$USER $AUTHDIR/$fname
     fi
 done
 
-export PYTHONPATH=$PYTHONPATH:/etc/secrets:/data/srv/current/auth/$srv/$fname
+export PYTHONPATH=$PYTHONPATH:/etc/secrets:$AUTHDIR/$fname
 
 # start the service
 wmc-httpd -r -d $STATEDIR -l "|rotatelogs $LOGDIR/$srv-%Y%m%d-`hostname -s`.log 86400" $CFGFILE
-sleep 10
-tail -f $LOGDIR/*.log


### PR DESCRIPTION
Related to https://github.com/dmwm/WMCore/issues/10178

I found that the `reqmgr2-tasks` service, PyPi-based, had a few CherryPy threads down with the following error [1], so I decided to refactor this run.sh script. Some highlights are:
* consolidate directory names and use the same shell variable everywhere
* robot and proxy certificates are placed under the same directory (AUTHDIR)
  * Note: I am not sure whether we should be exporting the X509_USER_PROXY variable though, I would be inclined not to.
* why the hmac file has to be placed under the /auth directory?
* removed tail -f logs that was executed at the very end (?)

@vkuznet can you please clarify some of these questions? It's not clear to me why and whether we actually need them.

[1]
```
[13/Dec/2022:21:37:43]  INFO: instantiating extension statusChangeTasks
advanceStatus
[13/Dec/2022:21:37:43]  INFO: instantiating extension parentLock
fetchIncludeParentsRequests
ERROR:root:DBSReaderError
Message: Error in DBSReader with DbsApi
ClientAuthException:'key or cert file does not exist: /data/srv/state/reqmgr2/proxy/proxy.key, /data/srv/state/reqmgr2/proxy/proxy.cert'
```