### PR TITLE
Update monitoring cluster create and deployment scripts

### DIFF
--- a/kubernetes/monitoring/create_cluster_cron.sh
+++ b/kubernetes/monitoring/create_cluster_cron.sh
@@ -1,22 +1,25 @@
 #!/bin/bash
-# Creates Kubernetes cluster using openstack templates for CRON
-# Please
-#   - find a latest kubernetes template and use it:
-#     * 'openstack coe cluster template list'
-#     * 'openstack coe cluster template show kubernetes-1.22.9-1 -f yaml'
-#   - Define your master and node counts
-#   - Define your master and node FLAVORS: 'openstack flavor list'
-#   - Define EOS enabled or not, default is TRUE.
-#   - Define ingress controller, default NGINX; it can be traefik too!
-#
+##H Creates Kubernetes cluster using openstack templates for CRON
+##H Please
+##H   - find a latest kubernetes template and use it:
+##H     * 'openstack coe cluster template list'
+##H     * 'openstack coe cluster template show kubernetes-1.25.3-3 -f yaml'
+##H   - Define your master and node counts
+##H   - Define your master and node FLAVORS: 'openstack flavor list'
+##H   - Define EOS enabled or not, default NOT.
+##H   - Define ingress controller, default NGINX; it can be traefik too!
+##H Usage:
+##H     ./create_cluster_cron.sh <cluster_name:put template version as suffix> <template_name:if not provided will use $template >
+##H Example:
+##H    ./create_cluster_cron.sh monitoring-vm-cron-v1.25.3-3 kubernetes-1.25.3-3
+##H
 
 namespace=${OS_PROJECT_NAME:-"CMS Web"}
 name=$1
-template=${2:-"kubernetes-1.22.9-1"}
+template=${2:-"kubernetes-1.25.3-3"}
 
-usage="create_cluster.sh <name> <template_name, if not provided will use $template>"
 if [ "$1" == "-h" ] || [ "$1" == "-help" ] || [ "$1" == "--help" ] || [ "$1" == "help" ] || [ "$1" == "" ]; then
-    echo "$usage"
+    grep "^##H" <"$0" | sed -e "s,##H,,g"
     exit 0
 fi
 echo "Creating cluster => NameSpace: ${namespace} , Name: ${name} , Template: ${template}"
@@ -32,6 +35,7 @@ openstack --os-project-name "$namespace" coe cluster create "$name" \
     --node-count 2 \
     --flavor m2.xlarge \
     --merge-labels \
+    --labels availability_zone="" \
     --labels cinder_csi_enabled="true" \
     --labels logging_include_internal="true" \
     --labels logging_http_destination="http://monit-logs.cern.ch:10012/" \

--- a/kubernetes/monitoring/create_cluster_vmagg.sh
+++ b/kubernetes/monitoring/create_cluster_vmagg.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
-##H Creates Kubernetes cluster using openstack templates for DM Monitoring(cms-dm-monit)
+##H Creates Kubernetes cluster using openstack templates for VM-AGG: VictoriaMetrics aggregated cluster
 ##H Please
 ##H   - find a latest kubernetes template and use it:
 ##H     * 'openstack coe cluster template list'
-##H     * 'openstack coe cluster template show kubernetes-1.25.3-3 -f yaml'
+##H     * 'openstack coe cluster template show kubernetes-1.22.9-1 -f yaml'
 ##H   - Define your master and node counts
 ##H   - Define your master and node FLAVORS: 'openstack flavor list'
-##H   - Define EOS enabled or not, default NOT.
+##H   - Define EOS enabled or not, default is TRUE.
 ##H   - Define ingress controller, default NGINX; it can be traefik too!
 ##H Usage:
-##H     ./create_cluster_dmmon.sh <cluster_name:put template version as suffix> <template_name:if not provided will use $template >
+##H     ./create_cluster_vmagg.sh <cluster_name:put template version as suffix> <template_name:if not provided will use $template >
 ##H Example:
-##H    ./create_cluster_dmmon.sh cms-dm-monit-v1.25.3-3 kubernetes-1.25.3-3
+##H    ./create_cluster_vmagg.sh monitoring-vm-agg-v1.25.3-3 kubernetes-1.25.3-3
 ##H
 
 namespace=${OS_PROJECT_NAME:-"CMS Web"}
@@ -23,7 +23,7 @@ if [ "$1" == "-h" ] || [ "$1" == "-help" ] || [ "$1" == "--help" ] || [ "$1" == 
     exit 0
 fi
 echo "Creating cluster => NameSpace: ${namespace} , Name: ${name} , Template: ${template}"
-echo "Check if EOS enabled! cms-dm-monit cluster does not need it."
+echo "Check if EOS enabled! VMAGG cluster does not need but others may need."
 
 sleep 10
 
@@ -33,7 +33,7 @@ openstack --os-project-name "$namespace" coe cluster create "$name" \
     --master-count 1 \
     --master-flavor m2.large \
     --node-count 2 \
-    --flavor m2.large \
+    --flavor m2.xlarge \
     --merge-labels \
     --labels availability_zone="" \
     --labels cinder_csi_enabled="true" \
@@ -50,4 +50,4 @@ openstack --os-project-name "$namespace" coe cluster create "$name" \
 
 # Ref: https://cms-http-group.docs.cern.ch/k8s_cluster/cmsweb-deployment/
 #
-# READ the DOC: https://cmsmonit-docs.web.cern.ch/k8s/cluster_upgrades/#dm-mon
+# READ the DOC: https://cmsmonit-docs.web.cern.ch/k8s/cluster_upgrades/#vm-agg

--- a/kubernetes/monitoring/deploy-cron.sh
+++ b/kubernetes/monitoring/deploy-cron.sh
@@ -122,7 +122,6 @@ function clean_secrets() {
     # sqoop
     kubectl -n sqoop --ignore-not-found=true delete secret sqoop-secrets
 }
-
 function deploy_services() {
     # default
     kubectl -n default apply -f services/pushgateway.yaml
@@ -159,7 +158,6 @@ deploy_all() {
     deploy_secrets
     deploy_services
 }
-
 clean_all() {
     clean_services
     sleep 10
@@ -169,7 +167,6 @@ clean_all() {
             kubectl --ignore-not-found=true delete namespace "$_ns"
         fi
     done
-
 }
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/kubernetes/monitoring/deploy-dmmon.sh
+++ b/kubernetes/monitoring/deploy-dmmon.sh
@@ -27,6 +27,9 @@ set -e
 ##H Environments:
 ##H   SECRETS_D        defines secrets repository local path. (default CMSKubernetes parent dir)
 ##H   CONFIGS_D        defines cmsmon-configs repository local path. (default CMSKubernetes parent dir)
+##H
+##H READ the DOC: https://cmsmonit-docs.web.cern.ch/k8s/cluster_upgrades/#dm-mon
+##H
 
 unset script_dir action cluster sdir cdir deploy_secrets_sh
 script_dir="$(cd "$(dirname "$0")" && pwd)"
@@ -104,7 +107,7 @@ function deploy_secrets() {
     rm_temp_deploy_secrets_sh
 }
 function clean_secrets() {
-    # hdfs
+    # auth
     kubectl -n auth --ignore-not-found=true delete secret proxy-secrets
     kubectl -n auth --ignore-not-found=true delete secret robot-secrets
     kubectl -n auth --ignore-not-found=true delete secret cern-certificates
@@ -127,7 +130,7 @@ function deploy_services() {
     kubectl -n datasetmon apply -f services/datasetmon/spark2mng.yaml
 }
 function clean_services() {
-    # default
+    # auth
     kubectl -n auth --ignore-not-found=true delete -f ingress/ingress-dm.yaml
     kubectl -n auth --ignore-not-found=true delete -f services/auth-proxy-server-dm.yaml
     kubectl -n auth --ignore-not-found=true delete -f crons/cron-proxy.yaml

--- a/kubernetes/monitoring/deploy-dmmon.sh
+++ b/kubernetes/monitoring/deploy-dmmon.sh
@@ -115,7 +115,6 @@ function clean_secrets() {
     # datasetmon
     kubectl -n datasetmon --ignore-not-found=true delete secret cmsmon-mongo-secrets
 }
-
 function deploy_services() {
     # auth
     # [ingress]: Don't forget to delete "cern-magnum-ingress-nginx-admission" ValidatingWebhookConfiguration
@@ -153,7 +152,6 @@ deploy_all() {
     deploy_secrets
     deploy_services
 }
-
 clean_all() {
     clean_services
     sleep 10
@@ -163,7 +161,6 @@ clean_all() {
             kubectl --ignore-not-found=true delete namespace "$_ns"
         fi
     done
-
 }
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/kubernetes/monitoring/deploy-ha.sh
+++ b/kubernetes/monitoring/deploy-ha.sh
@@ -30,6 +30,9 @@ set -e
 ##H Environments:
 ##H   SECRETS_D        defines secrets repository local path. (default CMSKubernetes parent dir)
 ##H   CONFIGS_D        defines cmsmon-configs repository local path. (default CMSKubernetes parent dir)
+##H
+##H READ the DOC: https://cmsmonit-docs.web.cern.ch/k8s/cluster_upgrades/#ha1
+##H
 
 unset script_dir ha action cluster sdir cdir deploy_secrets_sh
 script_dir="$(cd "$(dirname "$0")" && pwd)"

--- a/kubernetes/monitoring/deploy-ha.sh
+++ b/kubernetes/monitoring/deploy-ha.sh
@@ -179,7 +179,6 @@ function clean_secrets() {
     kubectl -n http --ignore-not-found=true delete secret robot-secrets
     kubectl -n http --ignore-not-found=true delete secret certcheck-secrets
 }
-
 function deploy_services() {
     # Fails because of /etc/proxy/proxy tls conf
     # check_configs_prometheus
@@ -236,7 +235,6 @@ deploy_all() {
     deploy_secrets
     deploy_services
 }
-
 clean_all() {
     clean_services
     sleep 10
@@ -247,7 +245,6 @@ clean_all() {
             kubectl --ignore-not-found=true delete namespace $_ns
         fi
     done
-
 }
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/kubernetes/monitoring/deploy-secrets.sh
+++ b/kubernetes/monitoring/deploy-secrets.sh
@@ -28,6 +28,7 @@ set -e
 ##H        redash-secrets
 ##H        robot-secrets
 ##H        rucio-daily-stats-secrets
+##H        s3-keys-secrets
 ##H        sqoop-secrets
 ##H        vmalert-secrets
 ##H Examples:
@@ -88,6 +89,8 @@ elif [ "$secret" == "promxy-secrets" ]; then
     files=`ls $cdir/promxy/ | awk '{ORS=" " ; print "--from-file="D"/"$1""}' D=$cdir/promxy | sed "s, $,,g"`
 elif [ "$secret" == "vmalert-secrets" ]; then
     files=`ls $cdir/vmalert/ | awk '{ORS=" " ; print "--from-file="D"/"$1""}' D=$cdir/vmalert | sed "s, $,,g"`
+elif [ "$secret" == "s3-keys-secrets" ]; then
+    files=`ls $sdir/victoria-metrics/ | awk '{ORS=" " ; print "--from-file="D"/"$1""}' D=$sdir/victoria-metrics | sed "s, $,,g"`
 elif [ "$secret" == "robot-secrets" ]; then
     files=`ls $sdir/robot/ | awk '{ORS=" " ; print "--from-file="D"/"$1""}' D=$sdir/robot | sed "s, $,,g"`
 elif [ "$secret" == "auth-secrets" ]; then

--- a/kubernetes/monitoring/deploy-vmagg.sh
+++ b/kubernetes/monitoring/deploy-vmagg.sh
@@ -107,7 +107,6 @@ function clean_secrets() {
     kubectl -n default --ignore-not-found=true delete secret s3-keys-secrets
     kubectl -n default --ignore-not-found=true delete secret vmalert-secrets
 }
-
 function deploy_services() {
     # default
     kubectl -n default apply -f services/agg/victoria-metrics.yaml
@@ -139,7 +138,6 @@ deploy_all() {
     deploy_secrets
     deploy_services
 }
-
 clean_all() {
     clean_services
     sleep 10

--- a/kubernetes/monitoring/deploy-vmagg.sh
+++ b/kubernetes/monitoring/deploy-vmagg.sh
@@ -1,16 +1,15 @@
 #!/bin/bash
 # shellcheck disable=SC2181
 set -e
-##H Usage: deploy-cron.sh ACTION
+##H Usage: deploy-vmagg.sh ACTION
 ##H
 ##H Examples:
 ##H    --- If CMSKubernetes, cmsmon-configs and secrets repos are in same directory ---
-##H    deploy-cron.sh status
-##H    deploy-cron.sh deploy-secrets
-##H    deploy-cron.sh deploy-all
-##H    deploy-cron.sh clean-services
+##H    deploy-vmagg.sh status
+##H    deploy-vmagg.sh deploy-secrets
+##H    deploy-vmagg.sh deploy-all
 ##H    --- Else ---
-##H    export SECRETS_D=$SOMEDIR/secrets; export CONFIGS_D=$SOMEDIR/cmsmon-configs; deploy-cron.sh status
+##H    export SECRETS_D=$SOMEDIR/secrets; export CONFIGS_D=$SOMEDIR/cmsmon-configs; deploy-vmagg.sh status
 ##H
 ##H Attention: this script depends on deploy-secrets.sh
 ##H
@@ -29,7 +28,7 @@ set -e
 ##H   SECRETS_D        defines secrets repository local path. (default CMSKubernetes parent dir)
 ##H   CONFIGS_D        defines cmsmon-configs repository local path. (default CMSKubernetes parent dir)
 ##H
-##H READ the DOC: https://cmsmonit-docs.web.cern.ch/k8s/cluster_upgrades/#cron
+##H READ the DOC: https://cmsmonit-docs.web.cern.ch/k8s/cluster_upgrades/#vm-agg
 ##H
 
 unset script_dir action cluster sdir cdir deploy_secrets_sh
@@ -97,65 +96,46 @@ function rm_temp_deploy_secrets_sh() {
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 function deploy_secrets() {
     create_temp_deploy_secrets_sh
-    # hdfs
-    "$deploy_secrets_sh" hdfs proxy-secrets
-    "$deploy_secrets_sh" hdfs robot-secrets
-    "$deploy_secrets_sh" hdfs rucio-daily-stats-secrets
-    "$deploy_secrets_sh" hdfs hpc-usage-secrets
-    "$deploy_secrets_sh" hdfs cron-size-quotas-secrets
-    "$deploy_secrets_sh" hdfs cms-eos-mon-secrets
-    "$deploy_secrets_sh" hdfs cron-spark-jobs-secrets
-    # sqoop
-    "$deploy_secrets_sh" sqoop sqoop-secrets
+    # default
+    "$deploy_secrets_sh" default s3-keys-secrets
+    "$deploy_secrets_sh" default vmalert-secrets
     #
     rm_temp_deploy_secrets_sh
 }
 function clean_secrets() {
-    # hdfs
-    kubectl -n hdfs --ignore-not-found=true delete secret proxy-secrets
-    kubectl -n hdfs --ignore-not-found=true delete secret robot-secrets
-    kubectl -n hdfs --ignore-not-found=true delete secret rucio-daily-stats-secrets
-    kubectl -n hdfs --ignore-not-found=true delete secret hpc-usage-secrets
-    kubectl -n hdfs --ignore-not-found=true delete secret cron-size-quotas-secrets
-    kubectl -n hdfs --ignore-not-found=true delete secret cms-eos-mon-secrets
-    kubectl -n hdfs --ignore-not-found=true delete secret cron-spark-jobs-secrets
-    # sqoop
-    kubectl -n sqoop --ignore-not-found=true delete secret sqoop-secrets
+    # default
+    kubectl -n default --ignore-not-found=true delete secret s3-keys-secrets
+    kubectl -n default --ignore-not-found=true delete secret vmalert-secrets
 }
 
 function deploy_services() {
     # default
-    kubectl -n default apply -f services/pushgateway.yaml
-    # hdfs
-    kubectl -n hdfs apply -f crons/cron-proxy.yaml
-    kubectl -n hdfs apply -f services/cmsmon-hpc-usage.yaml
-    kubectl -n hdfs apply -f services/cmsmon-rucio-ds.yaml
-    kubectl -n hdfs apply -f services/cron-size-quotas.yaml
-    kubectl -n hdfs apply -f services/cron-spark-jobs.yaml
-    # sqoop
-    kubectl -n sqoop apply -f services/sqoop.yaml
+    kubectl -n default apply -f services/agg/victoria-metrics.yaml
+    kubectl -n default apply -f services/agg/victoria-metrics-long.yaml
+    sleep 60
+    kubectl -n default apply -f services/vmalert.yaml
+    kubectl -n default apply -f services/vmalert-1h.yaml
 }
 function clean_services() {
     # default
-    kubectl -n default --ignore-not-found=true delete -f services/pushgateway.yaml
-    # hdfs
-    kubectl -n hdfs --ignore-not-found=true delete -f crons/cron-proxy.yaml
-    kubectl -n hdfs --ignore-not-found=true delete -f services/cmsmon-hpc-usage.yaml
-    kubectl -n hdfs --ignore-not-found=true delete -f services/cmsmon-rucio-ds.yaml
-    kubectl -n hdfs --ignore-not-found=true delete -f services/cron-size-quotas.yaml
-    kubectl -n hdfs --ignore-not-found=true delete -f services/cron-spark-jobs.yaml
-    # sqoop
-    kubectl -n sqoop --ignore-not-found=true delete -f services/sqoop.yaml
+    kubectl -n default --ignore-not-found=true delete -f services/vmalert.yaml
+    kubectl -n default --ignore-not-found=true delete -f services/vmalert-1h.yaml
+    sleep 5
+    kubectl -n default --ignore-not-found=true delete -f services/agg/victoria-metrics.yaml
+    kubectl -n default --ignore-not-found=true delete -f services/agg/victoria-metrics-long.yaml
+}
+# Deploy cinder volumes for default namespace
+function deploy_storages() {
+    kubectl apply -n default -f storages/vm-agg-cluster-cinder.yaml
+}
+function clean_storages() {
+    kubectl delete -n default -f storages/vm-agg-cluster-cinder.yaml
 }
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MAIN ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-namespaces="hdfs sqoop"
 deploy_all() {
-    for _ns in $namespaces; do
-        if ! kubectl get ns | grep -q "$_ns"; then
-            kubectl create namespace "$_ns"
-        fi
-    done
+    deploy_storages
+    sleep 10
     deploy_secrets
     deploy_services
 }
@@ -164,12 +144,7 @@ clean_all() {
     clean_services
     sleep 10
     clean_secrets
-    for _ns in $namespaces; do
-        if kubectl get ns | grep -q "$_ns"; then
-            kubectl --ignore-not-found=true delete namespace "$_ns"
-        fi
-    done
-
+    clean_storages
 }
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/kubernetes/monitoring/services/agg/victoria-metrics-long.yaml
+++ b/kubernetes/monitoring/services/agg/victoria-metrics-long.yaml
@@ -40,7 +40,7 @@ spec:
           - -storageDataPath=/tsdb
           - -search.maxConcurrentRequests=32
           name: victoria-metrics
-          image: victoriametrics/victoria-metrics
+          image: victoriametrics/victoria-metrics:v1.91.0
           ports:
           - containerPort: 4242
             protocol: TCP

--- a/kubernetes/monitoring/services/agg/victoria-metrics.yaml
+++ b/kubernetes/monitoring/services/agg/victoria-metrics.yaml
@@ -40,7 +40,7 @@ spec:
           - -storageDataPath=/tsdb
           - -search.maxConcurrentRequests=32
           name: victoria-metrics
-          image: victoriametrics/victoria-metrics
+          image: victoriametrics/victoria-metrics:v1.91.0
           ports:
           - containerPort: 4242
             protocol: TCP

--- a/kubernetes/monitoring/services/vmalert-1h.yaml
+++ b/kubernetes/monitoring/services/vmalert-1h.yaml
@@ -7,7 +7,6 @@ spec:
   type: ClusterIP
   selector:
     app: vmalert-1h
-  type: ClusterIP
   ports:
   - port: 31880
     protocol: TCP

--- a/kubernetes/monitoring/services/vmalert-1h.yaml
+++ b/kubernetes/monitoring/services/vmalert-1h.yaml
@@ -31,7 +31,7 @@ spec:
         containers:
         - args:
           - -datasource.url=http://cms-monitoring:30082
-          - -remoteWrite.url=http://cms-monitoring-agg:30428
+          - -remoteWrite.url=http://victoria-metrics:8428
           - -rule=/etc/vmalert/rucio-agg-1h.rules
           - -notifier.url=http://cms-monitoring:30093
           - -httpListenAddr=:31880

--- a/kubernetes/monitoring/services/vmalert.yaml
+++ b/kubernetes/monitoring/services/vmalert.yaml
@@ -31,7 +31,7 @@ spec:
         containers:
         - args:
           - -datasource.url=http://cms-monitoring:30082
-          - -remoteWrite.url=http://cms-monitoring-agg:31428
+          - -remoteWrite.url=http://victoria-metrics-long:8428
           - -rule=/etc/vmalert/rucio-agg.rules
           - -rule=/etc/vmalert/dbs-dbinfo.rules
           - -notifier.url=http://cms-monitoring:30093

--- a/kubernetes/monitoring/services/vmalert.yaml
+++ b/kubernetes/monitoring/services/vmalert.yaml
@@ -7,7 +7,6 @@ spec:
   type: ClusterIP
   selector:
     app: vmalert
-  type: ClusterIP
   ports:
   - port: 30880
     protocol: TCP


### PR DESCRIPTION
- VM AGG cluster creation and deployment scripts are added
- Other create_cluster and deploy scripts are updated with the latest change in cloud infrastructure `--labels availability_zone=""`
- `s3-keys-secrets` creation is added to `deploy-secrets.sh`
- Move `vmalert` and `vmalert-1h` to monitoring-vm-agg cluster from main cluster, and change their remote-write urls to internal k8s dns of `victoria-metrics` and `victoria-metrics-long`.

I think we can move `vmalert.yaml` and `vmalert-1h` services to vmagg cluster since they don't have any dependency to main monitoring cluster. @vkuznet I know you don't have much time to look our PRs but do you have any concern in this decision. They are already using LanDB aliases of VictoriaMetrics in all clusters while getting the raw data and sending aggregated data.

