### PR TITLE
Change CRABREST deployment to able to write logs to container stdout

### DIFF
--- a/docker/crabserver/monitor.sh
+++ b/docker/crabserver/monitor.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# inject delay to wait crabrest create pid file
+sleep 3
+
 # Check pid exist before start process_monitor.sh scripts
 # process_monitor.sh need PID to feed it to process_exporter
 RETRY=5
@@ -7,8 +10,10 @@ for ((i=1; i<=${RETRY}; i++))
 do
     if [ -f /data/srv/state/crabserver/crabserver.pid ]; then
         nohup process_monitor.sh /data/srv/state/crabserver/crabserver.pid crabserver ":18270" 15 2>&1 1>& crabserver_monitor.log < /dev/null &
+        break
     elif [ -f /data/srv/state/crabserver/pid ]; then
         nohup process_monitor.sh /data/srv/state/crabserver/pid crabserver ":18270" 15 2>&1 1>& crabserver_monitor.log < /dev/null &
+        break
     else
         if [ ${i} -eq ${RETRY} ]; then
             echo "Cannot find crabserver's PID file"
@@ -18,11 +23,12 @@ do
     fi
 done
 
-# run filebeat
-if [ -f /etc/secrets/filebeat.yaml ] && [ -f /usr/bin/filebeat ]; then
-    ldir=/tmp/filebeat
-    mkdir -p $ldir/data
-    nohup /usr/bin/filebeat \
-        -c /etc/secrets/filebeat.yaml \
-        --path.data $ldir/data --path.logs $ldir -e 2>&1 1>& $ldir/log < /dev/null &
-fi
+# Deprecated
+# Run filebeat
+#if [ -f /etc/secrets/filebeat.yaml ] && [ -f /usr/bin/filebeat ]; then
+#    ldir=/tmp/filebeat
+#    mkdir -p $ldir/data
+#    nohup /usr/bin/filebeat \
+#        -c /etc/secrets/filebeat.yaml \
+#        --path.data $ldir/data --path.logs $ldir -e 2>&1 1>& $ldir/log < /dev/null &
+#fi

--- a/kubernetes/cmsweb/monitoring/crab/logstash.conf
+++ b/kubernetes/cmsweb/monitoring/crab/logstash.conf
@@ -169,8 +169,15 @@ filter {
           "type" => "crabhttpcall"
         }
       }
+      # parse log path to get pod name
+      # /var/log/pods/crab_crabserver-test-5f9bd5f58d-5nfhc_5366ebdb-ee96-4641-8643-f3bbe63f808f/crabserver/0.log
       grok {
-        match => { "message" => '\[%{NOTSPACE:timestamp_temp}\] %{DATA:backend} %{IPORHOST:clientip} "%{WORD:method} %{NOTSPACE:request} %{DATA:httpversion}" %{NUMBER:code:int} %{DATA} \[data: (-|%{NUMBER:bytes_sent:int}) in (-|%{NUMBER:bytes_received:int}) out (-|%{NUMBER:time_spent_ms:int}) us \] \[auth: %{DATA} "%{DATA:dn}".*\] \[ref: "%{DATA}.*" "%{DATA:client}" \]' }
+          match => { "[log][file][path]" => '/var/log/pods/crab_%{DATA:pod_name}_%{DATA}/%{GREEDYDATA}' }
+      }
+
+      grok {
+          # [07/Dec/2022:20:06:47] crabserver-56c69685b6-477jr 188.184.91.103:41924 "GET /crabserver/devthree/info HTTP/1.1" 200 OK [data: 9354 in 103 out 4870 us ] [auth: ok "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=tseethon/CN=856006/CN=Thanayut Seethongchuen" "" ] [ref: "https://cmsweb-test12.cern.ch" "Mozilla/5.0 (X11; Linux x86_64; rv:107.0) Gecko/20100101 Firefox/107.0" ] Type=cherrypylog
++         match => { "message" => '\[%{NOTSPACE:timestamp_temp}\] %{DATA:backend} %{IPORHOST:clientip}(|:%{NUMBER}) "%{WORD:method} %{NOTSPACE:request} %{DATA:httpversion}" %{NUMBER:code:int} %{DATA} \[data: (-|%{NUMBER:bytes_sent:int}) in (-|%{NUMBER:bytes_received:int}) out (-|%{NUMBER:time_spent_ms:int}) us \] \[auth: %{DATA} "%{DATA:dn}".*\] \[ref: "%{DATA}.*" "%{DATA:client}" \]' }
       }
       grok {
         match => { "request" => '/%{WORD:system}%{UNIXPATH:uri_path}%{URIPARAM:uri_params}?' }
@@ -201,9 +208,15 @@ filter {
           "type" => "crabrest"
         }
       }
+      # parse log path to get pod name
+      # /var/log/pods/crab_crabserver-test-5f9bd5f58d-5nfhc_5366ebdb-ee96-4641-8643-f3bbe63f808f/crabserver/0.log
+      grok {
+          match => { "[log][file][path]" => '/var/log/pods/crab_%{DATA:pod_name}_%{DATA}/%{GREEDYDATA}' }
+      }
+
       if ( [message] =~ /.*MeasureTime:seconds.*/ ) {
           grok {
-            match => { "message" => "%{TIMESTAMP_ISO8601:timestamp_temp}:%{NOTSPACE:trace_id}:%{NOTSPACE:log_level}:%{NOTSPACE}:MeasureTime:seconds - modulename=%{NOTSPACE:modulename} label='%{NOTSPACE:label}' tot=%{NUMBER:tot:float} proc=%{NUMBER:total:float} thread=%{NUMBER:thread:float}" }
+            match => { "message" => "%{TIMESTAMP_ISO8601:timestamp_temp}:%{NOTSPACE:trace_id}:%{NOTSPACE:log_level}:%{NOTSPACE}:MeasureTime:seconds - modulename=%{NOTSPACE:modulename} label='%{NOTSPACE:label}' tot=%{NUMBER:tot:float} proc=%{NUMBER:proc:float} thread=%{NUMBER:thread:float}" }
             add_field => {"log_type" => "measure_time"}
           }
       } else if ( [message] =~ /.*MeasureSize:bytes.*/ ) {

--- a/kubernetes/cmsweb/services/crabserver.yaml
+++ b/kubernetes/cmsweb/services/crabserver.yaml
@@ -1,89 +1,4 @@
 ---
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: crabserver-filebeat-config
-  namespace: crab
-  labels:
-    k8s-app: filebeat
-data:
-  filebeat.yml: |-
-    filebeat.inputs:
-    - type: log
-      enabled: true
-      paths:
-        - /data/srv/logs/crabserver/crabserver-*${MY_POD_NAME}*.log
-      ignore_older: 1h
-      scan_frequency: 10s
-      backoff: 5s
-      max_backoff: 10s
-      processors:
-        - add_fields:
-            target: logtype
-            fields:
-              name: cherrypylog
-    - type: log
-      enabled: true
-      paths:
-        - /data/srv/logs/crabserver/CRAB-*${MY_POD_NAME}*.log
-      ignore_older: 1h
-      scan_frequency: 10s
-      backoff: 5s
-      max_backoff: 10s
-      processors:
-        - add_fields:
-            target: logtype
-            fields:
-              name: crablog
-    output.console:
-      codec.format:
-        string: '%{[message]} - Podname=${MY_POD_NAME} Type=%{[logtype][name]}'
-        pretty: false
-    queue.mem:
-      events: 65536
-    logging.metrics.enabled: false
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: crabserver-filebeat-monit-config
-  namespace: crab
-  labels:
-    k8s-app: filebeat
-data:
-  filebeat.yml: |-
-    filebeat.inputs:
-    - type: log
-      enabled: true
-      paths:
-        - /data/srv/logs/crabserver/crabserver-*${MY_POD_NAME}*.log
-      file_identity.path:
-      scan_frequency: 10s
-      backoff: 5s
-      max_backoff: 10s
-      include_lines:
-        - '^\[.+?\] crabserver-'
-      tags: ["crabhttpcall"]
-    - type: log
-      enabled: true
-      paths:
-        - /data/srv/logs/crabserver/CRAB-*${MY_POD_NAME}*.log
-      file_identity.path:
-      scan_frequency: 10s
-      backoff: 5s
-      max_backoff: 10s
-      include_lines:
-        - 'MeasureTime:seconds - '
-        - 'MeasureSize:bytes - '
-      tags: ["crabrest"]
-    output.logstash:
-      hosts: ["logstash:5044"]
-      compression_level: 3
-      bulk_max_size: 4096
-    queue.mem:
-      events: 65536
-    logging.metrics.enabled: false
----
 kind: Service
 apiVersion: v1
 metadata:
@@ -146,6 +61,9 @@ spec:
       #- image: sbelforte/crabserver:3.3.1911.rc3
       - image: registry.cern.ch/cmsweb/crabserver #imagetag
         name: crabserver
+        env:
+        - name: CRABSERVER_LOGSTDOUT
+          value: "t"
         resources:
           requests:
             memory: "256Mi"
@@ -204,73 +122,8 @@ spec:
         - name: token-secrets
           mountPath: /etc/token
           readOnly: true
-#PROD#  - name: logs
-#PROD#    mountPath: /data/srv/logs/crabserver
         securityContext:
           privileged: true
-#PROD#- name: crabserver-filebeat
-#PROD#  image: docker.elastic.co/beats/filebeat:7.12.0
-#PROD#  args: [
-#PROD#    "-c", "/etc/filebeat.yml",
-#PROD#    "-e",
-#PROD#  ]
-#PROD#  env:
-#PROD#  - name: MY_POD_NAME
-#PROD#    valueFrom:
-#PROD#      fieldRef:
-#PROD#        apiVersion: v1
-#PROD#        fieldPath: metadata.name
-#PROD#  resources:
-#PROD#    requests:
-#PROD#      memory: "50Mi"
-#PROD#      cpu: "50m"
-#PROD#  volumeMounts:
-#PROD#  - name: logs
-#PROD#    mountPath: /data/srv/logs/crabserver
-#PROD#  - name: config
-#PROD#    mountPath: /etc/filebeat.yml
-#PROD#    readOnly: true
-#PROD#    subPath: filebeat.yml
-#PROD#  - name: data
-#PROD#    mountPath: /usr/share/filebeat/data
-#PROD#  - name: varlog
-#PROD#    mountPath: /var/log
-#PROD#  - name: varlibdockercontainers
-#PROD#    mountPath: /var/lib/docker/containers
-#PROD#    readOnly: true
-#PROD#  securityContext:
-#PROD#    allowPrivilegeEscalation: false
-#PROD#- name: crabserver-filebeat-monit
-#PROD#  image: docker.elastic.co/beats/filebeat:8.1.3
-#PROD#  args: [
-#PROD#    "bash",
-#PROD#    "-c",
-#PROD#    "filebeat -c /etc/filebeat.yml --path.data /data/filebeat/${MY_POD_NAME}/data -e",
-#PROD#  ]
-#PROD#  env:
-#PROD#  - name: MY_POD_NAME
-#PROD#    valueFrom:
-#PROD#      fieldRef:
-#PROD#        apiVersion: v1
-#PROD#        fieldPath: metadata.name
-#PROD#  resources:
-#PROD#    requests:
-#PROD#      memory: "150Mi"
-#PROD#      cpu: "50m"
-#PROD#    limits:
-#PROD#      memory: "1Gi"
-#PROD#      cpu: "500m"
-#PROD#  volumeMounts:
-#PROD#  - name: logs
-#PROD#    mountPath: /data/srv/logs/crabserver
-#PROD#  - name: crabserver-filebeat-monit-config
-#PROD#    mountPath: /etc/filebeat.yml
-#PROD#    readOnly: true
-#PROD#    subPath: filebeat.yml
-#PROD#  - name: filebeat-cephfs
-#PROD#    mountPath: /data/filebeat
-#PROD#  securityContext:
-#PROD#    allowPrivilegeEscalation: false
       volumes:
       - name: proxy-secrets
         secret:
@@ -293,25 +146,118 @@ spec:
       - name: token-secrets
         secret:
           secretName: token-secrets
-#PROD#- name: logs
-#PROD#  persistentVolumeClaim:
-#PROD#      claimName: logs-cephfs-claim-crab
-#PROD#- name: varlog
-#PROD#  hostPath:
-#PROD#    path: /var/log
-#PROD#- name: varlibdockercontainers
-#PROD#  hostPath:
-#PROD#    path: /var/lib/docker/containers
-#PROD#- name: config
-#PROD#  configMap:
-#PROD#    defaultMode: 0640
-#PROD#    name: crabserver-filebeat-config
-#PROD#- name: data
-#PROD#  emptyDir: {}
-#PROD#- name: crabserver-filebeat-monit-config
-#PROD#  configMap:
-#PROD#    defaultMode: 0640
-#PROD#    name: crabserver-filebeat-monit-config
-#PROD#- name: filebeat-cephfs
-#PROD#  persistentVolumeClaim:
-#PROD#      claimName: crabserver-filebeat-monit-data
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    k8s-app: filebeat
+  name: filebeat-crab-config
+  namespace: crab
+data:
+  filebeat.yml: |-
+    filebeat.inputs:
+    - type: container
+      paths:
+        - /var/log/pods/crab_crabserver*/crabserver/*.log
+      include_lines:
+        - '\] crabserver-\w+-\w+ \d'
+      tags:
+        - "crabhttpcall"
+    - type: container
+      paths:
+        - /var/log/pods/crab_crabserver*/crabserver/*.log
+      include_lines:
+        - 'MeasureTime:seconds - '
+        - 'MeasureSize:bytes - '
+      tags:
+        - "crabrest"
+    output.logstash:
+      hosts: ["logstash:5044"]
+      compression_level: 3
+      bulk_max_size: 4096
+    queue.mem:
+      events: 65536
+    logging.metrics.enabled: false
+    logging.level: info
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: filebeat-crab
+  name: filebeat-crab
+  namespace: crab
+spec:
+  selector:
+    matchLabels:
+      app: filebeat-crab
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: "18270"
+        prometheus.io/scrape: "true"
+      labels:
+        app: filebeat-crab
+    spec:
+      containers:
+      - args:
+        - bash
+        - -c
+        - filebeat -c /etc/filebeat.yml --path.data /data/filebeat/${MY_NODE_NAME}/data -e
+        env:
+        - name: MY_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: MY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        image: docker.elastic.co/beats/filebeat:8.5.1
+        imagePullPolicy: IfNotPresent
+        name: filebeat
+        resources:
+          limits:
+            cpu: "1"
+            memory: "1Gi"
+          requests:
+            cpu: 200m
+            memory: 128Mi
+        volumeMounts:
+        - mountPath: /var/log/pods
+          name: varlogpods
+          readOnly: true
+        - mountPath: /var/log/containers
+          name: varlogcontainers
+          readOnly: true
+        - mountPath: /etc/filebeat.yml
+          name: config
+          subPath: filebeat.yml
+        - mountPath: /data
+          name: data
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - hostPath:
+          path: /var/log/pods
+          type: ""
+        name: varlogpods
+      - hostPath:
+          path: /var/log/containers
+          type: ""
+        name: varlogcontainers
+      - emptyDir: {}
+        name: data
+      - configMap:
+          defaultMode: 416
+          name: filebeat-crab-config
+        name: config


### PR DESCRIPTION
~~**PLEASE, DO NOT MERGE.**~~
~~Waiting until https://github.com/dmwm/WMCore/issues/11459 resolve.~~
*Above issue is fixed in wmcore 2.1.7rc3 release.*

Implement https://github.com/dmwm/CRABServer/issues/7463#issuecomment-1344306384, [CMSKUBERNETES-215](https://its.cern.ch/jira/browse/CMSKUBERNETES-215)

Changes:
- `run.sh` 
  - Accept `CRABSERVER_LOGSTDOUT=t`, setup crabrest writing logs to stdout (with help of  [dmwm/deployment#1240](https://github.com/dmwm/deployment/pull/1240)).
- `crabserver.yaml` 
  - New `CRABSERVER_LOGSTDOUT=t` env .
  - New Filebeat Daemonset for crabserver logs.
  - Remove sidecar from `crabserver` pod.
- `monitor.sh` Fix multiple `process_monitor.sh` when start pod. Also,  execute `/data/monitor.sh` as background process in `run.sh`.
- `logstash.conf` Update logstash config.
  - Fix parsing HTTP Call when clientip has port in it.
  - Fix wrong field name in `MeasureTime:seconds` log.
  - Parsing pod_name from log file path.