### PR TITLE
Script for renewing proxies on testbed and production VMs.

### DIFF
--- a/kubernetes/cmsweb/daemonset/frontendx509-ds.yaml
+++ b/kubernetes/cmsweb/daemonset/frontendx509-ds.yaml
@@ -77,7 +77,7 @@ spec:
               apiVersion: v1
               fieldPath: metadata.name
         ports:
-        - containerPort: 80
+        - containerPort: 8080
           name: http
         - containerPort: 8443
           name: services

--- a/kubernetes/cmsweb/daemonset/frontendx509-ds.yaml
+++ b/kubernetes/cmsweb/daemonset/frontendx509-ds.yaml
@@ -77,6 +77,8 @@ spec:
               apiVersion: v1
               fieldPath: metadata.name
         ports:
+        - containerPort: 80
+          name: http
         - containerPort: 8443
           name: services
         - containerPort: 18443

--- a/kubernetes/cmsweb/daemonset/frontendx509-ds.yaml
+++ b/kubernetes/cmsweb/daemonset/frontendx509-ds.yaml
@@ -77,8 +77,6 @@ spec:
               apiVersion: v1
               fieldPath: metadata.name
         ports:
-        - containerPort: 80
-          name: http
         - containerPort: 8443
           name: services
         - containerPort: 18443

--- a/kubernetes/cmsweb/daemonset/frontendx509-ds.yaml
+++ b/kubernetes/cmsweb/daemonset/frontendx509-ds.yaml
@@ -77,7 +77,7 @@ spec:
               apiVersion: v1
               fieldPath: metadata.name
         ports:
-        - containerPort: 8080
+        - containerPort: 80
           name: http
         - containerPort: 8443
           name: services

--- a/kubernetes/cmsweb/scripts/renewVMProxy.sh
+++ b/kubernetes/cmsweb/scripts/renewVMProxy.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+if [[ ( $@ == "--help") ||  $@ == "-h" || $# -ne 1 ]]
+then
+	echo "Usage: This helper script is used for renewing th proxy in testbed and prodction VMs. Please use the ./renewVMProxy.sh <username>"
+	exit 0
+fi
+admin_username=$1
+BHOSTS="vocms0731 vocms0132 vocms0136 vocms0738 vocms0739 vocms0841 vocms0842 vocms0843 vocms0844"
+for host in $BHOSTS
+do
+  echo "Operating on node $host.."
+  ssh $host -l cmsweb /bin/sh -s "$admin_username" << "EOF"
+    cd /data/srv/current/auth/proxy
+    admin_username=$1
+    if [ -f "seed-$admin_username.cert" ]; then
+      mv seed-$admin_username.cert proxy-$admin_username.cert
+    fi
+    /data/srv/current/config/admin/ProxyRenew /data/certs /data/srv/current/auth/proxy cmsweb_backends cms
+    echo "Done. Verifying if the proxy is valid.."
+    openssl x509 -enddate -noout -in /data/srv/current/auth/proxy/proxy.cert
+    exit
+EOF
+done


### PR DESCRIPTION
Sometimes, the proxies in the VMs expire, and they urgently need to be renewed. This script helps in urgently renewing the proxies in all the testbed and production VMs.