### PR TITLE
Update WMCore PyPi to use dmwm-base image from 20230110

### DIFF
--- a/docker/pypi/global-workqueue/Dockerfile
+++ b/docker/pypi/global-workqueue/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230106
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230110
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 ENV TAG=2.1.4
 RUN pip install global-workqueue==$TAG

--- a/docker/pypi/global-workqueue/Dockerfile
+++ b/docker/pypi/global-workqueue/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230110
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
-ENV TAG=2.1.4
+ENV TAG=X.Y.Z
 RUN pip install global-workqueue==$TAG
 ENV WDIR=/data
 ENV USER=_workqueue

--- a/docker/pypi/global-workqueue/Dockerfile.dist
+++ b/docker/pypi/global-workqueue/Dockerfile.dist
@@ -1,6 +1,6 @@
 FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20221129
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
-ENV TAG=2.1.4
+ENV TAG=X.Y.Z
 ADD global-workqueue-$TAG.tar.gz $WORKDIR
 WORKDIR global-workqueue-$TAG
 RUN pip install -r requirements.txt

--- a/docker/pypi/reqmgr2/Dockerfile
+++ b/docker/pypi/reqmgr2/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230106
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230110
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 ENV TAG=2.1.4
 RUN pip install reqmgr2==$TAG

--- a/docker/pypi/reqmgr2/Dockerfile
+++ b/docker/pypi/reqmgr2/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230110
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
-ENV TAG=2.1.4
+ENV TAG=X.Y.Z
 RUN pip install reqmgr2==$TAG
 ENV WDIR=/data
 ENV USER=_reqmgr2

--- a/docker/pypi/reqmgr2/Dockerfile.dist
+++ b/docker/pypi/reqmgr2/Dockerfile.dist
@@ -1,6 +1,6 @@
 FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20221129
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
-ENV TAG=2.1.4
+ENV TAG=X.Y.Z
 ADD reqmgr2-$TAG.tar.gz $WORKDIR
 WORKDIR reqmgr2-$TAG
 RUN pip install -r requirements.txt

--- a/docker/pypi/reqmgr2ms-monitor/Dockerfile
+++ b/docker/pypi/reqmgr2ms-monitor/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230110
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
-ENV TAG=2.1.4
+ENV TAG=X.Y.Z
 RUN pip install reqmgr2ms-monitor==$TAG
 RUN sed -i -e "s,-config.py,-config-monitor.py,g" /data/run.sh
 RUN sed -i -e "s,config.py,config-monitor.py,g" /data/manage

--- a/docker/pypi/reqmgr2ms-monitor/Dockerfile
+++ b/docker/pypi/reqmgr2ms-monitor/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230106
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230110
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 ENV TAG=2.1.4
 RUN pip install reqmgr2ms-monitor==$TAG

--- a/docker/pypi/reqmgr2ms-monitor/Dockerfile.dist
+++ b/docker/pypi/reqmgr2ms-monitor/Dockerfile.dist
@@ -1,6 +1,6 @@
 FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20221129
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
-ENV TAG=2.1.4
+ENV TAG=X.Y.Z
 ADD reqmgr2ms-monitor-$TAG.tar.gz $WORKDIR
 WORKDIR reqmgr2ms-monitor-$TAG
 RUN pip install -r requirements.txt

--- a/docker/pypi/reqmgr2ms-output/Dockerfile
+++ b/docker/pypi/reqmgr2ms-output/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230106
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230110
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 ENV TAG=2.1.4
 RUN pip install reqmgr2ms-output==$TAG

--- a/docker/pypi/reqmgr2ms-output/Dockerfile
+++ b/docker/pypi/reqmgr2ms-output/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230110
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
-ENV TAG=2.1.4
+ENV TAG=X.Y.Z
 RUN pip install reqmgr2ms-output==$TAG
 RUN sed -i -e "s,-config.py,-config-output.py,g" /data/run.sh
 RUN sed -i -e "s,config.py,config-output.py,g" /data/manage

--- a/docker/pypi/reqmgr2ms-output/Dockerfile.dist
+++ b/docker/pypi/reqmgr2ms-output/Dockerfile.dist
@@ -1,6 +1,6 @@
 FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20221129
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
-ENV TAG=2.1.4
+ENV TAG=X.Y.Z
 ADD reqmgr2ms-output-$TAG.tar.gz $WORKDIR
 WORKDIR reqmgr2ms-output-$TAG
 RUN pip install -r requirements.txt

--- a/docker/pypi/reqmgr2ms-pileup/Dockerfile
+++ b/docker/pypi/reqmgr2ms-pileup/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230106
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230110
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 ENV TAG=2.1.4
 RUN pip install reqmgr2ms-pielup==$TAG

--- a/docker/pypi/reqmgr2ms-pileup/Dockerfile
+++ b/docker/pypi/reqmgr2ms-pileup/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230110
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
-ENV TAG=2.1.4
+ENV TAG=X.Y.Z
 RUN pip install reqmgr2ms-pielup==$TAG
 #RUN sed -i -e "s,-config.py,-config-pielup.py,g" /data/run.sh
 #RUN sed -i -e "s,config.py,config-pielup.py,g" /data/manage

--- a/docker/pypi/reqmgr2ms-rulecleaner/Dockerfile
+++ b/docker/pypi/reqmgr2ms-rulecleaner/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230110
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
-ENV TAG=2.1.4
+ENV TAG=X.Y.Z
 RUN pip install reqmgr2ms-rulecleaner==$TAG
 RUN sed -i -e "s,-config.py,-config-ruleCleaner.py,g" /data/run.sh
 RUN sed -i -e "s,config.py,config-ruleCleaner.py,g" /data/manage

--- a/docker/pypi/reqmgr2ms-rulecleaner/Dockerfile
+++ b/docker/pypi/reqmgr2ms-rulecleaner/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230106
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230110
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 ENV TAG=2.1.4
 RUN pip install reqmgr2ms-rulecleaner==$TAG

--- a/docker/pypi/reqmgr2ms-rulecleaner/Dockerfile.dist
+++ b/docker/pypi/reqmgr2ms-rulecleaner/Dockerfile.dist
@@ -1,6 +1,6 @@
 FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20221129
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
-ENV TAG=2.1.4
+ENV TAG=X.Y.Z
 ADD reqmgr2ms-rulecleaner-$TAG.tar.gz $WORKDIR
 WORKDIR reqmgr2ms-rulecleaner-$TAG
 RUN pip install -r requirements.txt

--- a/docker/pypi/reqmgr2ms-transferor/Dockerfile
+++ b/docker/pypi/reqmgr2ms-transferor/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230106
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230110
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 ENV TAG=2.1.4
 RUN pip install reqmgr2ms-transferor==$TAG

--- a/docker/pypi/reqmgr2ms-transferor/Dockerfile
+++ b/docker/pypi/reqmgr2ms-transferor/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230110
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
-ENV TAG=2.1.4
+ENV TAG=X.Y.Z
 RUN pip install reqmgr2ms-transferor==$TAG
 RUN sed -i -e "s,-config.py,-config-transferor.py,g" /data/run.sh
 RUN sed -i -e "s,config.py,config-transferor.py,g" /data/manage

--- a/docker/pypi/reqmgr2ms-transferor/Dockerfile.dist
+++ b/docker/pypi/reqmgr2ms-transferor/Dockerfile.dist
@@ -1,6 +1,6 @@
 FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20221129
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
-ENV TAG=2.1.4
+ENV TAG=X.Y.Z
 ADD reqmgr2ms-transferor-$TAG.tar.gz $WORKDIR
 WORKDIR reqmgr2ms-transferor-$TAG
 RUN pip install -r requirements.txt

--- a/docker/pypi/reqmgr2ms-unmerged/Dockerfile
+++ b/docker/pypi/reqmgr2ms-unmerged/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.cern.ch/cmsweb/gfal:latest as gfal
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230106
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230110
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 COPY --from=gfal /data/miniconda /data/miniconda
 ENV WDIR=/data

--- a/docker/pypi/reqmgr2ms-unmerged/Dockerfile
+++ b/docker/pypi/reqmgr2ms-unmerged/Dockerfile
@@ -5,12 +5,11 @@ COPY --from=gfal /data/miniconda /data/miniconda
 ENV WDIR=/data
 ENV PATH $PATH:$WDIR/miniconda/bin
 ENV PYTHONPATH $WDIR/miniconda/lib/python3.8/site-packages/
-ENV TAG=2.1.4
-ENV REQTAG=2.1.4.pre3
+ENV TAG=X.Y.Z
 WORKDIR $WDIR
 # since we install gfal via external image we'll skip it for installation
 # of reqmgr2ms-unmerged, but to satisfy dependencies we'll install them first
-RUN curl -ksLO https://raw.githubusercontent.com/dmwm/WMCore/$REQTAG/requirements.txt
+RUN curl -ksLO https://raw.githubusercontent.com/dmwm/WMCore/$TAG/requirements.txt
 RUN cat requirements.txt | grep -v gfal2 > req.txt
 RUN pip install -r req.txt
 RUN pip install --no-deps reqmgr2ms-unmerged==$TAG dbs3-client

--- a/docker/pypi/reqmgr2ms-unmerged/Dockerfile.dist
+++ b/docker/pypi/reqmgr2ms-unmerged/Dockerfile.dist
@@ -5,14 +5,13 @@ COPY --from=gfal /data/miniconda /data/miniconda
 ENV WDIR=/data
 ENV PATH $PATH:$WDIR/miniconda/bin
 ENV PYTHONPATH $WDIR/miniconda/lib/python3.8/site-packages/
-ENV TAG=2.1.4
-ENV REQTAG=2.1.4.pre3
+ENV TAG=X.Y.Z
 WORKDIR $WDIR
 ADD reqmgr2ms-unmerged-$TAG.tar.gz $WORKDIR
 WORKDIR reqmgr2ms-unmerged-$TAG
 # since we install gfal via external image we'll skip it for installation
 # of reqmgr2ms-unmerged, but to satisfy dependencies we'll install them first
-# RUN curl -ksLO https://raw.githubusercontent.com/dmwm/WMCore/$REQTAG/requirements.txt
+# RUN curl -ksLO https://raw.githubusercontent.com/dmwm/WMCore/$TAG/requirements.txt
 # add requirements.txt file which should exclude gfal2 package
 RUN cat requirements.txt | grep -v gfal2 > req.txt
 RUN pip install -r req.txt

--- a/docker/pypi/reqmgr2ms/Dockerfile
+++ b/docker/pypi/reqmgr2ms/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230106
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230110
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 RUN pip install reqmgr2ms-output
 ENV WDIR=/data

--- a/docker/pypi/reqmon/Dockerfile
+++ b/docker/pypi/reqmon/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230110
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
-ENV TAG=2.1.4
+ENV TAG=X.Y.Z
 RUN pip install reqmon==$TAG
 ENV WDIR=/data
 ENV USER=_reqmon

--- a/docker/pypi/reqmon/Dockerfile
+++ b/docker/pypi/reqmon/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230106
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230110
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 ENV TAG=2.1.4
 RUN pip install reqmon==$TAG

--- a/docker/pypi/reqmon/Dockerfile.dist
+++ b/docker/pypi/reqmon/Dockerfile.dist
@@ -1,6 +1,6 @@
 FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20221129
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
-ENV TAG=2.1.4
+ENV TAG=X.Y.Z
 ADD reqmon-$TAG.tar.gz $WORKDIR
 WORKDIR reqmon-$TAG
 RUN pip install -r requirements.txt

--- a/docker/pypi/t0_reqmon/Dockerfile
+++ b/docker/pypi/t0_reqmon/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230106
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230110
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 ENV TAG=2.1.4
 RUN pip install reqmon==$TAG

--- a/docker/pypi/t0_reqmon/Dockerfile
+++ b/docker/pypi/t0_reqmon/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230110
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
-ENV TAG=2.1.4
+ENV TAG=X.Y.Z
 RUN pip install reqmon==$TAG
 ENV WDIR=/data
 ENV USER=_t0_reqmon

--- a/docker/pypi/t0_reqmon/Dockerfile.dist
+++ b/docker/pypi/t0_reqmon/Dockerfile.dist
@@ -1,6 +1,6 @@
 FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20221129
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
-ENV TAG=2.1.4
+ENV TAG=X.Y.Z
 ADD t0_reqmon-$TAG.tar.gz $WORKDIR
 WORKDIR t0_reqmon-$TAG
 RUN pip install -r requirements.txt

--- a/docker/pypi/wmagent/Dockerfile
+++ b/docker/pypi/wmagent/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230110
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 RUN apt-get update
 RUN apt-get install -y libmariadb-dev-compat libmariadb-dev apache2-utils sudo
-ENV TAG=2.1.4
+ENV TAG=X.Y.Z
 RUN pip install wmagent==$TAG
 ENV WDIR=/data
 ENV USER=_wmagent

--- a/docker/pypi/wmagent/Dockerfile
+++ b/docker/pypi/wmagent/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230106
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230110
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 RUN apt-get update
 RUN apt-get install -y libmariadb-dev-compat libmariadb-dev apache2-utils sudo

--- a/docker/pypi/wmagent/Dockerfile.dist
+++ b/docker/pypi/wmagent/Dockerfile.dist
@@ -2,7 +2,7 @@ FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20221129
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 RUN apt-get update
 RUN apt-get install -y libmariadb-dev-compat libmariadb-dev apache2-utils sudo
-ENV TAG=2.1.4
+ENV TAG=X.Y.Z
 ADD wmagent-$TAG.tar.gz $WORKDIR
 WORKDIR wmagent-$TAG
 RUN pip install -r requirements.txt


### PR DESCRIPTION
Update all the WMCore PyPi-based dockerfiles to use a new dmwm-base image that has been just created and uploaded to gitlab registry. That new image contains fixes to the run.sh and manage script.

UPDATE: the second commit removes the default WMCore tag and define just a placeholder instead. This way, if we ever try to build such images without update the TAG to be used, it will fail during the build time.