### PR TITLE
Update monitoring service image tags and spark-3.4

### DIFF
--- a/docker/cmsmon-hadoop-base/Dockerfile-spark3
+++ b/docker/cmsmon-hadoop-base/Dockerfile-spark3
@@ -53,7 +53,7 @@ RUN yum -y update && \
         libaio-devel net-tools lsof bind-utils initscripts patch voms-devel globus-gsi-credential-devel \
         globus-gsi-cert-utils-devel globus-common-devel globus-gsi-sysconfig-devel globus-gsi-callback-devel \
         oracle-instantclient-tnsnames.ora HEP_OSlibs python-pip libffi-devel gcc bzip2-devel zlib-devel wget sqlite-devel \
-        hadoop-bin-3.2 spark-bin-3.3 sqoop-bin-1.4 cern-hadoop-xrootd-connector cern-hadoop-config && \
+        hadoop-bin-3.2 spark-bin-3.4 sqoop-bin-1.4 cern-hadoop-xrootd-connector cern-hadoop-config && \
     yum clean all && rm -rf /var/cache/yum && \
 # Build Python3
     wget https://www.python.org/ftp/python/${PY_VERSION}/Python-${PY_VERSION}.tgz && \
@@ -73,7 +73,7 @@ RUN yum -y update && \
     hadoop-set-default-conf.sh analytix && \
     source hadoop-setconf.sh analytix 3.2 spark3 && \
     touch /etc/hadoop/conf/topology.table.file && ln -s /bin/bash /usr/bin/bashs && \
-    cp /usr/hdp/spark/kubernetes/dockerfiles/spark/entrypoint.sh /usr/bin/entrypoint.sh && \
+    cp /usr/hdp/spark-3.4/kubernetes/dockerfiles/spark/entrypoint.sh /usr/bin/entrypoint.sh && \
     echo "32 */6 * * * root ! /usr/sbin/fetch-crl -q -r 360" >/etc/cron.d/fetch-crl-docker
 # add fetch-crl to fetch all certificates
 

--- a/kubernetes/monitoring/services/cmsmon-hpc-usage.yaml
+++ b/kubernetes/monitoring/services/cmsmon-hpc-usage.yaml
@@ -57,7 +57,7 @@ spec:
       hostname: hpc-usage
       containers:
         - name: hpc-usage
-          image: registry.cern.ch/cmsmonitoring/cmsmon-spark:v0.4.0.27
+          image: registry.cern.ch/cmsmonitoring/cmsmon-spark:v0.4.1.3
           env:
             - name: MY_NODE_NAME
               valueFrom:

--- a/kubernetes/monitoring/services/cmsmon-rucio-ds.yaml
+++ b/kubernetes/monitoring/services/cmsmon-rucio-ds.yaml
@@ -65,7 +65,7 @@ spec:
       hostname: cmsmon-rucio-ds
       containers:
         - name: cmsmon-rucio-ds
-          image: registry.cern.ch/cmsmonitoring/cmsmon-spark:v0.4.0.27
+          image: registry.cern.ch/cmsmonitoring/cmsmon-spark:v0.4.1.3
           env:
             - name: MY_NODE_NAME
               valueFrom:

--- a/kubernetes/monitoring/services/cpueff/cpueff-goweb.yaml
+++ b/kubernetes/monitoring/services/cpueff/cpueff-goweb.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
       - name: cpueff-goweb
-        image: registry.cern.ch/cmsmonitoring/cpueff-goweb:cpueff-0.0.12
+        image: registry.cern.ch/cmsmonitoring/cpueff-goweb:cpueff-0.0.15
         # image: golang
         # command: [ "sleep" ]
         # args: [ "infinity" ]

--- a/kubernetes/monitoring/services/cpueff/cpueff-spark.yaml
+++ b/kubernetes/monitoring/services/cpueff/cpueff-spark.yaml
@@ -61,7 +61,7 @@ spec:
           hostname: cpueff-spark
           containers:
             - name: cpueff-spark
-              image: registry.cern.ch/cmsmonitoring/cpueff-spark:cpueff-0.0.12
+              image: registry.cern.ch/cmsmonitoring/cpueff-spark:cpueff-0.0.15
               command: [ "/bin/bash", "-c" ]
               args:
                 - source /etc/environment;

--- a/kubernetes/monitoring/services/cron-size-quotas.yaml
+++ b/kubernetes/monitoring/services/cron-size-quotas.yaml
@@ -61,7 +61,7 @@ spec:
     spec:
       containers:
         - name: test
-          image: registry.cern.ch/cmsmonitoring/cmsmon-py:drpy-0.0.12
+          image: registry.cern.ch/cmsmonitoring/cmsmon-py:drpy-0.0.14
           command: [ "crond" ]
           args: [ "-n", "-s" ]
           env:

--- a/kubernetes/monitoring/services/cron-spark-jobs.yaml
+++ b/kubernetes/monitoring/services/cron-spark-jobs.yaml
@@ -70,7 +70,7 @@ spec:
       hostname: cron-spark-jobs
       containers:
         - name: cron-spark-jobs
-          image: registry.cern.ch/cmsmonitoring/cmsmon-spark:v0.4.0.27
+          image: registry.cern.ch/cmsmonitoring/cmsmon-spark:v0.4.1.3
           env:
             - name: MY_NODE_NAME
               valueFrom:

--- a/kubernetes/monitoring/services/datasetmon/rucio-mon-goweb.yaml
+++ b/kubernetes/monitoring/services/datasetmon/rucio-mon-goweb.yaml
@@ -66,7 +66,7 @@ spec:
     spec:
       containers:
       - name: rucio-mon-goweb
-        image: registry.cern.ch/cmsmonitoring/rucio-mon-goweb:rgo-0.0.17
+        image: registry.cern.ch/cmsmonitoring/rucio-mon-goweb:rgo-0.0.23
         args:
           - /data/rucio-dataset-monitoring
           - -config

--- a/kubernetes/monitoring/services/datasetmon/spark2mng.yaml
+++ b/kubernetes/monitoring/services/datasetmon/spark2mng.yaml
@@ -71,7 +71,7 @@ spec:
           hostname: spark2mng
           containers:
             - name: spark2mng
-              image: registry.cern.ch/cmsmonitoring/spark2mng:rgo-0.0.17
+              image: registry.cern.ch/cmsmonitoring/spark2mng:rgo-0.0.23
               command: [ "/bin/bash", "-c" ]
               args:
                 - source /etc/environment;

--- a/kubernetes/monitoring/services/es-exporter-wma.yaml
+++ b/kubernetes/monitoring/services/es-exporter-wma.yaml
@@ -41,7 +41,7 @@ spec:
           - -port
           - ":18000"
           name: es-exporter-wma
-          image: registry.cern.ch/cmsmonitoring/cmsmon-alerts:go-0.5.39
+          image: registry.cern.ch/cmsmonitoring/cmsmon-alerts:go-0.6.0
           ports:
           - containerPort: 18000
           volumeMounts:

--- a/kubernetes/monitoring/services/ggus-alerts.yaml
+++ b/kubernetes/monitoring/services/ggus-alerts.yaml
@@ -25,7 +25,7 @@ spec:
           - "cms"
           - "10"
           - "1"
-          image: registry.cern.ch/cmsmonitoring/cmsmon-alerts:go-0.5.39
+          image: registry.cern.ch/cmsmonitoring/cmsmon-alerts:go-0.6.0
           name: alerts
           env:
             - name: X509_USER_PROXY

--- a/kubernetes/monitoring/services/ha/ggus-alerts-ha1.yaml
+++ b/kubernetes/monitoring/services/ha/ggus-alerts-ha1.yaml
@@ -25,7 +25,7 @@ spec:
           - "cms"
           - "10"
           - "1"
-          image: registry.cern.ch/cmsmonitoring/cmsmon-alerts:go-0.5.39
+          image: registry.cern.ch/cmsmonitoring/cmsmon-alerts:go-0.6.0
           name: alerts
           env:
             - name: X509_USER_PROXY

--- a/kubernetes/monitoring/services/ha/ggus-alerts-ha2.yaml
+++ b/kubernetes/monitoring/services/ha/ggus-alerts-ha2.yaml
@@ -25,7 +25,7 @@ spec:
           - "cms"
           - "10"
           - "1"
-          image: registry.cern.ch/cmsmonitoring/cmsmon-alerts:go-0.5.39
+          image: registry.cern.ch/cmsmonitoring/cmsmon-alerts:go-0.6.0
           name: alerts
           env:
             - name: X509_USER_PROXY

--- a/kubernetes/monitoring/services/ha/ssb-alerts-ha1.yaml
+++ b/kubernetes/monitoring/services/ha/ssb-alerts-ha1.yaml
@@ -24,7 +24,7 @@ spec:
           - "http://cms-monitoring-ha1.cern.ch:30093"
           - "60"
           - "1"
-          image: registry.cern.ch/cmsmonitoring/cmsmon-alerts:go-0.5.39
+          image: registry.cern.ch/cmsmonitoring/cmsmon-alerts:go-0.6.0
           name: alerts
           volumeMounts:
           - name: alerts-secrets

--- a/kubernetes/monitoring/services/ha/ssb-alerts-ha2.yaml
+++ b/kubernetes/monitoring/services/ha/ssb-alerts-ha2.yaml
@@ -24,7 +24,7 @@ spec:
           - "http://cms-monitoring-ha2.cern.ch:30093"
           - "60"
           - "1"
-          image: registry.cern.ch/cmsmonitoring/cmsmon-alerts:go-0.5.39
+          image: registry.cern.ch/cmsmonitoring/cmsmon-alerts:go-0.6.0
           name: alerts
           volumeMounts:
           - name: alerts-secrets

--- a/kubernetes/monitoring/services/hdfs-exporter-eos.yaml
+++ b/kubernetes/monitoring/services/hdfs-exporter-eos.yaml
@@ -47,7 +47,7 @@ spec:
       spec:
         containers:
         - name: hdfs-exporter-eos
-          image: registry.cern.ch/cmsmonitoring/sqoop:sqoop-0.1.5
+          image: registry.cern.ch/cmsmonitoring/sqoop:sqoop-0.1.8
           command:
           - /bin/sh
           - /data/setup-and-run/setup-and-run.sh

--- a/kubernetes/monitoring/services/sqoop.yaml
+++ b/kubernetes/monitoring/services/sqoop.yaml
@@ -42,7 +42,7 @@ spec:
             - /data/sqoop/log
             - "7"
             - "7200"
-          image: registry.cern.ch/cmsmonitoring/sqoop:sqoop-0.1.5
+          image: registry.cern.ch/cmsmonitoring/sqoop:sqoop-0.1.8
           name: sqoop
           env:
             - name: CMSSQOOP_ENV

--- a/kubernetes/monitoring/services/ssb-alerts.yaml
+++ b/kubernetes/monitoring/services/ssb-alerts.yaml
@@ -24,7 +24,7 @@ spec:
           - "http://cms-monitoring.cern.ch:30093"
           - "60"
           - "1"
-          image: registry.cern.ch/cmsmonitoring/cmsmon-alerts:go-0.5.39
+          image: registry.cern.ch/cmsmonitoring/cmsmon-alerts:go-0.6.0
           name: alerts
           volumeMounts:
           - name: alerts-secrets


### PR DESCRIPTION
- Upgrade Spark version to 3.4 in monitoring spark required docker images
- Update image tags of monitoring to latest versions