### PR TITLE
Update rucio dataset monitoring services

### DIFF
--- a/kubernetes/monitoring/services/datasetmon/rucio-mon-goweb.yaml
+++ b/kubernetes/monitoring/services/datasetmon/rucio-mon-goweb.yaml
@@ -29,6 +29,7 @@ data:
         "read_timeout": 10,
         "write_timeout": 10,
         "mongo_connection_timeout": 100,
+        "base_endpoint": "main",
         "prod_lock_accounts": [
             "transfer_ops",
             "wma_prod",
@@ -64,7 +65,7 @@ spec:
     spec:
       containers:
       - name: rucio-mon-goweb
-        image: registry.cern.ch/cmsmonitoring/rucio-mon-goweb:rgo-0.0.7
+        image: registry.cern.ch/cmsmonitoring/rucio-mon-goweb:rgo-0.0.12
         imagePullPolicy: Always
         args:
           - /data/rucio-dataset-monitoring

--- a/kubernetes/monitoring/services/datasetmon/spark2mng.yaml
+++ b/kubernetes/monitoring/services/datasetmon/spark2mng.yaml
@@ -33,8 +33,8 @@ data:
     echo "Starting run_spark2hdfs.sh ..."
     /data/CMSMonitoring/rucio-dataset-monitoring/spark/cron4rucio_spark2hdfs.sh \
       --keytab /etc/secrets/keytab --hdfs /tmp/cmsmonit/prod \
-      --p1 $CMSMON_RUCIO_SPARK2MNG_SERVICE_PORT_PORT_0 \
-      --p2 $CMSMON_RUCIO_SPARK2MNG_SERVICE_PORT_PORT_1 \
+      --p1 $SPARK2MNG_SERVICE_PORT_PORT_0 \
+      --p2 $SPARK2MNG_SERVICE_PORT_PORT_1 \
       --host $MY_NODE_NAME --wdir $WDIR
   run_hdfs2mongo.sh: |
     #!/bin/bash
@@ -57,7 +57,7 @@ metadata:
   namespace: datasetmon
 spec:
   # UTC
-  schedule: "30 08 * * *"
+  schedule: "30 07 * * *"
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 1
   jobTemplate:
@@ -72,7 +72,7 @@ spec:
           hostname: spark2mng
           containers:
             - name: spark2mng
-              image: registry.cern.ch/cmsmonitoring/spark2mng:rgo-0.0.7
+              image: registry.cern.ch/cmsmonitoring/spark2mng:rgo-0.0.10
               imagePullPolicy: Always
               command: [ "/bin/bash", "-c" ]
               args:


### PR DESCRIPTION
In production 🚀 
- No known bug yet.
- Rucio replicas `STATE=A` is fixed
- Reachable from outside: https://cms-dm-monitoring.cern.ch