### PR TITLE
Fix permissions for /data/srv in the PyPi based images

### DIFF
--- a/docker/pypi/dmwm-base/run.sh
+++ b/docker/pypi/dmwm-base/run.sh
@@ -9,6 +9,9 @@ CONFIGDIR=/data/srv/current/config/$srv
 CONFIGFILE=${CONFIGFILE:-config.py}
 CFGFILE=/etc/secrets/$CONFIGFILE
 
+### permission update to workaround issues with mounting logs volume
+sudo chown -R $USER.$USER /data
+
 mkdir -p $LOGDIR
 mkdir -p $STATEDIR
 mkdir -p $AUTHDIR

--- a/docker/pypi/global-workqueue/Dockerfile
+++ b/docker/pypi/global-workqueue/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20221219
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230106
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 ENV TAG=2.1.4
 RUN pip install global-workqueue==$TAG

--- a/docker/pypi/reqmgr2/Dockerfile
+++ b/docker/pypi/reqmgr2/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20221219
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230106
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 ENV TAG=2.1.4
 RUN pip install reqmgr2==$TAG

--- a/docker/pypi/reqmgr2ms-monitor/Dockerfile
+++ b/docker/pypi/reqmgr2ms-monitor/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20221219
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230106
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 ENV TAG=2.1.4
 RUN pip install reqmgr2ms-monitor==$TAG

--- a/docker/pypi/reqmgr2ms-output/Dockerfile
+++ b/docker/pypi/reqmgr2ms-output/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20221219
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230106
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 ENV TAG=2.1.4
 RUN pip install reqmgr2ms-output==$TAG

--- a/docker/pypi/reqmgr2ms-rulecleaner/Dockerfile
+++ b/docker/pypi/reqmgr2ms-rulecleaner/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20221219
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230106
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 ENV TAG=2.1.4
 RUN pip install reqmgr2ms-rulecleaner==$TAG

--- a/docker/pypi/reqmgr2ms-transferor/Dockerfile
+++ b/docker/pypi/reqmgr2ms-transferor/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20221219
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230106
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 ENV TAG=2.1.4
 RUN pip install reqmgr2ms-transferor==$TAG

--- a/docker/pypi/reqmgr2ms-unmerged/Dockerfile
+++ b/docker/pypi/reqmgr2ms-unmerged/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.cern.ch/cmsweb/gfal:latest as gfal
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20221219
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230106
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 COPY --from=gfal /data/miniconda /data/miniconda
 ENV WDIR=/data

--- a/docker/pypi/reqmgr2ms/Dockerfile
+++ b/docker/pypi/reqmgr2ms/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20221219
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230106
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 RUN pip install reqmgr2ms-output
 ENV WDIR=/data

--- a/docker/pypi/reqmon/Dockerfile
+++ b/docker/pypi/reqmon/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20221219
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230106
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 ENV TAG=2.1.4
 RUN pip install reqmon==$TAG

--- a/docker/pypi/t0_reqmon/Dockerfile
+++ b/docker/pypi/t0_reqmon/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20221219
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230106
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 ENV TAG=2.1.4
 RUN pip install reqmon==$TAG

--- a/docker/pypi/wmagent/Dockerfile
+++ b/docker/pypi/wmagent/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20221219
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230106
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 RUN apt-get update
 RUN apt-get install -y libmariadb-dev-compat libmariadb-dev apache2-utils sudo


### PR DESCRIPTION
After deploying WMCore images `2.1.6rc4` into testbed, many of the services are not functional. Scanning the logs, I see this for reqmgr2:
```
mkdir: cannot create directory ‘/data/srv/state’: Permission denied
mkdir: cannot create directory ‘/data/srv/current’: Permission denied
mkdir: cannot create directory ‘/data/srv/current’: Permission denied
mkdir: cannot create directory ‘/data/srv/current’: Permission denied
```

It's not clear to me why it works on test9 but not in testbed, but this might resolve the issue.

Please do NOT merge it because the other WMCore services will need the same changes, but I still have to test it.