### PR TITLE
Add proxy-secrets to cmsweb prometheus in monitoring namespace

### DIFF
--- a/kubernetes/cmsweb/monitoring/prometheus.yaml
+++ b/kubernetes/cmsweb/monitoring/prometheus.yaml
@@ -27,12 +27,18 @@ spec:
               mountPath: /etc/prometheus
             - name: prometheus-storage-volume
               mountPath: /prometheus/
+            - name: proxy-secrets
+              mountPath: /etc/proxy
+              readOnly: true
       volumes:
         - name: prometheus-secrets
           secret:
             secretName: prometheus-secrets
         - name: prometheus-storage-volume
           emptyDir: {}
+        - name: proxy-secrets
+          secret:
+            secretName: proxy-secrets
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
- Because crabserver cherrypy process exporter requires proxy certificates to query `:port/crabserver/metrics` which is behind service authentication, cmsweb Prometheus needs proxy-secrets in `monitoring` namespace.
- Requires `cron-proxy` deployment and `proxy-secrets` secret creation in `monitoring` namespace from CMSWEB operators.

Together with https://github.com/dmwm/CMSKubernetes/pull/1356 , this is ready to deploy in testbed (not urgent).

fyi @mapellidario @novicecpp 