### PR TITLE
[cpueff-goweb] fix config path

### DIFF
--- a/kubernetes/monitoring/services/cpueff/cpueff-goweb.yaml
+++ b/kubernetes/monitoring/services/cpueff/cpueff-goweb.yaml
@@ -32,14 +32,14 @@ spec:
     spec:
       containers:
       - name: cpueff-goweb
-        image: registry.cern.ch/cmsmonitoring/cpueff-goweb:cpueff-0.0.11
+        image: registry.cern.ch/cmsmonitoring/cpueff-goweb:cpueff-0.0.12
         # image: golang
         # command: [ "sleep" ]
         # args: [ "infinity" ]
         args:
           - /data/cpueff-goweb
           - -config
-          - /data/cpueff-goweb/config.json
+          - /data/config.json
         ports:
         - containerPort: 8080
           protocol: TCP

--- a/kubernetes/monitoring/services/cpueff/cpueff-spark.yaml
+++ b/kubernetes/monitoring/services/cpueff/cpueff-spark.yaml
@@ -61,7 +61,7 @@ spec:
           hostname: cpueff-spark
           containers:
             - name: cpueff-spark
-              image: registry.cern.ch/cmsmonitoring/cpueff-spark:cpueff-0.0.11
+              image: registry.cern.ch/cmsmonitoring/cpueff-spark:cpueff-0.0.12
               command: [ "/bin/bash", "-c" ]
               args:
                 - source /etc/environment;


### PR DESCRIPTION
We copy config.json to `$WDIR(/data)` in Dockerfile https://github.com/dmwm/CMSKubernetes/blob/master/docker/cpueff-goweb/Dockerfile-cpueff-goweb#L13
So config.json full path should be `/data/config.json`