### PR TITLE
Switch to new dmwm-base image tag with cmsweb-ping tool in it

### DIFF
--- a/docker/pypi/global-workqueue/Dockerfile
+++ b/docker/pypi/global-workqueue/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230110
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230123
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 ENV TAG=X.Y.Z
 RUN pip install global-workqueue==$TAG

--- a/docker/pypi/reqmgr2/Dockerfile
+++ b/docker/pypi/reqmgr2/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230110
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230123
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 ENV TAG=X.Y.Z
 RUN pip install reqmgr2==$TAG

--- a/docker/pypi/reqmgr2ms-monitor/Dockerfile
+++ b/docker/pypi/reqmgr2ms-monitor/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230110
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230123
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 ENV TAG=X.Y.Z
 RUN pip install reqmgr2ms-monitor==$TAG

--- a/docker/pypi/reqmgr2ms-output/Dockerfile
+++ b/docker/pypi/reqmgr2ms-output/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230110
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230123
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 ENV TAG=X.Y.Z
 RUN pip install reqmgr2ms-output==$TAG

--- a/docker/pypi/reqmgr2ms-pileup/Dockerfile
+++ b/docker/pypi/reqmgr2ms-pileup/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230110
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230123
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 ENV TAG=X.Y.Z
 RUN pip install reqmgr2ms-pileup==$TAG

--- a/docker/pypi/reqmgr2ms-rulecleaner/Dockerfile
+++ b/docker/pypi/reqmgr2ms-rulecleaner/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230110
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230123
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 ENV TAG=X.Y.Z
 RUN pip install reqmgr2ms-rulecleaner==$TAG

--- a/docker/pypi/reqmgr2ms-transferor/Dockerfile
+++ b/docker/pypi/reqmgr2ms-transferor/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230110
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230123
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 ENV TAG=X.Y.Z
 RUN pip install reqmgr2ms-transferor==$TAG

--- a/docker/pypi/reqmgr2ms-unmerged/Dockerfile
+++ b/docker/pypi/reqmgr2ms-unmerged/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.cern.ch/cmsweb/gfal:latest as gfal
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230110
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230123
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 COPY --from=gfal /data/miniconda /data/miniconda
 ENV WDIR=/data

--- a/docker/pypi/reqmgr2ms/Dockerfile
+++ b/docker/pypi/reqmgr2ms/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230110
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230123
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 RUN pip install reqmgr2ms-output
 ENV WDIR=/data

--- a/docker/pypi/reqmon/Dockerfile
+++ b/docker/pypi/reqmon/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230110
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230123
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 ENV TAG=X.Y.Z
 RUN pip install reqmon==$TAG

--- a/docker/pypi/t0_reqmon/Dockerfile
+++ b/docker/pypi/t0_reqmon/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230110
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230123
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 ENV TAG=X.Y.Z
 RUN pip install reqmon==$TAG

--- a/docker/pypi/wmagent/Dockerfile
+++ b/docker/pypi/wmagent/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230110
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230123
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 RUN apt-get update
 RUN apt-get install -y libmariadb-dev-compat libmariadb-dev apache2-utils sudo


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/11451

The new dmwm-base image tag provides image with `cmsweb-ping` tool in it. Therefore, all pypi images should use it to properly enable liveness probes.

Relevant changes to the dmwm-base image have been applied with: https://github.com/dmwm/CMSKubernetes/commit/574e25c2335d812de357ca84ef8c8ed2bc8b0c51