### PR TITLE
Tell Helm Not To Uninstall a Resource

### DIFF
--- a/helm/mongodb/Chart.yaml
+++ b/helm/mongodb/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: mongodb
 description: A Helm chart for launching a MongoDB ReplicaSet with 3 instances
 type: application
-version: 1.0.4
-appVersion: 1.0.4
+version: 1.0.5
+appVersion: 1.0.5

--- a/helm/mongodb/templates/pvc.yaml
+++ b/helm/mongodb/templates/pvc.yaml
@@ -2,6 +2,8 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
   name: cpio1
+  annotations:
+    "helm.sh/resource-policy": keep
 provisioner: kubernetes.io/cinder
 parameters:
   type: cpio1
@@ -11,6 +13,8 @@ kind: PersistentVolumeClaim
 metadata:
   namespace: {{.Values.quickSetting.namespace}}
   name: {{.Values.db.instance0.pvName}}
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   accessModes:
     - {{.Values.quickSetting.pvc.accessMode}}
@@ -24,6 +28,8 @@ kind: PersistentVolumeClaim
 metadata:
   namespace: {{.Values.quickSetting.namespace}}
   name: {{.Values.db.instance1.pvName}}
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   accessModes:
     - {{.Values.quickSetting.pvc.accessMode}}
@@ -37,6 +43,8 @@ kind: PersistentVolumeClaim
 metadata:
   name: {{.Values.db.instance2.pvName}}
   namespace: {{.Values.quickSetting.namespace}}
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   accessModes:
     - {{.Values.quickSetting.pvc.accessMode}}


### PR DESCRIPTION
The annotation "helm.sh/resource-policy": keep instructs Helm to skip deleting this resource when a helm operation (such as helm uninstall, helm upgrade or helm rollback) would result in its deletion. 

FYI @todor-ivanov.