### PR TITLE
Explicitly specifying node names in `values.yaml.`

### DIFF
--- a/helm/mongodb/Chart.yaml
+++ b/helm/mongodb/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: mongodb
 description: A Helm chart for launching a MongoDB ReplicaSet with 3 instances
 type: application
-version: 1.0.3
-appVersion: 1.0.3
+version: 1.0.4
+appVersion: 1.0.4

--- a/helm/mongodb/templates/deployment.yaml
+++ b/helm/mongodb/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $environment := .Values.environment | default dict }}
 ---
 apiVersion: v1
 kind: Service
@@ -65,12 +66,22 @@ spec:
           env:
             - name: "RS_NAME"
               value: {{.Values.db.rsname}}
+          {{- if  (eq (toString $environment) "prod") }}
             - name: "NODE_HOSTNAME_ONE"
-              value: {{.Values.db.nodeHostname.one}}
+              value: {{.Values.db.nodeName.prod.one}}
             - name: "NODE_HOSTNAME_TWO"
-              value: {{.Values.db.nodeHostname.two}}
+              value: {{.Values.db.nodeName.prod.two}}
             - name: "NODE_HOSTNAME_THREE"
-              value: {{.Values.db.nodeHostname.three}}
+              value: {{.Values.db.nodeName.prod.three}}
+           {{- end }}
+           {{- if  (eq (toString $environment) "preprod")}}
+            - name: "NODE_HOSTNAME_ONE"
+              value: {{.Values.db.nodeName.preprod.one}}
+            - name: "NODE_HOSTNAME_TWO"
+              value: {{.Values.db.nodeName.preprod.two}}
+            - name: "NODE_HOSTNAME_THREE"
+              value: {{.Values.db.nodeName.preprod.three}}
+            {{- end }}
             - name: "MONGODB_ID"
               value: {{.Values.db.instance0.mongoId | quote}}
             - name: "MONGODB_ADMIN_PASSWORD"

--- a/helm/mongodb/values.yaml
+++ b/helm/mongodb/values.yaml
@@ -1,3 +1,4 @@
+environment: test
 quickSetting:
   namespace: default
   env: test-rs
@@ -12,12 +13,18 @@ monitoring:
   jobName: "mongodb-exporter"
 db:
   rsname: "cms-rs"
-  nodeHostname: 
-    one: nodeHostName1
-    two: nodeHostName2
-    three: nodeHostName3
   clusterName: mongodb
   env: k8s-mongo
+#ensuring different explicit node names for prod and preprod cluster
+  nodeName:
+    prod:
+      one: cms-mongo-prod-node-0.cern.ch
+      two: cms-mongo-prod-node-1.cern.ch
+      three: cms-mongo-prod-node-2.cern.ch
+    preprod:
+      one: cms-mongo-preprod-node-0.cern.ch
+      two: cms-mongo-preprod-node-1.cern.ch
+      three: cms-mongo-preprod-node-2.cern.ch
   auth:
     password: password
     keyfile: keyfile


### PR DESCRIPTION
Hi @todor-ivanov,

This PR explicitly defines the host names for mongodb prod and preprod cluster. Kindly review it.

Thanks.