### PR TITLE
Improve cmsmon-spark docker by using both CMSMonitoring and CMSSpark tags as build args

### DIFF
--- a/docker/cmsmon-hadoop-base/Dockerfile-spark3
+++ b/docker/cmsmon-hadoop-base/Dockerfile-spark3
@@ -33,8 +33,7 @@ ADD epel.repo /etc/yum.repos.d/epel.repo
 ADD slc7-cernonly.repo /etc/yum.repos.d/slc7-cernonly.repo
 ADD RPM-GPG-KEY-wlcg /etc/pki/rpm-gpg/RPM-GPG-KEY-wlcg
 
-ENV PATH $PATH:/usr/hdp/hadoop/bin:/usr/hdp/sqoop/bin
-ENV PATH $PATH:/data
+ENV PATH="${PATH}:/data:/usr/hdp/hadoop/bin/hadoop:/usr/hdp/spark/bin:/usr/hdp/sqoop/bin"
 
 # add necessary RPMs for cmsweb deployment
 RUN yum -y update && \
@@ -78,7 +77,6 @@ RUN yum -y update && \
 # add fetch-crl to fetch all certificates
 
 ENV HADOOP_CONF_DIR=/etc/hadoop/conf
-ENV PATH="${PATH}:/usr/hdp/hadoop/bin/hadoop:/usr/hdp/spark/bin:/usr/hdp/sqoop/bin"
 ENV PYTHONPATH "${PYTHONPATH}:${WDIR}"
 
 ENV PYSPARK_PYTHON=/cvmfs/sft.cern.ch/lcg/releases/Python/3.9.12-9a1bc/x86_64-centos7-gcc8-opt/bin/python3

--- a/docker/cmsmon-spark/Dockerfile
+++ b/docker/cmsmon-spark/Dockerfile
@@ -3,9 +3,12 @@ FROM registry.cern.ch/cmsmonitoring/cmsmon-hadoop-base:spark3-latest
 MAINTAINER Ceyhun Uzunoglu ceyhunuzngl@gmail.com
 
 # tag to use
-ARG CMSSPARK_TAG=0.0.0
+ARG CMSSPARK_TAG
+ARG CMSMON_TAG
+
 ENV WDIR=/data
 WORKDIR $WDIR
+ADD install.sh $WDIR/install.sh
 
 ENV HADOOP_CONF_DIR=/etc/hadoop/conf
 ENV PATH="${PATH}:${WDIR}/CMSSpark/bin"
@@ -16,11 +19,7 @@ ENV PYSPARK_PYTHON=/cvmfs/sft.cern.ch/lcg/releases/Python/3.9.12-9a1bc/x86_64-ce
 ENV PYSPARK_DRIVER_PYTHON=/usr/bin/python3
 ENV LC_ALL=en_US.utf-8 LANG=en_US.utf-8
 
-RUN mkdir -p $WDIR/logs && \
-    git clone https://github.com/dmwm/CMSSpark.git && cd CMSSpark && git checkout tags/$CMSSPARK_TAG -b build && cd .. && \
-    git clone https://github.com/dmwm/CMSMonitoring.git && \
-    zip -r CMSMonitoring.zip CMSMonitoring/src/python/CMSMonitoring/* && \
-    pip install --no-cache-dir stomp.py==7.0.0 click pyspark pandas numpy schema seaborn matplotlib plotly && \
+RUN CMSSPARK_TAG="$CMSSPARK_TAG" CMSMON_TAG="$CMSMON_TAG" ./install.sh && \
     hadoop-set-default-conf.sh analytix && source hadoop-setconf.sh analytix 3.2 spark3
 
 # Run crond

--- a/docker/cmsmon-spark/Dockerfile
+++ b/docker/cmsmon-spark/Dockerfile
@@ -8,7 +8,7 @@ ENV WDIR=/data
 WORKDIR $WDIR
 
 ENV HADOOP_CONF_DIR=/etc/hadoop/conf
-ENV PATH="${PATH}:/usr/hdp/hadoop/bin/hadoop:/usr/hdp/spark/bin:/usr/hdp/sqoop/bin:${WDIR}/CMSSpark/bin"
+ENV PATH="${PATH}:${WDIR}/CMSSpark/bin"
 ENV PYTHONPATH "${PYTHONPATH}:${WDIR}:${WDIR}/CMSSpark/src/python:${WDIR}/CMSMonitoring/src/python"
 
 # How to find: source LCG102 hadoop setup, which python, ln -ls python, voila!

--- a/docker/cmsmon-spark/README.md
+++ b/docker/cmsmon-spark/README.md
@@ -9,17 +9,25 @@ Installs:
 
 - stomp.py==7.0.0 and creates its zip for spark-submit `--py-files` (spark nodes don't have this version yet)
 - Only src/python/CMSMonitoring folder of dmwm/CMSMonitoring repo and creates its zip for spark-submit `--py-files` (WDIR should be in path)
-- dmwm/CMSSpark
-- Other PY modules: click pyspark pandas numpy seaborn matplotlib plotly
+- dmwm/CMSSpark of `CMSSPARK_TAG` build arg and dmwm/CMSMonitoring of `CMSMON_TAG` of build arg
+- Other PY modules: click pyspark pandas numpy seaborn matplotlib plotly requests
+- amtool
 
-##### Image is built by GH workflow in CMSSpark repository
+##### Image is built by GH workflow in CMSSpark and CMSMonitoring repository
 
 #### Manual build and push
 
 ```shell
 # docker image prune -a OR docker system prune -f -a
 docker_registry=registry.cern.ch/cmsmonitoring
-image_tag=v0.0.0.test
-docker build -t "${docker_registry}/cmsmon-spark:${image_tag}" .
+
+# For CMSSpark
+image_tag=v0.4.1.7
+docker build --build-arg CMSSPARK_TAG="image_tag" -t "${docker_registry}/cmsmon-spark:${image_tag}" .
+
+# For CMSMonitoring
+image_tag=mon-0.0.1
+docker build --build-arg CMSSMON_TAG="image_tag" -t "${docker_registry}/cmsmon-spark:${image_tag}" .
+
 docker push "${docker_registry}/cmsmon-spark:${image_tag}"
 ```

--- a/docker/cmsmon-spark/install.sh
+++ b/docker/cmsmon-spark/install.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+# Build help script for cmsmon-spark docker image
+
+mkdir -p "$WDIR"/logs
+
+# -- Get amtool
+curl -ksLO https://github.com/prometheus/alertmanager/releases/download/v0.24.0/alertmanager-0.24.0.linux-amd64.tar.gz
+tar xfz alertmanager-0.24.0.linux-amd64.tar.gz && mv alertmanager-0.24.0.linux-amd64/amtool "$WDIR/" && rm -rf alertmanager-0.24.0.linux-amd64*
+
+# -- If $CMSSPARK_TAG docker arg is defined, checkout to its CMSSpark git tag, else use dmwm master branch.
+if [ -z "$CMSSPARK_TAG" ]; then
+    git clone https://github.com/dmwm/CMSSpark.git
+else
+    git clone https://github.com/dmwm/CMSSpark.git && cd CMSSpark && git checkout tags/"$CMSSPARK_TAG" -b build && cd ..
+fi
+
+# -- If $CMSMON_TAG docker arg is defined, checkout to its CMSMonitoring git tag, else use dmwm master branch.
+if [ -z "$CMSMON_TAG" ]; then
+    git clone https://github.com/dmwm/CMSMonitoring.git
+else
+    git clone https://github.com/dmwm/CMSMonitoring.git && cd CMSMonitoring && git checkout tags/"$CMSMON_TAG" -b build && cd ..
+fi
+
+# -- Create zip file of only CMSMonitoring/src/python/CMSMonitoring to provide to Spark "--py-files"
+zip -r CMSMonitoring.zip CMSMonitoring/src/python/CMSMonitoring/*
+
+# -- Install python modules
+pip install --no-cache-dir stomp.py==7.0.0 click pyspark pandas numpy schema seaborn matplotlib plotly requests
+
+echo "Info: CMSSPARK_TAG=${CMSSPARK_TAG} , CMSMON_TAG=${CMSMON_TAG}, HADOOP_CONF_DIR=${HADOOP_CONF_DIR}, PATH=${PATH}, PYTHONPATH=${PYTHONPATH}, PYSPARK_PYTHON=${PYSPARK_PYTHON}, PYSPARK_DRIVER_PYTHON=${PYSPARK_DRIVER_PYTHON}"

--- a/docker/cpueff-goweb/Dockerfile-cpueff-spark
+++ b/docker/cpueff-goweb/Dockerfile-cpueff-spark
@@ -9,7 +9,7 @@ ENV WDIR=/data
 WORKDIR $WDIR
 
 ENV HADOOP_CONF_DIR=/etc/hadoop/conf
-ENV PATH="${PATH}:/usr/hdp/hadoop/bin/hadoop:/usr/hdp/spark/bin:/usr/hdp/sqoop/bin:${WDIR}/CMSMonitoring/cpueff-goweb/spark"
+ENV PATH="${PATH}:${WDIR}/CMSMonitoring/cpueff-goweb/spark"
 ENV PYTHONPATH "${PYTHONPATH}:${WDIR}:${WDIR}/CMSSpark/src/python:${WDIR}/CMSMonitoring/src/python:${WDIR}/CMSMonitoring/cpueff-goweb/spark"
 
 # How to find: source LCG102 hadoop setup, which python, ln -ls python, voila!

--- a/docker/rucio-dataset-monitoring/Dockerfile-spark2mng
+++ b/docker/rucio-dataset-monitoring/Dockerfile-spark2mng
@@ -9,7 +9,7 @@ ENV WDIR=/data
 WORKDIR $WDIR
 
 ENV HADOOP_CONF_DIR=/etc/hadoop/conf
-ENV PATH="${PATH}:/usr/hdp/hadoop/bin/hadoop:/usr/hdp/spark/bin:/usr/hdp/sqoop/bin:${WDIR}/CMSMonitoring/rucio-dataset-monitoring/spark"
+ENV PATH="${PATH}:${WDIR}/CMSMonitoring/rucio-dataset-monitoring/spark"
 ENV PYTHONPATH "${PYTHONPATH}:${WDIR}:${WDIR}/CMSMonitoring/src/python:${WDIR}/CMSMonitoring/rucio-dataset-monitoring/spark"
 
 # How to find: source LCG102 hadoop setup, which python, ln -ls python, voila!


### PR DESCRIPTION
Modify `cmsmon-spark` Dockerfile to be built by both CMSMonitoring and CMSSpark GH actions using their tags.

- `CMSMON_TAG` is added as a docker built argument additional to `CMSSPARK_TAG`.
- `amtool` is added
- `install.sh` is used to make build commands readable