### PR TITLE
Add wlcg-voms-cms to cmsweb-base && Copy voms files to grid-security at dmwm-base

### DIFF
--- a/docker/cmsweb-base/Dockerfile
+++ b/docker/cmsweb-base/Dockerfile
@@ -7,7 +7,7 @@ ADD slc7-cernonly.repo /etc/yum.repos.d/slc7-cernonly.repo
 # see https://developers.redhat.com/blog/2016/03/09/more-about-docker-images-size/
 RUN yum install -y sudo cern-get-certificate fetch-crl \
     CERN-CA-certs ca-certificates dummy-ca-certs ca-policy-lcg ca-policy-egi-core \
-    ca_EG-GRID ca_CERN-GridCA ca_CERN-LCG-IOTA-CA ca_CERN-Root-2 \
+    ca_EG-GRID ca_CERN-GridCA ca_CERN-LCG-IOTA-CA ca_CERN-Root-2 wlcg-voms-cms \
     && yum clean all && rm -rf /var/cache/yum && ln -s /bin/bash /usr/bin/bashs && echo "32 */6 * * * root ! /usr/sbin/fetch-crl -q -r 360" > /etc/cron.d/fetch-crl-docker
 RUN yum info CERN-CA-certs
 RUN update-ca-trust

--- a/docker/pypi/dmwm-base/Dockerfile
+++ b/docker/pypi/dmwm-base/Dockerfile
@@ -7,6 +7,8 @@ RUN apt-get install -y curl vim libcurl4 libcurl4-openssl-dev python3-pycurl pip
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN mkdir /etc/grid-security
 COPY --from=cmsweb-base /etc/grid-security/certificates /etc/grid-security/certificates
+COPY --from=cmsweb-base /etc/grid-security/vomsdir /etc/grid-security/vomsdir
+COPY --from=cmsweb-base /etc/vomses /etc/vomses
 COPY --from=exporters /data/cmsweb-ping /usr/bin/cmsweb-ping
 COPY --from=exporters /data/process_exporter /usr/bin/process_exporter
 COPY --from=exporters /data/cpy_exporter /usr/bin/cpy_exporter


### PR DESCRIPTION
With the Current PR, the CMS voms files are made available to both images: `cmsweb-base` and `dmwm-base`

At the former, they are installed through the `wlcg-voms-cms` package and to the later,  are simply copied to `/etc/grid-security/`. 

With that, all images which are based on `dwm-base` and are supposed to  contain code which uses `voms-proxy-*` commands will be able to use the `--voms` extension as well (e.g. the `wmagent` one).

The list of all files provided with the `wlcg-voms-cms` packages is: 
```
$ rpm -ql wlcg-voms-cms
/etc/grid-security/vomsdir/cms/lcg-voms2.cern.ch.lsc
/etc/grid-security/vomsdir/cms/voms2.cern.ch.lsc
/etc/vomses/cms-lcg-voms2.cern.ch
/etc/vomses/cms-voms2.cern.ch
```