### PR TITLE
Fix prometheus monitoring for reqmgr2/reqmon/globalworkqueue

### DIFF
--- a/helm/reqmgr2/templates/deployment.yaml
+++ b/helm/reqmgr2/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
         - containerPort: 8246
           protocol: TCP
           name: reqmgr2
-        - containerPort: 18240
+        - containerPort: 18246
           protocol: TCP
           name: reqmgr2-mon
         command:

--- a/helm/reqmgr2/templates/service.yaml
+++ b/helm/reqmgr2/templates/service.yaml
@@ -10,7 +10,7 @@ spec:
     - port: 8246
       targetPort: 8246
       name: reqmgr2
-    - port: 18240
-      targetPort: 18240
+    - port: 18246
+      targetPort: 18246
       name: reqmgr2-mon
 ---

--- a/helm/reqmgr2/values.yaml
+++ b/helm/reqmgr2/values.yaml
@@ -28,7 +28,7 @@ serviceAccount:
 
 podAnnotations:
   prometheus.io/scrape: 'true'
-  prometheus.io/port: "18240"
+  prometheus.io/port: "18246"
 
 securityContext: 
   privileged: true

--- a/helm/workqueue/templates/deployment.yaml
+++ b/helm/workqueue/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
         ports:
         - containerPort: 8240
           protocol: TCP
+          name: workqueue
+        - containerPort: 18240
+          protocol: TCP
+          name: workqueue-mon
         command:
         - /bin/bash
         - /opt/setup-certs-and-run/setup-certs-and-run.sh

--- a/helm/workqueue/templates/service.yaml
+++ b/helm/workqueue/templates/service.yaml
@@ -9,3 +9,7 @@ spec:
   ports:
     - port: 8240
       targetPort: 8240
+      name: workqueue
+    - port: 18240
+      targetPort: 18240
+      name: workqueue-mon

--- a/helm/workqueue/values.yaml
+++ b/helm/workqueue/values.yaml
@@ -22,9 +22,10 @@ environment:
 serviceAccount:
   # Specifies whether a service account should be created
   create: false
-  # Annotations to add to the service account
 
-podAnnotations: {}
+podAnnotations:
+  prometheus.io/scrape: 'true'
+  prometheus.io/port: "18240"
 
 securityContext: 
   privileged: true

--- a/kubernetes/cmsweb/services/reqmgr2.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2.yaml
@@ -37,8 +37,8 @@ spec:
     - port: 8246
       targetPort: 8246
       name: reqmgr2
-    - port: 18240
-      targetPort: 18240
+    - port: 18246
+      targetPort: 18246
       name: reqmgr2-mon
 ---
 kind: ConfigMap
@@ -77,7 +77,7 @@ spec:
         env: k8s #k8s#
       annotations:
         prometheus.io/scrape: 'true'
-        prometheus.io/port: "18240"
+        prometheus.io/port: "18246"
     spec:
       # use hostNetwork to allow communication between reqmgr2/reqmon/workqueue and couch
 #       hostNetwork: true
@@ -119,7 +119,7 @@ spec:
         - containerPort: 8246
           protocol: TCP
           name: reqmgr2
-        - containerPort: 18240
+        - containerPort: 18246
           protocol: TCP
           name: reqmgr2-mon
         command:

--- a/kubernetes/cmsweb/services/reqmon.yaml
+++ b/kubernetes/cmsweb/services/reqmon.yaml
@@ -74,6 +74,10 @@ spec:
     metadata:
       labels:
         app: reqmon
+        env: k8s #k8s#
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: "18249"
     spec:
       # use hostNetwork to allow communication between reqmgr/reqmon/workqueue and couch
 #       hostNetwork: true

--- a/kubernetes/cmsweb/services/workqueue.yaml
+++ b/kubernetes/cmsweb/services/workqueue.yaml
@@ -36,6 +36,10 @@ spec:
   ports:
     - port: 8240
       targetPort: 8240
+      name: workqueue
+    - port: 18240
+      targetPort: 18240
+      name: workqueue-mon
 ---
 kind: ConfigMap
 apiVersion: v1
@@ -70,10 +74,9 @@ spec:
       labels:
         app: workqueue
         env: k8s #k8s#
-# should be enabled once we'll have exporter running with this sercice
-# we should also add prometheus.io/port in that case
-#       annotations:
-#         prometheus.io/scrape: 'true'
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: "18240"
     spec:
       # use hostNetwork to allow communication between reqmgr/reqmon/workqueue and couch
 #       hostNetwork: true
@@ -106,6 +109,10 @@ spec:
         ports:
         - containerPort: 8240
           protocol: TCP
+          name: workqueue
+        - containerPort: 18240
+          protocol: TCP
+          name: workqueue-mon
         command:
         - /bin/bash
         - /opt/setup-certs-and-run/setup-certs-and-run.sh


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/11598

First commit fixes prometheus monitoring configuration in the kubernetes manifests:
* fixes port used in `reqmgr2`
* enabled scraping for `reqmon` and `globalworkqueue`

Second commit fixes prometheus monitoring configuration in the helm charts:
* fixes port used in `reqmgr2`
* enable scraping for `globalworkqueue` (reqmon is already setup)

@arooshap as we discussed over Zoom, could you please review this. If everything is Okay, please go ahead and merge it as well.
FYI @vkuznet @todor-ivanov 