### PR TITLE
Fix badly set sops executable.

### DIFF
--- a/kubernetes/cmsweb/scripts/deploy-secrets.sh
+++ b/kubernetes/cmsweb/scripts/deploy-secrets.sh
@@ -35,7 +35,7 @@ SOPS=$(command -v sops) || installSops ||  { err=$?; echo "`sops` command is not
 [[ -e $SOPS ]] || installSops || { err=$?; echo "$SOPS is not executable"; exit $err; }
 
 # check if sops is the expected version:
-[[ $($SOPS --version) =~ sops[[:blank:]]+3\.7\.[2,3]+.* ]] || installSops || { err=$?; echo "$SOPS is not the expected version"; exit $err; }
+[[ $($SOPS --version) =~ sops[[:blank:]]+3\.[7-9]+\.[0-9]+.* ]] || installSops || { err=$?; echo "$SOPS is not the expected version"; exit $err; }
 
 # cmsweb configuration area
 echo "+++ cluster name: $cluster_name"

--- a/kubernetes/cmsweb/scripts/deploy-secrets.sh
+++ b/kubernetes/cmsweb/scripts/deploy-secrets.sh
@@ -18,14 +18,15 @@ fi
 mkdir -p $tmpDir
 cd $tmpDir
 
-if [ -z "$(command -v sops)" ]; then
+SOPS=$(command -v sops)  || {
     # download soap in tmp area
     wget -O sops https://github.com/mozilla/sops/releases/download/v3.7.2/sops-v3.7.2.linux.amd64
     chmod u+x sops
     mkdir -p $HOME/bin
     echo "Download and install sops under $HOME/bin"
     cp ./sops $HOME/bin
-fi
+    SOPS="$HOME/bin/sops"
+}
 
 # cmsweb configuration area
 echo "+++ cluster name: $cluster_name"
@@ -75,9 +76,9 @@ if [ "$srv" == "auth-proxy-server" ] || [ "$srv" == "x509-proxy-server" ] || [ "
     for fname in $secretdir/*; do
         if [[ $fname == *.encrypted ]]; then
             if [[ $fname == *.json* ]]; then
-                $HOME/bin/sops --output-type json -d $fname > $secretdir/$(basename $fname .encrypted)
+                $SOPS --output-type json -d $fname > $secretdir/$(basename $fname .encrypted)
             else
-                $HOME/bin/sops -d $fname > $secretdir/$(basename $fname .encrypted)
+                $SOPS -d $fname > $secretdir/$(basename $fname .encrypted)
             fi
         fi
     done
@@ -123,9 +124,9 @@ if [ -d $secretdir ] && [ -n "$(ls $secretdir)" ]; then
 	fi
         if [[ $fname == *.encrypted ]]; then
             if [[ $fname == *.json* ]]; then
-                $HOME/bin/sops --output-type json -d $fname > $secretdir/$(basename $fname .encrypted)
+                $SOPS --output-type json -d $fname > $secretdir/$(basename $fname .encrypted)
             else
-                $HOME/bin/sops -d $fname > $secretdir/$(basename $fname .encrypted)
+                $SOPS -d $fname > $secretdir/$(basename $fname .encrypted)
             fi
             fname=$secretdir/$(basename $fname .encrypted)
             echo "Decrypted file $fname"
@@ -140,7 +141,7 @@ fi
 if [ "$ns" == "dbs" ]; then
     for fname in $conf/dbs/*; do
         if [[ $fname == *.encrypted ]]; then
-            $HOME/bin/sops -d $fname >$conf/dbs/$(basename $fname .encrypted)
+            $SOPS -d $fname >$conf/dbs/$(basename $fname .encrypted)
         fi
     done
     if [ -f $conf/dbs/DBSSecrets.py ]; then

--- a/kubernetes/cmsweb/scripts/deploy-secrets.sh
+++ b/kubernetes/cmsweb/scripts/deploy-secrets.sh
@@ -29,13 +29,13 @@ installSops() {
 }
 
 # check if sops is set at the current machine's path:
-SOPS=$(command -v sops) || installSops ||  { err=$?; echo "`sops` command not setup"; exit $err; }
+SOPS=$(command -v sops) || installSops ||  { err=$?; echo "`sops` command is not properly setup"; exit $err; }
 
 # check if sops is executable:
-[[ -e $SOPS ]] || installSops || { err=$?; echo "`sops` command not executable"; exit $err; }
+[[ -e $SOPS ]] || installSops || { err=$?; echo "$SOPS is not executable"; exit $err; }
 
 # check if sops is the expected version:
-[[ $($SOPS --version) =~ sops[[:blank:]]+3\.7\.[2,3]+.* ]] || installSops || { err=$?; echo "`sops` command not expected version"; exit $err; }
+[[ $($SOPS --version) =~ sops[[:blank:]]+3\.7\.[2,3]+.* ]] || installSops || { err=$?; echo "$SOPS is not the expected version"; exit $err; }
 
 # cmsweb configuration area
 echo "+++ cluster name: $cluster_name"

--- a/kubernetes/cmsweb/scripts/deploy-secrets.sh
+++ b/kubernetes/cmsweb/scripts/deploy-secrets.sh
@@ -18,7 +18,7 @@ fi
 mkdir -p $tmpDir
 cd $tmpDir
 
-SOPS=$(command -v sops)  || {
+installSops() {
     # download soap in tmp area
     wget -O sops https://github.com/mozilla/sops/releases/download/v3.7.2/sops-v3.7.2.linux.amd64
     chmod u+x sops
@@ -27,6 +27,15 @@ SOPS=$(command -v sops)  || {
     cp ./sops $HOME/bin
     SOPS="$HOME/bin/sops"
 }
+
+# check if sops is set at the current machine's path:
+SOPS=$(command -v sops) || installSops ||  { err=$?; echo "`sops` command not setup"; exit $err; }
+
+# check if sops is executable:
+[[ -e $SOPS ]] || installSops || { err=$?; echo "`sops` command not executable"; exit $err; }
+
+# check if sops is the expected version:
+[[ $($SOPS --version) =~ sops[[:blank:]]+3\.7\.[2,3]+.* ]] || installSops || { err=$?; echo "`sops` command not expected version"; exit $err; }
 
 # cmsweb configuration area
 echo "+++ cluster name: $cluster_name"


### PR DESCRIPTION
In the current code the `sops` executable is badly set and always assumed to be present at the user's $HOME.  because the results from the test for the presence of the `sops` command here: https://github.com/dmwm/CMSKubernetes/blob/ee4dd47e0b1a39cc6cabba4acaf0c952e15df28b/kubernetes/cmsweb/scripts/deploy-secrets.sh#L21-L28 are simply ignored for the rest of the script. Currently the test at the lxplus cluster gives positive result:
```
[<user>@lxplus804 cmsweb]$ echo "$(command -v sops)"
/usr/bin/sops
```
And the above manual deployment of the `sops` executable at  the user's home destination simply never happens.
 
This misbehavior may have been masked because in the past the machines at the `lxplus 8` cluster have been missing the the executable at `/usr/bin/sops` and the above test has been always returning negative results, hence  the people who were using the script were always ending up having the package installed at their  $HOME. This is not the case in lxplus machines any more... so this script cannot work in the current form for every body.   

With the current PR the executable to be used down the script is tied to the  result of  the test for the presence of the command. And the artificial installation at the user's $HOME destination happens only if it is missing at the machine from which the current deployment is happening.