### PR TITLE
Remove ms-output dependency on ms-output-mongo

### DIFF
--- a/kubernetes/cmsweb/services/reqmgr2ms-output.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-output.yaml
@@ -183,10 +183,6 @@ spec:
 #PROD#    readOnly: true
 #PROD#  securityContext:
 #PROD#    allowPrivilegeEscalation: false
-      initContainers:
-      - name: checkmongodb
-        image: busybox:1.28
-        command: ['sh', '-c', 'until nslookup ms-output-mongo.dmwm; do echo "Waiting for ms-output-mongo"; sleep 10; done;']
       volumes:
       - name: rucio-secrets
         secret:

--- a/kubernetes/cmsweb/vault/services/reqmgr2ms-output.yaml
+++ b/kubernetes/cmsweb/vault/services/reqmgr2ms-output.yaml
@@ -153,14 +153,6 @@ spec:
         - mountPath: /etc/token
           name: token-secrets
           readOnly: true
-      initContainers:
-      - command:
-        - sh
-        - -c
-        - until nslookup ms-output-mongo.dmwm; do echo "Waiting for ms-output-mongo";
-          sleep 10; done;
-        image: busybox:1.28
-        name: checkmongodb
       securityContext:
         fsGroup: 2000
         runAsGroup: 1000


### PR DESCRIPTION
Otherwise MSOutput will get stuck in the `Init` kubernetes status. Given that we have migrated MSOutput to MongoDB as a service (for a few months now), there is really no need for this neither to keep ms-output-mongo service running.