### PR TITLE
[cpueff-goweb] remove k8s cm for config.json and use default config.json instead

### DIFF
--- a/kubernetes/monitoring/services/cpueff/cpueff-goweb.yaml
+++ b/kubernetes/monitoring/services/cpueff/cpueff-goweb.yaml
@@ -13,59 +13,6 @@ spec:
       targetPort: 8080
       name: http
 ---
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: cpueff-goweb
-  namespace: cpueff
-  labels:
-    app: cpueff-goweb
-data:
-  config.json: |
-    {
-        "port": 8080,
-        "is_test": false,
-        "verbose": 0,
-        "env_file": "/etc/secrets/client_env",
-        "read_timeout": 600,
-        "write_timeout": 600,
-        "mongo_connection_timeout": 600,
-        "base_endpoint": "web/cpueff",
-        "collection_names": {
-            "sc_task": "sc_task",
-            "sc_task_cmsrun": "sc_task_cmsrun",
-            "sc_task_cmsrun_jobtype": "sc_task_cmsrun_jobtype",
-            "sc_task_cmsrun_jobtype_site": "sc_task_cmsrun_jobtype_site",
-            "condor_main": "condor_main",
-            "condor_detailed": "condor_detailed",
-            "condor_tiers": "condor_tiers",
-            "short_url": "short_url",
-            "datasource_timestamp": "source_timestamp"
-        },
-        "external_links": {
-            "str_start_date": "[[__START_DATE__]]",
-            "str_start_date_msec": "[[__START_DATE_MSEC__]]",
-            "str_end_date": "[[__END_DATE__]]",
-            "str_end_date_msec": "[[__END_DATE_MSEC__]]",
-            "str_workflow": "[[__WORKFLOW__]]",
-            "str_wmagent_request_name": "[[__WMAGENT_REQUEST_NAME__]]",
-            "str_site": "[[__SITE__]]",
-            "str_job_type": "[[__JOB_TYPE__]]",
-            "str_task_name": "[[__TASK_NAME__]]",
-            "str_task_name_prefix": "[[__TASK_NAME_PREFIX__]]",
-            "link_monte_carlo_management": "<a href=\"https://cms-pdmv.cern.ch/mcm/requests?prepid=[[__WORKFLOW__]]\" target=\"_blank\" >McM</a>",
-            "link_dmytro_prod_mon": "<a href=\"https://dmytro.web.cern.ch/dmytro/cmsprodmon/workflows.php?prep_id=task_[[__WORKFLOW__]]\" target=\"_blank\">PMon</a>",
-            "link_unified_report": "<a href=\"https://cms-unified.web.cern.ch/cms-unified/report/[[__WMAGENT_REQUEST_NAME__]]\" target=\"_blank\">Unified</a>",
-            "link_es_cms": "<a href=\"https://es-cms.cern.ch/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:'[[__START_DATE__]]T00:00:00.000Z',to:'[[__END_DATE__]]T00:00:00.000Z'))&_a=(columns:!(RequestCpus,CpuEff,CpuTimeHr,WallClockHr,Site,RequestMemory,RequestMemory_Eval,CpuEffOutlier,Tier),index:'cms-20*',interval:auto,query:(language:lucene,query:'Tier:%2FT1%7CT2%2F%20AND%20Workflow:%22[[__WORKFLOW__]]%22%20AND%20WMAgent_RequestName:%22[[__WMAGENT_REQUEST_NAME__]]%22%20AND%20CpuEffOutlier:0%20AND%20Status:Completed%20AND%20JobFailed:0'),sort:!(RecordTime,desc))\" target=\"_blank\">ES_T1T2</a>",
-            "link_es_cms_with_site": "<a href=\"https://es-cms.cern.ch/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:'[[__START_DATE__]]T00:00:00.000Z',to:'[[__END_DATE__]]T00:00:00.000Z'))&_a=(columns:!(RequestCpus,CpuEff,CpuTimeHr,WallClockHr,Site,RequestMemory,RequestMemory_Eval,CpuEffOutlier),index:'cms-20*',interval:auto,query:(language:lucene,query:'Site:%22[[__SITE__]]%22%20AND%20Workflow:%22[[__WORKFLOW__]]%22%20AND%20WMAgent_RequestName:%22[[__WMAGENT_REQUEST_NAME__]]%22%20AND%20CpuEffOutlier:0%20AND%20Status:Completed%20AND%20JobFailed:0'),sort:!(RecordTime,desc))\" target=\"_blank\">ES</a>",
-            "link_grafana": "<a href=\"https://monit-grafana.cern.ch/d/svwndNBVk/cpu-efficiency-investigation-used-by-web-service?orgId=11&from=[[__START_DATE_MSEC__]]&to=[[__END_DATE_MSEC__]]&var-Bin=1h&var-Site=All&var-Workflow=[[__WORKFLOW__]]&var-WMAgent_RequestName=[[__WMAGENT_REQUEST_NAME__]]\" target=\"_blank\">Grafana</a>",
-            "link_grafana_with_site": "<a href=\"https://monit-grafana.cern.ch/d/svwndNBVk/cpu-efficiency-investigation-used-by-web-service?orgId=11&from=[[__START_DATE_MSEC__]]&to=[[__END_DATE_MSEC__]]&var-Bin=1h&var-Site=[[__SITE__]]&var-Workflow=[[__WORKFLOW__]]&var-WMAgent_RequestName=[[__WMAGENT_REQUEST_NAME__]]\" target=\"_blank\">Grafana</a>",
-            "link_reqmgr": "<a href=\"https://cmsweb.cern.ch/reqmgr2/fetch?rid=[[__TASK_NAME_PREFIX__]]\" target=\"_blank\">RegMgr</a>",
-            "link_es_wmarchive": "<a href=\"https://monit-opensearch.cern.ch/dashboards/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'[[__START_DATE__]]T00:00:00.000Z',to:'[[__END_DATE__]]T00:00:00.000Z'))&_a=(columns:!(data.meta_data.jobtype,data.meta_data.jobstate,data.task,data.Campaign,data.PrepID,data.meta_data.fwjr_id,data.meta_data.host),filters:!(),index:'60770470-8326-11ea-88fc-cfaa9841e350',interval:auto,query:(language:lucene,query:'data.meta_data.jobstate:%22success%22%20%20AND%20data.task:%22[[__TASK_NAME__]]%22'),sort:!(!(metadata.timestamp,desc)))\" target=\"_blank\">WMArc</a>",
-            "link_es_wmarchive_jobtype": "<a href=\"https://monit-opensearch.cern.ch/dashboards/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'[[__START_DATE__]]T00:00:00.000Z',to:'[[__END_DATE__]]T00:00:00.000Z'))&_a=(columns:!(data.meta_data.jobtype,data.meta_data.jobstate,data.task,data.Campaign,data.PrepID,data.meta_data.fwjr_id,data.meta_data.host),filters:!(),index:'60770470-8326-11ea-88fc-cfaa9841e350',interval:auto,query:(language:lucene,query:'data.meta_data.jobtype:%22[[__JOB_TYPE__]]%22%20AND%20data.meta_data.jobstate:%22success%22%20%20AND%20data.task:%22[[__TASK_NAME__]]%22'),sort:!(!(metadata.timestamp,desc)))\" target=\"_blank\">WMArc</a>"
-        }
-    }
----
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -85,14 +32,14 @@ spec:
     spec:
       containers:
       - name: cpueff-goweb
-        image: registry.cern.ch/cmsmonitoring/cpueff-goweb:cpueff-0.0.10
+        image: registry.cern.ch/cmsmonitoring/cpueff-goweb:cpueff-0.0.11
         # image: golang
         # command: [ "sleep" ]
         # args: [ "infinity" ]
         args:
           - /data/cpueff-goweb
           - -config
-          - /data/etc/config.json
+          - /data/cpueff-goweb/config.json
         ports:
         - containerPort: 8080
           protocol: TCP
@@ -111,13 +58,8 @@ spec:
         - name: cpueff-mongo-secrets
           mountPath: /etc/secrets
           readOnly: true
-        - name: configmap-config-json
-          mountPath: /data/etc
       volumes:
       - name: cpueff-mongo-secrets
         secret:
           secretName: cpueff-mongo-secrets
           defaultMode: 0444
-      - name: configmap-config-json
-        configMap:
-          name: cpueff-goweb

--- a/kubernetes/monitoring/services/cpueff/cpueff-spark.yaml
+++ b/kubernetes/monitoring/services/cpueff/cpueff-spark.yaml
@@ -46,7 +46,7 @@ metadata:
   namespace: cpueff
 spec:
   # UTC
-  schedule: "30 05 * * *"
+  schedule: "00 06 * * *"
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 1
   jobTemplate:
@@ -61,7 +61,7 @@ spec:
           hostname: cpueff-spark
           containers:
             - name: cpueff-spark
-              image: registry.cern.ch/cmsmonitoring/cpueff-spark:cpueff-0.0.10
+              image: registry.cern.ch/cmsmonitoring/cpueff-spark:cpueff-0.0.11
               command: [ "/bin/bash", "-c" ]
               args:
                 - source /etc/environment;

--- a/kubernetes/monitoring/services/cron-size-quotas.yaml
+++ b/kubernetes/monitoring/services/cron-size-quotas.yaml
@@ -61,7 +61,7 @@ spec:
     spec:
       containers:
         - name: test
-          image: registry.cern.ch/cmsmonitoring/cmsmon-py:drpy-0.0.9
+          image: registry.cern.ch/cmsmonitoring/cmsmon-py:drpy-0.0.12
           command: [ "crond" ]
           args: [ "-n", "-s" ]
           env:


### PR DESCRIPTION
https://github.com/dmwm/CMSMonitoring/blob/master/cpueff-goweb/config.json is getting more complicated and open to errors if someone provides it as K8s ConfigMap. That's why `cpueff-goweb ConfigMap` is removed and default `~/cpueff-goweb/config.json` will be used.
