### PR TITLE
Synchronize the deployment procedure to have the prometheus port across all the services.

### DIFF
--- a/kubernetes/cmsweb/services/dbs2go-global-migration.yaml
+++ b/kubernetes/cmsweb/services/dbs2go-global-migration.yaml
@@ -1,3 +1,15 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: dbs2go-global-migration
+  namespace: dbs
+spec:
+  selector:
+    app: dbs2go-global-migration
+  ports:
+    - port: 19251
+      targetPort: 19251
+      name: dbs-mon
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/kubernetes/cmsweb/services/dbs2go-phys03-migration.yaml
+++ b/kubernetes/cmsweb/services/dbs2go-phys03-migration.yaml
@@ -1,4 +1,17 @@
 ---
+kind: Service
+apiVersion: v1
+metadata:
+  name: dbs2go-phys03-migration
+  namespace: dbs
+spec:
+  selector:
+    app: dbs2go-global-m
+  ports:
+    - port: 19251
+      targetPort: 19251
+      name: dbs-mon
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/kubernetes/cmsweb/services/sitedb.yaml
+++ b/kubernetes/cmsweb/services/sitedb.yaml
@@ -28,6 +28,9 @@ spec:
     metadata:
       labels:
         app: sitedb
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: "18051"
     spec:
 #       hostNetwork: true
 #       dnsPolicy: ClusterFirstWithHostNet


### PR DESCRIPTION
Hi @vkuznet,

As per your suggestion, I had a look at all the manifest files for all the services that we have user the cmsweb/services section, and I made the changes wherever we declared the container port in the Deployment section for the monitoring, or where we had an annotation to scrape the metrics.

I also checked to make sure that the deployment that are scraping the metrics(and have this port already) are using the correct ports to ensure we don't run have a problem like yesterday. Apart from that, there are some exceptional services that I would like you to comment on if you have the time:

- **dqm-square**: The port is exposed, but the annotation for scraping the pods does not exist. [1]
- **auth-proxy-server, x509-proxy-server, scitokens-proxy-server**: We do have separate pods for monitoring, but should we expose them? Or can we stick to the current procedure?
- **frontend**: we can expose the 18443 port, but do we really need that? I will make the changes if you say.
- **WMStats**: We are using the same port, 8360, for Prometheus. 

Please let me know if you would like me to make any other changes as well, at your convenience. 

Thank you for your time.



[1]. https://github.com/dmwm/CMSKubernetes/blob/beec6e2848412b7fb146f5fec129712ad7820001/kubernetes/cmsweb/services/dqmsquare.yaml#L11