### PR TITLE
Add cpueff-goweb

### DIFF
--- a/docker/cpueff-goweb/Dockerfile-cpueff-goweb
+++ b/docker/cpueff-goweb/Dockerfile-cpueff-goweb
@@ -1,0 +1,17 @@
+FROM golang:latest as go-builder
+MAINTAINER Ceyhun Uzunoglu ceyhunuzngl@gmail.com
+
+# tag to use
+ARG CMSMON_TAG=cpueff-0.0.0
+ENV WDIR=/data
+
+# build
+WORKDIR $GOPATH/src/github.com/dmwm
+RUN git clone https://github.com/dmwm/CMSMonitoring.git && cd CMSMonitoring && git checkout tags/$CMSMON_TAG -b build
+WORKDIR $GOPATH/src/github.com/dmwm/CMSMonitoring/cpueff-goweb
+
+RUN mkdir -p $WDIR && make && cp -r cpueff-goweb static config.json $WDIR
+
+FROM gcr.io/distroless/base
+COPY --from=go-builder /data /data/
+WORKDIR /data

--- a/docker/cpueff-goweb/Dockerfile-cpueff-spark
+++ b/docker/cpueff-goweb/Dockerfile-cpueff-spark
@@ -1,0 +1,34 @@
+# cpueff-spark
+FROM mongo:5.0.14 as builder
+FROM registry.cern.ch/cmsmonitoring/cmsmon-hadoop-base:spark3-latest
+MAINTAINER Ceyhun Uzunoglu ceyhunuzngl@gmail.com
+
+# tag to use
+ARG CMSMON_TAG=cpueff-0.0.0
+ENV WDIR=/data
+WORKDIR $WDIR
+
+ENV HADOOP_CONF_DIR=/etc/hadoop/conf
+ENV PATH="${PATH}:/usr/hdp/hadoop/bin/hadoop:/usr/hdp/spark3/bin:/usr/hdp/sqoop/bin:${WDIR}/CMSMonitoring/cpueff-goweb/spark"
+ENV PYTHONPATH "${PYTHONPATH}:${WDIR}:${WDIR}/CMSSpark/src/python:${WDIR}/CMSMonitoring/src/python:${WDIR}/CMSMonitoring/cpueff-goweb/spark"
+
+# How to find: source LCG102 hadoop setup, which python, ln -ls python, voila!
+ENV PYSPARK_PYTHON=/cvmfs/sft.cern.ch/lcg/releases/Python/3.9.12-9a1bc/x86_64-centos7-gcc8-opt/bin/python3
+ENV PYSPARK_DRIVER_PYTHON=/usr/bin/python3
+ENV LC_ALL=en_US.utf-8 LANG=en_US.utf-8
+
+COPY --from=builder /usr/bin/mongoimport $WDIR
+COPY --from=builder /usr/bin/mongosh $WDIR
+
+RUN mkdir -p $WDIR/logs && \
+    git clone https://github.com/dmwm/CMSSpark.git &&  \
+    git clone https://github.com/dmwm/CMSMonitoring.git &&  \
+    cd CMSMonitoring && git checkout tags/$CMSMON_TAG -b build && cd .. && \
+    zip -r CMSMonitoring.zip CMSMonitoring/src/python/CMSMonitoring/* && \
+    pip install --no-cache-dir stomp.py==7.0.0 click pyspark pandas numpy schema seaborn matplotlib plotly && \
+    hadoop-set-default-conf.sh analytix && source hadoop-setconf.sh analytix 3.2 spark3
+
+WORKDIR $WDIR
+
+# Run crond
+CMD ["crond", "-n", "-s", "&"]

--- a/docker/cpueff-goweb/README.md
+++ b/docker/cpueff-goweb/README.md
@@ -1,0 +1,15 @@
+# cpueff-goweb and cpueff-spark
+
+Build by dmwm/CMSMonitoring GH workflows
+
+## cpueff-goweb
+
+Notes:
+- Built by github wf
+- `gcr.io/distroless/static` gives: standard_init_linux.go:219: exec user process caused: no such file or directory.
+  - it seems go executable requires `libc` somewhere
+  - Reference for `libc` in go: https://github.com/GoogleContainerTools/distroless/blob/main/base/README.md
+
+
+#### References
+- docker/dbs2go/Dockerfile

--- a/kubernetes/monitoring/deploy-secrets.sh
+++ b/kubernetes/monitoring/deploy-secrets.sh
@@ -13,6 +13,7 @@ set -e
 ##H        cms-eos-mon-secrets
 ##H        cmsmon-mongo-secrets
 ##H        condor-cpu-eff-secrets
+##H        cpueff-mongo-secrets
 ##H        cron-size-quotas-secrets
 ##H        cron-spark-jobs-secrets
 ##H        dm-auth-secrets
@@ -144,8 +145,17 @@ elif [ "$secret" == "cmsmon-mongo-secrets" ]; then
     cmsmonit_f="--from-file=${sdir}/cmsmonit-keytab/keytab"
     mongo_f=`ls $sdir/cmsmon-mongo-secrets/ | awk '{ORS=" " ; print "--from-file="D"/"$1""}' D=$sdir/cmsmon-mongo-secrets | sed "s, $,,g"`
     files="${mongo_f} ${cmsmonit_f} ${literals}"
-    # Double quoted literals variable in "kubectl create secret generic" only provide first literal because of unknown issue ...
-    #   because of this we embed literals in files variable
+    unset literals
+elif [ "$secret" == "cpueff-mongo-secrets" ]; then
+    mongo_envs="MONGO_ROOT_USERNAME MONGO_ROOT_PASSWORD MONGO_USERNAME MONGO_PASSWORD MONGO_USERS_LIST"
+    literals=""
+    for mongo_env in $mongo_envs; do
+        temp_env_val=$(grep "$mongo_env" $sdir/cpueff-mongo-secrets/secrets | awk '{print $2}')
+        literals="--from-literal=${mongo_env}=${temp_env_val} ${literals}"
+    done
+    cmsmonit_f="--from-file=${sdir}/cmsmonit-keytab/keytab"
+    mongo_f=$(ls $sdir/cpueff-mongo-secrets/ | awk '{ORS=" " ; print "--from-file="D"/"$1""}' D=$sdir/cpueff-mongo-secrets | sed "s, $,,g")
+    files="${mongo_f} ${cmsmonit_f} ${literals}"
     unset literals
 elif [ "$secret" == "cron-size-quotas-secrets" ]; then
     files="--from-file=${sdir}/cmsmonit-keytab/keytab"

--- a/kubernetes/monitoring/services/cpueff/README.md
+++ b/kubernetes/monitoring/services/cpueff/README.md
@@ -1,0 +1,32 @@
+# CPU Efficiency Web Service
+
+References:
+
+- https://phoenixnap.com/kb/kubernetes-mongodb
+
+### Test utils
+
+```
+# Change ClusterIP to NodePort for test and set 32017 as node port
+
+# Connect to Mongo Compass url
+mongodb://admin:password@[CLUSTER-NAME]-xxxxx-node-0:32017
+```
+
+### Login to mongo client
+
+```shell
+apt-get update
+apt-get install nano
+
+# Service name is cmsmon-mongo
+# Headless FQDN definition: <StatefulSet name>-<sequence number>.<Service name>.<Namespace name>.svc.cluster.local
+mongo --host mongodb-0.mongodb.cpueff.svc.cluster.local --port 27017 -u admin -p password
+show dbs
+use cpueff
+show collections
+
+# Use mongoimport cli
+mongoimport --host mongodb-0.mongodb.cpueff.svc.cluster.local --port 27017 -u admin -p password \
+    --authenticationDatabase admin --db cpueff --collection sc_task --file test.json --type=json
+```

--- a/kubernetes/monitoring/services/cpueff/cpueff-goweb.yaml
+++ b/kubernetes/monitoring/services/cpueff/cpueff-goweb.yaml
@@ -1,0 +1,99 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: cpueff-goweb
+  namespace: cpueff
+spec:
+  selector:
+    app: cpueff-goweb
+  type: NodePort
+  ports:
+    - port: 8080
+      nodePort: 31380
+      targetPort: 8080
+      name: web
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: cpueff-goweb
+  namespace: cpueff
+  labels:
+    app: cpueff-goweb
+data:
+  config.json: |
+    {
+        "port": 8080,
+        "verbose": 1,
+        "env_file": "/etc/secrets/client_env",
+        "read_timeout": 600,
+        "write_timeout": 600,
+        "mongo_connection_timeout": 600,
+        "base_endpoint": "cpueff",
+        "collection_names": {
+            "sc_task": "sc_task",
+            "sc_task_cmsrun": "sc_task_cmsrun",
+            "sc_task_cmsrun_jobtype": "sc_task_cmsrun_jobtype",
+            "sc_task_cmsrun_jobtype_site": "sc_task_cmsrun_jobtype_site",
+            "condor_main": "condor_main",
+            "condor_detailed": "condor_detailed",
+            "short_url": "short_url",
+            "datasource_timestamp": "source_timestamp"
+        }
+    }
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  labels:
+    app: cpueff-goweb
+  name: cpueff-goweb
+  namespace: cpueff
+spec:
+  selector:
+    matchLabels:
+      app: cpueff-goweb
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: cpueff-goweb
+    spec:
+      containers:
+      - name: cpueff-goweb
+        image: registry.cern.ch/cmsmonitoring/cpueff-goweb:cpueff-0.0.0
+        # image: golang
+        # command: [ "sleep" ]
+        # args: [ "infinity" ]
+        args:
+          - /data/cpueff-goweb
+          - -config
+          - /data/etc/config.json
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+          name: web
+        env:
+        - name: GIN_MODE
+          value: release
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 2Gi
+          requests:
+            cpu: 250m
+            memory: 250Mi
+        volumeMounts:
+        - name: cpueff-mongo-secrets
+          mountPath: /etc/secrets
+          readOnly: true
+        - name: configmap-config-json
+          mountPath: /data/etc
+      volumes:
+      - name: cpueff-mongo-secrets
+        secret:
+          secretName: cpueff-mongo-secrets
+          defaultMode: 0444
+      - name: configmap-config-json
+        configMap:
+          name: cpueff-goweb

--- a/kubernetes/monitoring/services/cpueff/cpueff-spark.yaml
+++ b/kubernetes/monitoring/services/cpueff/cpueff-spark.yaml
@@ -1,0 +1,210 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: cpueff-spark
+  namespace: cpueff
+spec:
+  selector:
+    app: cpueff-spark
+  type: NodePort
+  ports:
+    - name: port-0 # spark.driver.port
+      nodePort: 31205
+      port: 31205
+      protocol: TCP
+      targetPort: 31205
+    - name: port-1 # spark.driver.blockManager.port
+      nodePort: 31206
+      port: 31206
+      protocol: TCP
+      targetPort: 31206
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: cm-cpueff-spark
+  namespace: cpueff
+  labels:
+    app: cpueff-spark
+data:
+  run_spark2mongo.sh: |
+    #!/bin/bash
+    export MONGO_WRITE_DB="cpueff"
+    export MONGO_AUTH_DB="admin"
+    export MONGO_HOST="mongodb-0.mongodb.cpueff.svc.cluster.local"
+    export MONGO_PORT="27017"                   
+    . /etc/environment
+    echo "Starting run_spark2mongo.sh ..."
+        /data/CMSMonitoring/cpueff-goweb/spark/cron4cpueff_goweb.sh \
+      --keytab /etc/secrets/keytab --p1 31205 --p2 31206 --host $MY_NODE_NAME --wdir $WDIR
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cpueff-spark
+  namespace: cpueff
+spec:
+  # UTC
+  schedule: "30 05 * * *"
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            app: cpueff-spark
+        spec:
+          restartPolicy: Never
+          hostname: cpueff-spark
+          containers:
+            - name: cpueff-spark
+              image: registry.cern.ch/cmsmonitoring/cpueff-spark:cpueff-0.0.0
+              command: [ "/bin/bash", "-c" ]
+              args:
+                - source /etc/environment;
+                  /data/cronjob/run_spark2mongo.sh;
+              env:
+                - name: MY_NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
+                - name: MONGO_ROOT_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: cpueff-mongo-secrets
+                      key: MONGO_ROOT_USERNAME
+                      optional: false
+                - name: MONGO_ROOT_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: cpueff-mongo-secrets
+                      key: MONGO_ROOT_PASSWORD
+                      optional: false
+                - name: K8S_ENV
+                  value: "prod"
+                - name: PUSHGATEWAY_URL
+                  # value: pushgateway.default.svc.cluster.local:9091
+                  value: "cms-monitoring:30091"
+              ports:
+                - containerPort: 31205 # spark.driver.port
+                  name: port-0
+                - containerPort: 31206 # spark.driver.blockManager.port
+                  name: port-1
+              lifecycle:
+                postStart:
+                  exec:
+                    command:
+                      - "sh"
+                      - "-c"
+                      - >
+                        export > /etc/environment;
+              resources:
+                limits:
+                  cpu: 2000m
+                  memory: 6Gi
+                requests:
+                  cpu: 500m
+                  memory: 750Mi
+              stdin: true
+              tty: true
+              volumeMounts:
+                - name: cpueff-mongo-secrets
+                  mountPath: /etc/secrets
+                  readOnly: true
+                - name: cronjobs-configmap
+                  mountPath: /data/cronjob
+          volumes:
+            - name: cpueff-mongo-secrets
+              secret:
+                secretName: cpueff-mongo-secrets
+                defaultMode: 0444
+            - name: cronjobs-configmap
+              configMap:
+                name: cm-cpueff-spark
+                defaultMode: 0777
+
+#---
+#apiVersion: apps/v1
+#kind: Deployment
+#metadata:
+#  name: cpueff-spark
+#  namespace: cpueff
+#  labels:
+#    app: cpueff-spark
+#spec:
+#  replicas: 1
+#  selector:
+#    matchLabels:
+#      app: cpueff-spark
+#  template:
+#    metadata:
+#      labels:
+#        app: cpueff-spark
+#    spec:
+#      hostname: cpueff-spark
+#      containers:
+#        - name: cpueff-spark
+#          image: registry.cern.ch/cmsmonitoring/cpueff-spark:cpueff-0.0.0
+#          command: [ "sleep" ]
+#          args: [ "infinity" ]
+#          env:
+#            - name: MY_NODE_NAME
+#              valueFrom:
+#                fieldRef:
+#                  fieldPath: spec.nodeName
+#            - name: MONGO_ROOT_USERNAME
+#              valueFrom:
+#                secretKeyRef:
+#                  name: cpueff-mongo-secrets
+#                  key: MONGO_ROOT_USERNAME
+#                  optional: false
+#            - name: MONGO_ROOT_PASSWORD
+#              valueFrom:
+#                secretKeyRef:
+#                  name: cpueff-mongo-secrets
+#                  key: MONGO_ROOT_PASSWORD
+#                  optional: false
+#            - name: K8S_ENV
+#              value: "prod"
+#            - name: PUSHGATEWAY_URL
+#              # value: pushgateway.default.svc.cluster.local:9091
+#              value: "cms-monitoring:30091"
+#          ports:
+#            - containerPort: 31205 # spark.driver.port
+#              name: port-0
+#            - containerPort: 31206 # spark.driver.blockManager.port
+#              name: port-1
+#          lifecycle:
+#            postStart:
+#              exec:
+#                command:
+#                  - "sh"
+#                  - "-c"
+#                  - >
+#                    export > /etc/environment;
+#          resources:
+#            limits:
+#              cpu: 2000m
+#              memory: 6Gi
+#            requests:
+#              cpu: 500m
+#              memory: 750Mi
+#          stdin: true
+#          tty: true
+#          volumeMounts:
+#            - name: cpueff-mongo-secrets
+#              mountPath: /etc/secrets
+#              readOnly: true
+#            - name: cronjobs-configmap
+#              mountPath: /data/cronjob
+#      volumes:
+#        - name: cpueff-mongo-secrets
+#          secret:
+#            secretName: cpueff-mongo-secrets
+#            defaultMode: 0444
+#        - name: cronjobs-configmap
+#          configMap:
+#            name: cm-cpueff-spark
+#            defaultMode: 0777

--- a/kubernetes/monitoring/services/cpueff/mongo-cpueff.yaml
+++ b/kubernetes/monitoring/services/cpueff/mongo-cpueff.yaml
@@ -1,0 +1,126 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongodb
+  namespace: cpueff
+  labels:
+    app: mongodb
+#spec:
+#  selector:
+#    app: mongodb
+#  type: NodePort
+#  ports:
+#  - port: 27017
+#    nodePort: 32017
+#    targetPort: 27017
+#    name: mongo
+spec:
+  clusterIP: None
+  selector:
+    app: mongodb
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mongodb
+  namespace: cpueff
+spec:
+  serviceName: mongodb
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mongodb
+  template:
+    metadata:
+      namespace: cpueff
+      labels:
+        app: mongodb
+        selector: mongodb
+    spec:
+      containers:
+      - name: mongodb
+        image: registry.cern.ch/cmsmonitoring/cmsmon-mongo:5.0.9
+        args: [ "--tlsAllowInvalidHostnames","--dbpath","/data/db","--profile","2","--slowms","9","--slowOpSampleRate","0.5"]
+        livenessProbe:
+          exec:
+            command:
+              - mongo
+              - --disableImplicitSessions
+              - --eval
+              - "db.adminCommand('ping')"
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 6
+        readinessProbe:
+          exec:
+            command:
+              - mongo
+              - --disableImplicitSessions
+              - --eval
+              - "db.adminCommand('ping')"
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 6
+        resources:
+          limits:
+            cpu: 3000m
+            memory: 6Gi
+          requests:
+            cpu: 250m
+            memory: 200Mi
+        env:
+          - name: MONGO_ROOT_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: cpueff-mongo-secrets
+                key: MONGO_ROOT_USERNAME
+                optional: false
+          - name: MONGO_ROOT_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: cpueff-mongo-secrets
+                key: MONGO_ROOT_PASSWORD
+                optional: false
+          - name: MONGO_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: cpueff-mongo-secrets
+                key: MONGO_USERNAME
+                optional: false
+          - name: MONGO_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: cpueff-mongo-secrets
+                key: MONGO_PASSWORD
+                optional: false
+          - name: MONGO_USERS_LIST
+            valueFrom:
+              secretKeyRef:
+                name: cpueff-mongo-secrets
+                key: MONGO_USERS_LIST
+                optional: false
+          - name: MONGO_INITDB_ROOT_USERNAME_FILE # Required by MongoDB
+            value: /etc/secrets/MONGO_INITDB_ROOT_USERNAME_FILE
+          - name: MONGO_INITDB_ROOT_PASSWORD_FILE # Required by MongoDB
+            value: /etc/secrets/MONGO_INITDB_ROOT_PASSWORD_FILE
+        volumeMounts:
+        - name: cpueff-mongo-secrets
+          mountPath: /etc/secrets
+          readOnly: true
+        - name: cmsmon-mongo-data
+          mountPath: /data/db
+      volumes:
+        - name: cpueff-mongo-secrets
+          secret:
+            secretName: cpueff-mongo-secrets
+            defaultMode: 0444
+        - name: cmsmon-mongo-data
+          emptyDir: {}
+
+# References
+#  - https://devopscube.com/deploy-mongodb-kubernetes/
+#  - https://phoenixnap.com/kb/kubernetes-mongodb

--- a/kubernetes/monitoring/services/datasetmon/spark2mng.yaml
+++ b/kubernetes/monitoring/services/datasetmon/spark2mng.yaml
@@ -33,8 +33,7 @@ data:
     echo "Starting run_spark2hdfs.sh ..."
     /data/CMSMonitoring/rucio-dataset-monitoring/spark/cron4rucio_spark2hdfs.sh \
       --keytab /etc/secrets/keytab --hdfs /tmp/cmsmonit/prod \
-      --p1 $SPARK2MNG_SERVICE_PORT_PORT_0 \
-      --p2 $SPARK2MNG_SERVICE_PORT_PORT_1 \
+      --p1 31203 --p2 31204 \
       --host $MY_NODE_NAME --wdir $WDIR
   run_hdfs2mongo.sh: |
     #!/bin/bash


### PR DESCRIPTION
Add cpueff-goweb GoLang web service kubernetes and docker configurations : https://github.com/dmwm/CMSMonitoring/pull/204

It is in test now, open to CERN internal network: [cpueff-goweb](http://cmsmon-test-2tzv4rdqsho2-node-0:31380)

