### PR TITLE
Edit cpueff-goweb

### DIFF
--- a/kubernetes/monitoring/services/cpueff/cpueff-goweb.yaml
+++ b/kubernetes/monitoring/services/cpueff/cpueff-goweb.yaml
@@ -81,7 +81,7 @@ spec:
     spec:
       containers:
       - name: cpueff-goweb
-        image: registry.cern.ch/cmsmonitoring/cpueff-goweb:cpueff-0.0.6
+        image: registry.cern.ch/cmsmonitoring/cpueff-goweb:cpueff-0.0.7
         # image: golang
         # command: [ "sleep" ]
         # args: [ "infinity" ]

--- a/kubernetes/monitoring/services/cpueff/cpueff-spark.yaml
+++ b/kubernetes/monitoring/services/cpueff/cpueff-spark.yaml
@@ -61,7 +61,7 @@ spec:
           hostname: cpueff-spark
           containers:
             - name: cpueff-spark
-              image: registry.cern.ch/cmsmonitoring/cpueff-spark:cpueff-0.0.4
+              image: registry.cern.ch/cmsmonitoring/cpueff-spark:cpueff-0.0.7
               command: [ "/bin/bash", "-c" ]
               args:
                 - source /etc/environment;


### PR DESCRIPTION
Condor CPU efficiency tables require different external service urls. Their formattable url strings are included in ConfigMap for reusability.