### PR TITLE
Skip application_dir when parsing WMCore configuration files for process_exporter

### DIFF
--- a/docker/pypi/dmwm-base/monitor.sh
+++ b/docker/pypi/dmwm-base/monitor.sh
@@ -1,20 +1,21 @@
 #!/bin/bash
 
+echo -e "\nTrying to start process_exporter..."
 # start process exporter
 configs="config config-monitor config-output config-transferor config-ruleCleaner config-unmerged"
 for p in $configs; do
     if [ -f /etc/secrets/${p}.py ]; then
-        echo "use /etc/secrets/${p}.py"
+        echo "  Using configuration file: /etc/secrets/${p}.py"
         pat="wmc-httpd.*$p"
         pid=`ps axjfwww | grep "$pat" | grep -v grep | grep -v process_monitor | grep -v " 1 " | awk '{print $1}'`
         if [ -n "$pid" ]; then
-            app=`grep ^main.application /etc/secrets/${p}.py | sed -e 's,#.*,,g' | awk '{split($0,a,"="); print a[2]}' | sed -e "s, ,,g" -e 's,",,g' -e "s,-,_,g"`
-            echo "use PID: $pid and app: '$app'"
+            app=`grep ^main.application /etc/secrets/${p}.py | grep -v application_dir | sed -e 's,#.*,,g' | awk '{split($0,a,"="); print a[2]}' | sed -e "s, ,,g" -e 's,",,g' -e "s,-,_,g"`
+            echo "  Using PID: $pid and app name: '$app'"
             if [ -n "$app" ]; then
                 prefix=process_exporter_${app}
                 port=`grep main.port /etc/secrets/${p}.py | sed -e 's,#.*,,g' | awk '{split($0,a,"="); print a[2]}' | sed -e "s, ,,g"`
                 address=":1${port}"
-                echo "Start process_exporter with prefix ${prefix} on ${address}"
+                echo "  Starting process_exporter with prefix ${prefix} on ${address}"
                 nohup process_exporter -pid $pid -prefix $prefix -address "$address" 2>&1 1>& ${prefix}.log < /dev/null &
                 #cpyAddr=`echo ${address} | sed "s,8,9,g"`
                 #echo "Start cpy_exporter on ${cpyAddr}"


### PR DESCRIPTION
Take 2 fixing WMCore issue https://github.com/dmwm/WMCore/issues/11454

Real fix is just the extra exclusive grep for application_dir, otherwise we get 2 strings assigned to the `app` and it messes up with the command to be executed. See config:
https://gitlab.cern.ch/cmsweb-k8s/services_config/-/blob/prod/reqmon/config.py#L24-L25

Other changes are only cosmetic and making it slightly more verbose during container startup.