### PR TITLE
Add crabserver process exporter to cmsweb prometheus

### DIFF
--- a/kubernetes/cmsweb/monitoring/prometheus-services.yaml
+++ b/kubernetes/cmsweb/monitoring/prometheus-services.yaml
@@ -51,6 +51,10 @@ data:
       - job_name: 'crabserver-service'
         static_configs:
             - targets: ['crabserver.crab.svc.cluster.local:18270']
+      - job_name: 'crabserver-processes'
+        metrics_path: '/crabserver/metrics'
+        static_configs:
+            - targets: ['crabserver.crab.svc.cluster.local:8270']
       - job_name: 'couchdb-service'
         static_configs:
             - targets: ['couchdb.couchdb.svc.cluster.local:9984']


### PR DESCRIPTION
CRAB team deployed new process exporter to monitor crabserver processes. To be able to remote write metrics to CMS Monitoring, we need to scrape them in CMSWEB prometheus. Its job config is added.

@arooshap could you please deploy this to testbed?

@vkuznet we can scrape them directly from Monitoring prometheus like we do for [cherrypy](https://gitlab.cern.ch/cmsmonitoring/cmsmon-configs/-/blob/master/prometheus/cherrypy.json) . I don't want to go against the convention, but I am open to suggestions. What do you think?