### PR TITLE
Set CouchDB image to use 3.2.2 version; fix monitoring.ini in the CouchDB image

### DIFF
--- a/docker/couchdb/Dockerfile
+++ b/docker/couchdb/Dockerfile
@@ -1,4 +1,4 @@
-FROM couchdb
+FROM couchdb:3.2.2
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 
 RUN apt-get update && apt-get install -y vim less sudo wget unzip python pip
@@ -50,7 +50,7 @@ RUN mkdir -p /data/srv/current/config/couchdb \
     && ln -s /etc/secrets/local.ini /data/srv/current/config/couchdb/local.ini
 ADD manage /data/srv/current/config/couchdb/manage
 ADD couchdb-logrotate.conf /data/srv/current/config/couchdb/couchdb-logrotate.conf
-ADD monitoring.ini /data/srv/current/config/couchdb/monitoring.ini
+
 ENV PATH="/opt/couchdb/bin:/usr/local/bin/:${PATH}"
 
 # setup final environment

--- a/docker/couchdb/monitor.sh
+++ b/docker/couchdb/monitor.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 # start couchdb exporter
-nohup couchdb-prometheus-exporter -telemetry.address=":9984" 2>&1 1>& couchdb_exporter.log < /dev/null &
+COUCH_CONFIG=/data/srv/current/auth/couchdb/couchdb_config.ini
+nohup couchdb-prometheus-exporter -telemetry.address=":9984" -logtostderr=true \
+      --config=$COUCH_CONFIG -databases.views=false 2>&1 1>& couchdb_exporter.log < /dev/null &
 
 # run filebeat
 if [ -f /etc/secrets/filebeat.yaml ] && [ -f /usr/bin/filebeat ]; then

--- a/docker/couchdb/monitor.sh
+++ b/docker/couchdb/monitor.sh
@@ -2,8 +2,15 @@
 
 # start couchdb exporter
 COUCH_CONFIG=/data/srv/current/auth/couchdb/couchdb_config.ini
-nohup couchdb-prometheus-exporter -telemetry.address=":9984" -logtostderr=true \
+# test if file is not zero size
+if [ -s "${COUCH_CONFIG}" ]; then
+    sudo cp /etc/secrets/$fname /data/srv/current/auth/$srv/$fname
+    sudo chown $USER.$USER /data/srv/current/auth/$srv/$fname
+    nohup couchdb-prometheus-exporter -telemetry.address=":9984" -logtostderr=true \
       --config=$COUCH_CONFIG -databases.views=false 2>&1 1>& couchdb_exporter.log < /dev/null &
+else
+    echo "ERROR: couchdb_config.ini file is empty and prometheus exporter cannot be started!"
+fi
 
 # run filebeat
 if [ -f /etc/secrets/filebeat.yaml ] && [ -f /usr/bin/filebeat ]; then

--- a/docker/couchdb/run.sh
+++ b/docker/couchdb/run.sh
@@ -71,6 +71,17 @@ for fname in $files; do
     fi
 done
 
+if [ -f /data/srv/current/auth/$srv/couch_creds ]; then
+    # also create the ini configuration for prometheus exporter
+    cp /data/srv/current/auth/$srv/couch_creds /data/srv/current/auth/$srv/couchdb_config.ini
+    sed -i "s+COUCH_USER+couchdb.username+" /data/srv/current/auth/$srv/couchdb_config.ini
+    sed -i "s+COUCH_PASS+couchdb.password+" /data/srv/current/auth/$srv/couchdb_config.ini
+else
+  # create empty file
+  touch /data/srv/current/auth/$srv/couchdb_config.ini
+fi
+
+
 # start the service
 /data/srv/current/config/$srv/manage start 'I did read documentation'
 

--- a/docker/couchdb/run.sh
+++ b/docker/couchdb/run.sh
@@ -78,6 +78,7 @@ if [ -f /data/srv/current/auth/$srv/couch_creds ]; then
     sed -i "s+COUCH_PASS+couchdb.password+" /data/srv/current/auth/$srv/couchdb_config.ini
 else
   # create empty file
+  echo "ERROR: couch_creds file has not been found and prometheus exporter cannot run!"
   touch /data/srv/current/auth/$srv/couchdb_config.ini
 fi
 


### PR DESCRIPTION
As the title says:
* ensure we are using the same CouchDB version as used in preprod/prod (3.2.2)
* stop using monitoring.ini for vanilla couchdb
* fix credentials used for couchdb_prometheus exporter

UPDATE: exporter setup similar to what we have been using in preprod/prod:
https://github.com/dmwm/deployment/blob/master/exporters/manage#L167