### PR TITLE
Changing crabserver's replicas to 8 to reflect what we have in production cluster.

### DIFF
--- a/kubernetes/cmsweb/services/crabserver.yaml
+++ b/kubernetes/cmsweb/services/crabserver.yaml
@@ -43,7 +43,7 @@ spec:
   selector:
     matchLabels:
       app: crabserver
-  replicas: 1 #PROD# 5
+  replicas: 1 #PROD# 8
   template:
     metadata:
       labels:


### PR DESCRIPTION
```
[apervaiz@lxplus805 crabserver]$ k describe deploy crabserver -n crab
Name:                   crabserver
Namespace:              crab
CreationTimestamp:      Fri, 05 Aug 2022 11:52:38 +0200
Labels:                 app=crabserver
Annotations:            deployment.kubernetes.io/revision: 14
Selector:               app=crabserver
Replicas:               8 desired | 8 updated | 8 total | 8 available | 0 unavailable
StrategyType:           RollingUpdate
MinReadySeconds:        0
RollingUpdateStrategy:  25% max unavailable, 25% max surge

```