### PR TITLE
Changes to install WMAgent from PyPi; provided install and run.sh scripts

### DIFF
--- a/docker/pypi/wmagent/Dockerfile
+++ b/docker/pypi/wmagent/Dockerfile
@@ -12,10 +12,11 @@ ENV LD_LIBRARY_PATH=/usr/lib/oracle
 ENV PATH=$PATH:/usr/lib/oracle
 ENV PKG_CONFIG_PATH=/usr/lib/oracle
 
+# This TAG is overwritten by WMCore GH actions workflow
+ENV TAG=X.Y.Z
 # WMA_TAG to be passed at build time through `--build-arg WMA_TAG=<WMA_TAG>`. Default: None
-ARG WMA_TAG=None
+ARG WMA_TAG=${TAG}
 ENV WMA_TAG=${WMA_TAG}
-ENV TAG=${WMA_TAG}
 ENV WMA_USER=cmst1
 ENV WMA_GROUP=zh
 ENV WMA_UID=31961

--- a/docker/pypi/wmagent/Dockerfile
+++ b/docker/pypi/wmagent/Dockerfile
@@ -1,14 +1,70 @@
+FROM registry.cern.ch/cmsweb/oracle:21_5-stable as oracle
 FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230525
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
+
+# Install basic OS package dependencies
 RUN apt-get update
-RUN apt-get install -y libmariadb-dev-compat libmariadb-dev apache2-utils sudo
-ENV TAG=X.Y.Z
-RUN pip install wmagent==$TAG
-ENV WDIR=/data
-ENV USER=_wmagent
-RUN useradd ${USER} && install -o ${USER} -d ${WDIR}
-RUN echo "%$USER ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
-USER ${USER}
-RUN sudo chown -R $USER.$USER $WDIR
-WORKDIR $WDIR
-CMD ["python3"]
+RUN apt-get install -y libmariadb-dev-compat libmariadb-dev apache2-utils hostname net-tools iputils-ping cron mariadb-server myproxy voms-clients rlwrap libaio1 procps && apt-get clean
+
+# copy oracle client:
+COPY --from=oracle /usr/lib/oracle /usr/lib/oracle
+ENV LD_LIBRARY_PATH=/usr/lib/oracle
+ENV PATH=$PATH:/usr/lib/oracle
+ENV PKG_CONFIG_PATH=/usr/lib/oracle
+
+# WMA_TAG to be passed at build time through `--build-arg WMA_TAG=<WMA_TAG>`. Default: None
+ARG WMA_TAG=None
+ENV WMA_TAG=${WMA_TAG}
+ENV TAG=${WMA_TAG}
+ENV WMA_USER=cmst1
+ENV WMA_GROUP=zh
+ENV WMA_UID=31961
+ENV WMA_GID=1399
+ENV WMA_ROOT_DIR=/data
+
+# Basic WMAgent directory structure passed to all scripts through env variables:
+# NOTE: Those should be static and depend only on $WMA_BASE_DIR
+ENV WMA_BASE_DIR=$WMA_ROOT_DIR/srv
+ENV WMA_ADMIN_DIR=$WMA_ROOT_DIR/admin/wmagent
+ENV WMA_CERTS_DIR=$WMA_ROOT_DIR/certs
+
+ENV WMA_HOSTADMIN_DIR=$WMA_ADMIN_DIR/hostadmin
+ENV WMA_CURRENT_DIR=$WMA_BASE_DIR/wmagent/current
+ENV WMA_INSTALL_DIR=$WMA_CURRENT_DIR/install
+ENV WMA_CONFIG_DIR=$WMA_CURRENT_DIR/config
+ENV WMA_MANAGE_DIR=$WMA_CONFIG_DIR/wmagent
+ENV WMA_DEPLOY_DIR=/usr/local
+ENV WMA_ENV_FILE=$WMA_DEPLOY_DIR/deploy/env.sh
+
+
+# Setting up users and previleges
+RUN groupadd -g ${WMA_GID} ${WMA_GROUP}
+RUN useradd -u ${WMA_UID} -g ${WMA_GID} -m ${WMA_USER}
+RUN install -o ${WMA_USER} -g ${WMA_GID} -d ${WMA_ROOT_DIR}
+RUN usermod -aG mysql ${WMA_USER}
+RUN rm -f /etc/mysql/mariadb.conf.d/50-server.cnf
+
+# Add WMA_USER to sudoers
+RUN echo "${WMA_USER} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+# Add all deployment needed directories
+ADD bin $WMA_DEPLOY_DIR/bin
+ADD etc $WMA_DEPLOY_DIR/etc
+
+# Add install script
+ADD install.sh ${WMA_ROOT_DIR}/install.sh
+
+# Add wmagent run script
+ADD run.sh ${WMA_ROOT_DIR}/run.sh
+
+# Install the requested WMA_TAG.
+RUN ${WMA_ROOT_DIR}/install.sh -v ${WMA_TAG}
+RUN chown -R ${WMA_USER}:${WMA_GID} ${WMA_ROOT_DIR}
+
+# Switch to the runtime directory and user
+WORKDIR ${WMA_ROOT_DIR}
+USER ${WMA_USER}
+ENV USER=$WMA_USER
+
+# Define the entrypoint. All the run.sh paramters should be passed at runtime.
+ENTRYPOINT ["./run.sh"]

--- a/docker/pypi/wmagent/README.md
+++ b/docker/pypi/wmagent/README.md
@@ -1,0 +1,230 @@
+## WMAgent in Docker using pypi deployment method.
+
+### Requires:
+ * Docker to be installed on the host VM (vocmsXXXX)
+ * HTcondor schedd to be installed and configured at the host VM
+ * CouchDB to be installed on the host VM
+ * MariaDB to be installed on the host VM (Depends on the type of relational database to be used MariaDB/Oracle)
+ * Service certificates to be present at the host VM
+ * `WMAgent.secrets` file to be present at the host VM
+
+### The implementation is realized through the following files:
+ * `Dockerfile` - provides all basic requirements for the image and sets all common env variables to both `install.sh` and `run.sh`.
+ * `install.sh` - called through `Dockerfile` `RUN` command and provided with a single parameter at build time `WMA_TAG`
+ * `run.sh` - set as default `ENTRYPOINT` at container runtime. All agent related configuration parameters are passed as named arguments and used to (re)generate the agent configuration files. All service credentials and schedd caches are accessed via host mount points
+ * `wmagent-docker-build.sh` - simple script to be used for building a WMAgent docker image
+ * `wmagent-docker-run.sh` - simple script to be used for running a WMAgent docker container
+
+**Build options (accepted by `install.sh`):**
+* `WMA_TAG=2.2.1`
+
+**RUN options (accepted by `run.sh`):**
+* `TEAMNAME=testbed-$HOSTNAME`
+* `CENTRAL_SERVICES=cmsweb-testbed.cern.ch`
+* `AGENT_NUMBER=0`
+* `FLAVOR=mysql`
+
+
+### Building a WMAgent image
+
+The build process may happen at any machine running a Docker Engine.
+
+**Build command:**
+* Using the wrapper script to build WMAgent locally:
+```
+ssh vocms****
+cmst1
+cd /data
+git clone https://github.com/dmwm/CMSKubernetes.git
+cd /data/CMSKubernetes/docker/pypi/wmagent/
+./wmagent-docker-build.sh -v 2.2.1
+```
+* Using the wrapper script to build and upload WMAgent to registry.cern.ch:
+```
+./wmagent-docker-build.sh -v 2.2.1 -p
+```
+* Here is what is happening under the hood:
+```
+WMA_TAG=2.2.1
+docker build --network=host --progress=plain --build-arg WMA_TAG=$WMA_TAG -t wmagent:$WMA_TAG -t wmagent:latest  /data/CMSKubernetes/docker/pypi/wmagent/ 2>&1 |tee /data/build-wma.log
+```
+**Partial output:**
+```
+...
+#4 [ 1/13] FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230314@sha256:71cf3825ed9acf4e84f36753365f363cfd53d933b4abf3c31ef828828e7bdf83
+#4 DONE 0.0s
+...
+#14 0.110 =======================================================
+#14 0.110 Starting new agent deployment with the following data:
+#14 0.110 -------------------------------------------------------
+#14 0.111  - WMAgent version         : 2.2.1
+#14 0.113  - Python verson           : Python 3.8.16
+#14 0.114  - Python Module Path      : /usr/local/lib/python3.8/site-packages
+#14 0.114 =======================================================
+...
+#18 naming to docker.io/library/wmagent:2.2.1 done
+#18 DONE 3.3s
+```
+
+### Running a WMAgent container
+
+One needs to bind mount several directories from the host VM (vocmsXXXX).
+* /data/dockerMount/certs
+* /etc/condor (schedd runs on the host, not the container)
+* /tmp
+* /data/dockerMount/srv/wmagent/current/install (stateful service and component dirs)
+* /data/dockerMount/srv/wmagent/current/config  (for persisting agent configuration data)
+* /data/dockerMount/admin/wmagent               (in order to access the WMAgent.secrets)
+
+
+The install and config dirs will be initialized the first time you execute run.sh and a .dockerinit file will be placed to keep track of the initialization. Subsequent container restarts won't touch these directories.
+
+**Run command:**
+
+* Initialising the agent for the first time:
+```
+ssh vocms****
+cmst1
+cd /data/CMSKubernetes/docker/pypi/wmagent/
+### cleaning old agent data:
+rm -rf /data/dockerMount/srv/
+./wmagent-docker-run.sh -t <team_name> -n <agent_number> -f <db_flavour> -c <central_services> &
+```
+* Initialising the agent for the first time using a docker image from registry.cern.ch:
+```
+./wmagent-docker-run.sh -t <team_name> -n <agent_number> -f <db_flavour> -c <central_services>  -p -v 2.2.1 &
+```
+* Running the agent:
+```
+./wmagent-docker-run.sh &
+```
+
+* Here is what is happening under the hood:
+```
+WMA_ROOT_DIR=/data/dockerMount
+
+dockerOpts=" \
+--network=host \
+--rm \
+--hostname=`hostname -f` \
+--name=wmagent \
+--mount type=bind,source=/etc/tnsnames.ora,target=/etc/tnsnames.ora,readonly \
+--mount type=bind,source=/etc/condor,target=/etc/condor,readonly \
+--mount type=bind,source=/tmp,target=/tmp \
+--mount type=bind,source=$WMA_ROOT_DIR/certs,target=/data/certs \
+--mount type=bind,source=$WMA_ROOT_DIR/srv/wmagent/current/install,target=/data/srv/wmagent/current/install \
+--mount type=bind,source=$WMA_ROOT_DIR/srv/wmagent/current/config,target=/data/srv/wmagent/current/config \
+--mount type=bind,source=$WMA_ROOT_DIR/admin/wmagent,target=/data/admin/wmagent/hostadmin \
+"
+
+wmaOpts=" \
+-f mysql \
+-t testbed-vocms0260 \
+-n 0 \
+-c cmsweb-testbed.cern.ch"
+
+docker run $dockerOpts wmagent $wmaOpts
+```
+
+**Partial output:**
+```
+=======================================================
+Starting WMAgent with the following initial data:
+-------------------------------------------------------
+ - WMAgent Version            : 2.2.1
+ - WMAgent TeamName           : testbed-vocms0260
+ - WMAgent Number             : 0
+ - WMAgent Host               : vocms0260.cern.ch
+ - WMAgent Config             : /data/srv/wmagent/current/config
+ - WMAgent Relational DB type : oracle
+ - Python verson              : Python 3.8.16
+ - Python Module Path         : /usr/local/lib/python3.8/site-packages
+=======================================================
+...
+```
+
+**NOTE:**
+Currently, it is a must that only one WMAgent container should be running on a singe agent VM. It is partially guarantied by setting the `--name=wmagent` parameter at the `docker run` command above. But it is in fact possible to over come this by setting a different name of the new container, but bare in mind all unpredictable consequences of such action. If one tries tr start two containers with the same name, the expected err is:
+```
+docker run $dockerOpts wmagent:$WMA_TAG $wmaOpts
+
+docker: Error response from daemon: Conflict. The container name "/wmagent" is already in use by container "c4c64688a75b6ac8f5cc5e4c951db324b2441ec1434f2e1d604a49d8009ff2a1". You have to remove (or rename) that container to be able to reuse that name.
+See 'docker run --help'
+```
+
+
+
+
+### Checking container status
+```
+ssh vocms****
+
+docker container ps
+CONTAINER ID   IMAGE             COMMAND                CREATED       STATUS       PORTS     NAMES
+78d7e1baa3df   wmagent:2.2.1   "./run.sh -f oracle ..."   2 hours ago   Up 2 hours             wmagent
+
+```
+
+## Stopping the WMAgent container
+In order to stop the WMAgent container one just needs to kill it, the `--rm` option at `docker run` commands assures we leave no leftover containers.
+
+**Shutdown command:**
+```
+docker kill wmagent
+```
+
+### Enforce container reinitialisation at the host:
+The WMAgent needs to preserve its configuration and initialisation data permanently at the host. For the purpose we use Host to Docker bind mounts.
+Once a specific WMAgent image has been run for the first time it leaves a small set of .dockerInit files at all places where permanent data(like config files and job caches) at the host is preserved.
+On any further restart of the container, hence the WMAgent itself, we do not go through all the initialisation steps again if we find the
+relevant .dockerInit file and the $WMA_BUILD_ID hash contained there matches the $WMA_BUILD_ID of the currently starting container.
+In order for one to enforce reinitialisation steps to be performed one needs to delete all .dockerInit files and restart the wmagent container.
+
+**NOTE: This reinitialisation may result in losing previous job caches and database records**
+**Reinitialisation command:**
+```
+docker kill wmagent
+
+sudo find /data/dockerMount -name .dockerInit -delete
+
+docker run $dockerOpts wmagent:$WMA_TAG $wmaOpts
+```
+
+**Partial output:**
+```
+=======================================================
+Starting WMAgent with the following initialisation data:
+-------------------------------------------------------
+ - WMAgent Version            : 2.2.1
+...
+=======================================================
+-------------------------------------------------------
+Start: Performing checks for successful Docker initialisation steps...
+WMA_BUILD_ID: 110b443165e3b5a4ba569b8a1ab063a616132602e55ba06b0c3e89a01e643f31
+dockerInitId: /data/admin/wmagent/hostadmin/.dockerInit:
+...
+ERROR
+-------------------------------------------------------
+Start: Performing Docker image to Host initialisation steps
+...
+Done: Performing Docker image to Host initialisation steps
+-------------------------------------------------------
+-------------------------------------------------------
+Start: Performing checks for successful Docker initialisation steps...
+WMA_BUILD_ID: 110b443165e3b5a4ba569b8a1ab063a616132602e55ba06b0c3e89a01e643f31
+dockerInitId: 110b443165e3b5a4ba569b8a1ab063a616132602e55ba06b0c3e89a01e643f31
+OK
+-------------------------------------------------------
+...
+```
+
+### Connecting to the container
+
+First login at the VM and from there connect to the container:
+
+**Login sequence:**
+```
+docker exec -it wmagent /bin/bash
+...
+(WMAgent-2.2.1) [cmst1@vocms0260:current]$ manage status
+```

--- a/docker/pypi/wmagent/bin/manage
+++ b/docker/pypi/wmagent/bin/manage
@@ -1,0 +1,738 @@
+#!/bin/bash
+
+
+#
+# Global variables etc
+#
+ROOT_DIR=$WMA_CURRENT_DIR
+INSTALL_AG="$ROOT_DIR/install/wmagentpy3"
+INSTALL_MYSQL="$ROOT_DIR/install/mysql"
+INSTALL_COUCH="$ROOT_DIR/install/couchdb"
+
+CONFIG_COUCH="$ROOT_DIR/config/couchdb"
+CONFIG_MYSQL="$ROOT_DIR/config/mysql"
+CONFIG_AG="$ROOT_DIR/config/wmagentpy3"
+CONFIG_RUCIO="$ROOT_DIR/config/rucio/etc/rucio.cfg"
+
+USING_AG=0
+
+MYSQL_INIT_DONE=0
+COUCH_INIT_DONE=0
+AG_INIT_DONE=0
+
+
+MYSQL_DATABASE_AG=wmagent
+
+ORACLE_USER=
+ORACLE_PASS=
+ORACLE_TNS=
+
+MYSQL_USER=
+if [ -z "$DBSOCK" ]; then
+    MYSQL_SOCK=$INSTALL_MYSQL/logs/mysql.sock
+else
+    MYSQL_SOCK=$DBSOCK
+fi
+
+GRAFANA_TOKEN=
+
+COUCH_USER=
+COUCH_PASS=
+
+COUCH_HOST=127.0.0.1
+COUCH_PORT=5984
+COUCH_HOST_NAME=localhost
+COUCH_CERT_FILE=
+COUCH_KEY_FILE=
+
+GLOBAL_WORKQUEUE_URL=
+LOCAL_WORKQUEUE_DBNAME=workqueue
+
+WORKLOAD_SUMMARY_URL=
+WORKLOAD_SUMMARY_DBNAME=workloadsummary
+WMSTATS_URL=
+REQMGR2_URL=
+ACDC_URL=
+DBS3_URL=
+DQM_URL=
+REQUESTCOUCH_URL=
+CENTRAL_LOGDB_URL=
+WMARCHIVE_URL=
+AMQ_CREDENTIALS=
+RUCIO_HOST=
+RUCIO_AUTH=
+RUCIO_ACCOUNT=
+
+#
+# Init checks
+#
+# are we using the agent?
+if [ -e $INSTALL_AG/.using ]; then USING_AG=1; else USING_AG=0; fi;
+
+# Flags to show which tools have been initialised
+if [ -e $INSTALL_AG/.init ]; then AG_INIT_DONE=1; else AG_INIT_DONE=0; fi;
+if [ -e $INSTALL_MYSQL/.init ]; then MYSQL_INIT_DONE=1; else MYSQL_INIT_DONE=0; fi;
+if [ -e $INSTALL_COUCH/.init ]; then COUCH_INIT_DONE=1; else COUCH_INIT_DONE=0; fi;
+
+#callbacks to activate or show initialisation has been done
+activate_agent(){
+    touch $INSTALL_AG/.using
+    cp $WMCORE_ROOT/etc/WMAgentConfig.py $CONFIG_AG/config-template.py
+}
+
+inited_agent(){
+    touch $INSTALL_AG/.init
+}
+inited_couch(){
+    touch $INSTALL_COUCH/.init
+}
+inited_mysql(){
+    touch $INSTALL_MYSQL/.init
+}
+
+
+#
+# Passwords/Secrets handling
+#
+load_secrets_file(){
+    if [ "x$WMAGENT_SECRETS_LOCATION" == "x" ]; then
+        WMAGENT_SECRETS_LOCATION=$HOME/WMAgent.secrets;
+    fi
+    if [ ! -e $WMAGENT_SECRETS_LOCATION ]; then
+        echo "Password file: $WMAGENT_SECRETS_LOCATION does not exist"
+        echo "Either set WMAGENT_SECRETS_LOCATION to a valid file or check that $HOME/WMAgent.secrets exists"
+        exit 1;
+    fi
+
+    local MATCH_ORACLE_USER=`cat $WMAGENT_SECRETS_LOCATION | grep ORACLE_USER | sed s/ORACLE_USER=//`
+    local MATCH_ORACLE_PASS=`cat $WMAGENT_SECRETS_LOCATION | grep ORACLE_PASS | sed s/ORACLE_PASS=//`
+    local MATCH_ORACLE_TNS=`cat $WMAGENT_SECRETS_LOCATION | grep ORACLE_TNS | sed s/ORACLE_TNS=//`
+    local MATCH_GRAFANA_TOKEN=`cat $WMAGENT_SECRETS_LOCATION | grep GRAFANA_TOKEN | sed s/GRAFANA_TOKEN=//`
+    local MATCH_MYSQL_USER=`cat $WMAGENT_SECRETS_LOCATION | grep MYSQL_USER | sed s/MYSQL_USER=//`
+    local MATCH_COUCH_USER=`cat $WMAGENT_SECRETS_LOCATION | grep COUCH_USER | sed s/COUCH_USER=//`
+    local MATCH_COUCH_PASS=`cat $WMAGENT_SECRETS_LOCATION | grep COUCH_PASS | sed s/COUCH_PASS=//`
+    local MATCH_COUCH_PORT=`cat $WMAGENT_SECRETS_LOCATION | grep COUCH_PORT | sed s/COUCH_PORT=//`
+    local MATCH_COUCH_CERT_FILE=`cat $WMAGENT_SECRETS_LOCATION | grep COUCH_CERT_FILE | sed s/COUCH_CERT_FILE=//`
+    local MATCH_COUCH_KEY_FILE=`cat $WMAGENT_SECRETS_LOCATION | grep COUCH_KEY_FILE | sed s/COUCH_KEY_FILE=//`
+    local MATCH_GLOBAL_WORKQUEUE_URL=`cat $WMAGENT_SECRETS_LOCATION | grep GLOBAL_WORKQUEUE_URL | sed s/GLOBAL_WORKQUEUE_URL=//`
+    local MATCH_LOCAL_WORKQUEUE_DBNAME=`cat $WMAGENT_SECRETS_LOCATION | grep LOCAL_WORKQUEUE_DBNAME | sed s/LOCAL_WORKQUEUE_DBNAME=//`
+    local MATCH_WORKLOAD_SUMMARY_URL=`cat $WMAGENT_SECRETS_LOCATION | grep WORKLOAD_SUMMARY_URL | sed s/WORKLOAD_SUMMARY_URL=//`
+    local MATCH_WORKLOAD_SUMMARY_DBNAME=`cat $WMAGENT_SECRETS_LOCATION | grep WORKLOAD_SUMMARY_DBNAME | sed s/WORKLOAD_SUMMARY_DBNAME=//`
+    local MATCH_WMSTATS_URL=`cat $WMAGENT_SECRETS_LOCATION | grep WMSTATS_URL | sed s/WMSTATS_URL=//`
+    local MATCH_REQMGR2_URL=`cat $WMAGENT_SECRETS_LOCATION | grep REQMGR2_URL | sed s/REQMGR2_URL=//`
+    local MATCH_ACDC_URL=`cat $WMAGENT_SECRETS_LOCATION | grep ACDC_URL | sed s/ACDC_URL=//`
+    local MATCH_DBS3_URL=`cat $WMAGENT_SECRETS_LOCATION | grep DBS3_URL | sed s/DBS3_URL=//`
+    local MATCH_DQM_URL=`cat $WMAGENT_SECRETS_LOCATION | grep DQM_URL | sed s/DQM_URL=//`
+    local MATCH_REQUESTCOUCH_URL=`cat $WMAGENT_SECRETS_LOCATION | grep REQUESTCOUCH_URL | sed s/REQUESTCOUCH_URL=//`
+    local MATCH_CENTRAL_LOGDB_URL=`cat $WMAGENT_SECRETS_LOCATION | grep CENTRAL_LOGDB_URL | sed s/CENTRAL_LOGDB_URL=//`
+    local MATCH_WMARCHIVE_URL=`cat $WMAGENT_SECRETS_LOCATION | grep WMARCHIVE_URL | sed s/WMARCHIVE_URL=//`
+    local MATCH_AMQ_CREDENTIALS=`cat $WMAGENT_SECRETS_LOCATION | grep AMQ_CREDENTIALS | sed s/AMQ_CREDENTIALS=//`
+    local MATCH_RUCIO_HOST=`cat $WMAGENT_SECRETS_LOCATION | grep RUCIO_HOST | sed s/RUCIO_HOST=//`
+    local MATCH_RUCIO_AUTH=`cat $WMAGENT_SECRETS_LOCATION | grep RUCIO_AUTH | sed s/RUCIO_AUTH=//`
+    local MATCH_RUCIO_ACCOUNT=`cat $WMAGENT_SECRETS_LOCATION | grep RUCIO_ACCOUNT | sed s/RUCIO_ACCOUNT=//`
+
+    # database settings (mysql or oracle)
+    if [ "x$MATCH_ORACLE_USER" == "x" ]; then
+        MYSQL_USER=${MATCH_MYSQL_USER:-$USER};
+    else
+        ORACLE_USER=$MATCH_ORACLE_USER;
+        ORACLE_PASS=$MATCH_ORACLE_PASS;
+        ORACLE_TNS=$MATCH_ORACLE_TNS;
+        if [ "x$ORACLE_PASS" == "x" ] || [ "x$ORACLE_TNS" == "x" ]; then
+            echo "Secrets file doesnt contain ORACLE_PASS or ORACLE_TNS";
+            exit 1
+        fi
+    fi
+
+    GRAFANA_TOKEN=${MATCH_GRAFANA_TOKEN:-$GRAFANA_TOKEN};
+    if [ "x$GRAFANA_TOKEN" == "x" ]; then
+        echo "Secrets file doesnt contain GRAFANA_TOKEN";
+        exit 1
+    fi
+
+    # basic couch settings
+    COUCH_USER=${MATCH_COUCH_USER:-wmagentcouch};
+    COUCH_PASS=${MATCH_COUCH_PASS:-$COUCH_PASS};
+    if [ "x$COUCH_PASS" == "x" ]; then
+        echo "Secrets file doesnt contain COUCH_PASS";
+        exit 1
+    fi
+    
+    COUCH_PORT=${MATCH_COUCH_PORT:-$COUCH_PORT};
+    # if couch ssl certificate not specified check X509_USER_CERT and X509_USER_PROXY
+    COUCH_CERT_FILE=${MATCH_COUCH_CERT_FILE:-${X509_USER_CERT:-$X509_USER_PROXY}};
+
+    # if couch ssl key not specified check X509_USER_KEY and X509_USER_PROXY
+    COUCH_KEY_FILE=${MATCH_COUCH_KEY_FILE:-${X509_USER_KEY:-$X509_USER_PROXY}};
+
+    GLOBAL_WORKQUEUE_URL=${MATCH_GLOBAL_WORKQUEUE_URL:-$GLOBAL_WORKQUEUE_URL};
+
+    LOCAL_WORKQUEUE_DBNAME=${MATCH_LOCAL_WORKQUEUE_DBNAME:-$LOCAL_WORKQUEUE_DBNAME};
+
+    WORKLOAD_SUMMARY_URL=${MATCH_WORKLOAD_SUMMARY_URL:-$WORKLOAD_SUMMARY_URL};
+    
+    WMSTATS_URL=${MATCH_WMSTATS_URL:-$WMSTATS_URL}
+
+    REQMGR2_URL=${MATCH_REQMGR2_URL:-$REQMGR2_URL}
+    
+    ACDC_URL=${MATCH_ACDC_URL:-$ACDC_URL}
+    
+    DBS3_URL=${MATCH_DBS3_URL:-$DBS3_URL}
+
+    DQM_URL=${MATCH_DQM_URL:-$DQM_URL}
+
+    REQUESTCOUCH_URL=${MATCH_REQUESTCOUCH_URL:-$REQUESTCOUCH_URL}
+    
+    CENTRAL_LOGDB_URL=${MATCH_CENTRAL_LOGDB_URL:-$CENTRAL_LOGDB_URL}
+    
+    WMARCHIVE_URL=${MATCH_WMARCHIVE_URL:-$WMARCHIVE_URL}
+
+    AMQ_CREDENTIALS=${MATCH_AMQ_CREDENTIALS:-$AMQ_CREDENTIALS}
+    RUCIO_HOST=${MATCH_RUCIO_HOST:-$RUCIO_HOST}
+    RUCIO_AUTH=${MATCH_RUCIO_AUTH:-$RUCIO_AUTH}
+    RUCIO_ACCOUNT=${MATCH_RUCIO_ACCOUNT:-$RUCIO_ACCOUNT}
+}
+
+print_settings(){
+    echo "INSTALL_AG=                $INSTALL_AG                "
+    echo "CONFIG_COUCH=              $CONFIG_COUCH              "
+    echo "CONFIG_MYSQL=              $CONFIG_MYSQL              "
+    echo "CONFIG_AG=                 $CONFIG_AG                 "
+    echo "MYSQL_DATABASE_AG=         $MYSQL_DATABASE_AG         "
+    echo "ORACLE_USER=               $ORACLE_USER               "
+    echo "ORACLE_PASS=               $ORACLE_PASS               "
+    echo "ORACLE_TNS=                $ORACLE_TNS                "
+    echo "GRAFANA_TOKEN=             $GRAFANA_TOKEN             "
+    echo "MYSQL_USER=                $MYSQL_USER                "
+    echo "COUCH_USER=                $COUCH_USER                "
+    echo "COUCH_PASS=                $COUCH_PASS                "
+    echo "COUCH_PORT=                $COUCH_PORT                "
+    echo "COUCH_CERT_FILE=           $COUCH_CERT_FILE           "
+    echo "COUCH_KEY_FILE=            $COUCH_KEY_FILE            "
+    echo "GLOBAL_WORKQUEUE_URL=      $GLOBAL_WORKQUEUE_URL      "
+    echo "LOCAL_WORKQUEUE_DBNAME=    $LOCAL_WORKQUEUE_DBNAME    "
+    echo "WORKLOAD_SUMMARY_URL=      $WORKLOAD_SUMMARY_URL      "
+    echo "WORKLOAD_SUMMARY_DBNAME=   $WORKLOAD_SUMMARY_DBNAME   "
+    echo "WMSTATS_URL=               $WMSTATS_URL               "
+    echo "REQMGR2_URL=               $REQMGR2_URL               "
+    echo "ACDC_URL=                  $ACDC_URL                  "
+    echo "DBS3_URL=                  $DBS3_URL                  "
+    echo "DQM_URL=                   $DQM_URL                   "
+    echo "REQUESTCOUCH_URL=          $REQUESTCOUCH_URL          "
+    echo "CENTRAL_LOGDB_URL=         $CENTRAL_LOGDB_URL         "
+    echo "WMARCHIVE_URL=             $WMARCHIVE_URL             "
+    echo "AMQ_CREDENTIALS=           $AMQ_CREDENTIALS           "
+    echo "RUCIO_HOST=                $RUCIO_HOST                "
+    echo "RUCIO_AUTH=                $RUCIO_AUTH                "
+    echo "RUCIO_ACCOUNT=             $RUCIO_ACCOUNT             "
+
+}
+
+
+#
+# Environment
+#
+
+# . $ROOT_DIR/apps/wmagentpy3/etc/profile.d/init.sh
+
+# WMAGENT_ROOT == WMCORE_ROOT now but in old rpms WMCORE_ROOT was seperate,
+# if WMCORE_ROOT already set export it, else set to WMAGENT_ROOT
+export WMAGENTPY3_ROOT=$WMA_DEPLOY_DIR
+export WMCORE_ROOT=$WMA_DEPLOY_DIR
+export YUI_ROOT=$WMA_DEPLOY_DIR/yui/
+export WMAGENTPY3_VERSION=$WMA_TAG
+export CRYPTOGRAPHY_ALLOW_OPENSSL_102=true
+
+#########################
+#  MySQL                #
+#########################
+
+#
+# first time startup routines for mysql
+# pre gets called before startup, post called after it
+init_mysql_db_pre(){
+    echo "Installing the mysql database area..."
+    mkdir -p $INSTALL_MYSQL/database
+    mkdir -p $INSTALL_MYSQL/logs
+    mysql_install_db --datadir=$INSTALL_MYSQL/database
+}
+init_mysql_db_post(){
+    #install the WMAgent stuff
+    echo "Installing the mysql schema..."
+    load_secrets_file;
+    local TIMEOUT=0;
+    while [ ! -e $MYSQL_SOCK ]
+    do
+        sleep 2;
+        TIMEOUT=$(($TIMEOUT+2))
+        if [ $TIMEOUT -ge 300 ]; then
+            echo "ERROR: Timeout waiting for mysqld to start."
+            exit 1;
+        fi
+    done
+    echo "Socket file exists, proceeding with schema install..."
+
+    inited_mysql;
+
+    # create a user - different than root and current unix user - and grant privileges
+    if [ "$MYSQL_USER" != "$USER" ]; then
+        mysql -u $USER --socket=$MYSQL_SOCK --execute "CREATE USER '${MYSQL_USER}'@'localhost'"
+        mysql -u $USER --socket=$MYSQL_SOCK --execute "GRANT ALL ON *.* TO $MYSQL_USER@localhost WITH GRANT OPTION"
+    fi
+
+    # create databases for agent
+    if [ $USING_AG -eq 1 ]; then
+        echo "Installing WMAgent Database: ${MYSQL_DATABASE_AG}"
+        mysql -u $USER --socket=$MYSQL_SOCK --execute "create database ${MYSQL_DATABASE_AG}"
+    fi
+}
+
+status_of_mysql(){
+    load_secrets_file;
+    if [ "x$MYSQL_USER" == "x" ]; then
+	echo "Not using MySQL..."
+	exit 1;
+    fi
+
+    echo "+ Status of MySQL"
+    if [ ! -e $INSTALL_MYSQL/logs/mysqld.pid ]; then
+        echo "++ MySQL process file not found"
+        return
+    fi
+    local MYSQL_PID=`cat $INSTALL_MYSQL/logs/mysqld.pid`
+    kill -0 $MYSQL_PID;
+    local MYSQL_STATUS=$?
+    if [ $MYSQL_STATUS -eq 0 ]; then
+        echo "++ MYSQL running with process: $MYSQL_PID";
+    else
+        echo "++ MYSQL process not running"
+    fi
+
+    echo "++" `mysqladmin -u $MYSQL_USER --socket=$MYSQL_SOCK status`
+}
+
+#
+# Main startup method for MySQL.
+# Checks for initialisation
+start_mysql(){
+    load_secrets_file;
+    if [ "x$MYSQL_USER" == "x" ]; then
+	    echo "Not using MySQL..."
+	    exit 1;
+    fi
+
+    echo "Starting mysql..."
+
+    if [ $MYSQL_INIT_DONE -eq 0 ]; then
+	    echo "MySQL has not been initialised... running pre initialisation";
+	    init_mysql_db_pre;
+    fi
+
+    # Start mysqld to install the database schemas
+    #
+    echo "starting mysqld_safe..."
+    nohup mysqld_safe --defaults-extra-file=$CONFIG_MYSQL/my.cnf \
+                      --datadir=$INSTALL_MYSQL/database \
+                      --log-bin \
+                      --socket=$MYSQL_SOCK \
+                      --skip-networking --log-error=$INSTALL_MYSQL/logs/error.log \
+                      --pid-file=$INSTALL_MYSQL/logs/mysqld.pid > /dev/null 2>&1 < /dev/null &
+    local TIMEOUT=0;
+    echo "Checking MySQL Socket file exists..."
+    while [ ! -e $MYSQL_SOCK ]
+      do
+      sleep 2;
+      TIMEOUT=$(($TIMEOUT+2))
+      if [ $TIMEOUT -ge 300 ]; then
+	    echo "ERROR: Timeout waiting for mysqld to start."
+	    exit 1;
+      fi
+    done
+    echo "Socket file exists: $MYSQL_SOCK"
+
+    if [ $MYSQL_INIT_DONE -eq 0 ]; then
+        echo "MySQL has not been initialised... running post initialisation";
+        init_mysql_db_post;
+    fi
+    echo "Checking Server connection..."
+    mysql -u $USER --socket=$MYSQL_SOCK --execute "SHOW GLOBAL STATUS" > /dev/null;
+    if [ $? -ne 0 ]; then
+	    echo "ERROR: checking mysql database is running, failed to execute SHOW GLOBAL STATUS"
+	    exit 1
+    fi
+   echo "Connection OK"
+}
+
+#
+# stop MySQL
+#
+stop_mysql(){
+    load_secrets_file;
+    if [ "x$MYSQL_USER" == "x" ]; then
+	echo "Not using MySQL..."
+	exit 1;
+    fi
+
+    echo "stopping mysql..."
+    mysqladmin -u $MYSQL_USER --socket=$MYSQL_SOCK shutdown &
+    wait $!
+    echo "Making sure the MySQL socket file is removed..."
+    local TIMEOUT=0;
+    while [ -e $MYSQL_SOCK ]
+      do
+      sleep 2;
+      TIMEOUT=$(($TIMEOUT+2))
+      if [ $TIMEOUT -ge 300 ]; then
+	  echo "ERROR: Timeout waiting for mysqld to shutdown."
+	  echo "ERROR: Socket file still exists: $MYSQL_SOCK"
+	  exit 1;
+      fi
+    done
+    echo "MySQL is shutdown."
+}
+
+#
+# Wipe out MySQL
+# Will cause next start to recreate databases
+clean_mysql(){
+    load_secrets_file;
+    if [ "x$MYSQL_USER" == "x" ]; then
+	echo "Not using MySQL..."
+	exit 1;
+    fi
+
+    echo "cleaning MySQL DB...";
+    if [ -e $INSTALL_MYSQL/logs/mysql.pid ]; then stop_mysql; fi;
+
+    /bin/rm -f $INSTALL_MYSQL/.init
+    /bin/rm -f $MYSQL_SOCK
+    /bin/rm -f $INSTALL_MYSQL/logs/mysqld.pid
+    /bin/rm -rf $INSTALL_MYSQL/database/*
+}
+
+#
+# Database prompt so that people can poke around in the db interactively
+#
+db_prompt(){
+    load_secrets_file;
+    if [ "x$MYSQL_USER" != "x" ]; then
+	case "$2" in
+	  "wmagent")
+	      mysql -u $MYSQL_USER --socket=$MYSQL_SOCK --database=${MYSQL_DATABASE_AG};;
+	  *)
+	      echo "Unknown arg to db_prompt: $2"
+	      echo "Should be one of unittest, wmagent"
+	      exit 1
+	esac
+    elif [ "x$ORACLE_USER" != "x" ]; then
+	sqlplus $ORACLE_USER/$ORACLE_PASS@$ORACLE_TNS
+    else
+	echo "No database configured..."
+	exit 1;
+    fi
+}
+
+#########################
+#  CouchDB              #
+#########################
+
+#
+# first time startup for couch: disable admin party and create user based on secrets file
+#
+init_couch_pre(){
+    echo "Initialising CouchDB on $COUCH_HOST:$COUCH_PORT..."
+    echo "  With installation directory: $INSTALL_COUCH"
+    echo "  With configuration directory: $CONFIG_COUCH"
+    mkdir -p $INSTALL_COUCH/logs
+    mkdir -p $INSTALL_COUCH/database
+    perl -p -i -e "s{deploy_project_root/couchdb}{$INSTALL_COUCH}" $CONFIG_COUCH/local.ini
+    # couch ini file requires IP based hostname
+    perl -p -i -e "s{bind_address = 127.0.0.1}{bind_address = $COUCH_HOST}g" $CONFIG_COUCH/local.ini
+    perl -p -i -e "s{port = 6994}{port = $COUCH_PORT}g" $CONFIG_COUCH/local.ini
+    perl -p -i -e "s{unittestagent = passwd}{$COUCH_USER = $COUCH_PASS}g" $CONFIG_COUCH/local.ini
+    if [ "x$COUCH_CERT_FILE" != "x" ] && [ "x$COUCH_KEY_FILE" != "x" ]; then
+        mkdir -p $INSTALL_COUCH/certs
+        perl -p -i -e "s{;cert_file =.*}{cert_file = $INSTALL_COUCH/certs/cert.pem}g" $CONFIG_COUCH/local.ini
+        perl -p -i -e "s{;key_file =.*}{key_file = $INSTALL_COUCH/certs/key.pem}g" $CONFIG_COUCH/local.ini
+        perl -p -i -e "s{;cacert_file =.*}{cacert_file = $INSTALL_COUCH/certs/cert.pem}g" $CONFIG_COUCH/local.ini
+        ln -s $COUCH_CERT_FILE $INSTALL_COUCH/certs/cert.pem
+        ln -s $COUCH_KEY_FILE $INSTALL_COUCH/certs/key.pem
+    fi
+}
+
+init_couch_post(){
+    inited_couch;
+}
+
+status_of_couch(){
+    load_secrets_file;
+    echo "+ Couch Status:"
+    echo "++" `curl -s $COUCH_HOST:$COUCH_PORT`
+}
+
+#
+# Startup couch
+#
+start_couch(){
+    load_secrets_file;
+    echo "starting couch..."
+    if [ $COUCH_INIT_DONE -eq 0 ]; then
+	echo "CouchDB has not been initialised... running pre initialisation";
+	init_couch_pre;
+    fi
+    echo -n "Which couchdb: "
+    which couchdb
+    echo "  With installation directory: $INSTALL_COUCH"
+    echo "  With configuration directory: $CONFIG_COUCH"
+    nohup couchdb -couch_ini $CONFIG_COUCH >> $INSTALL_COUCH/logs/couch.log 2>&1 &
+    if [ $COUCH_INIT_DONE -eq 0 ]; then
+	echo "CouchDB has not been initialised... running post initialisation"
+	init_couch_post;
+    fi
+}
+
+#
+# shutdown couch
+#
+stop_couch(){
+    echo "Stopping CouchDB service..."
+    for couch_pid in $(ps aux | grep couchdb | egrep -v 'grep|\/manage|ps aux' | awk '{print $2}'); do
+        echo "  killing CouchDB process... ${couch_pid}"
+        kill -9 $couch_pid || true
+    done
+}
+
+clean_couch(){
+    echo "cleaning couch installation..."
+    stop_couch
+    echo "removing files"
+    rm -f $INSTALL_COUCH/.init
+    rm -rf $INSTALL_COUCH/database/*
+}
+
+
+#
+# combined startup of all required services
+#
+start_services(){
+    load_secrets_file;
+    echo "Starting Services..."
+    #start up the services required by the agent
+    start_couch;
+    if [ "x$MYSQL_USER" != "x" ]; then
+	start_mysql;
+    fi
+}
+
+stop_services(){
+    load_secrets_file;
+    #shut down all services
+    echo "Shutting down services..."
+    stop_couch;
+    if [ "x$MYSQL_USER" != "x" ]; then
+	stop_mysql;
+    fi
+}
+
+##############################
+#  Agent stuff               #
+##############################
+
+# update the rucio.cfg file with the proper parameters from the secrets file
+init_rucio(){
+    sed -i "s+RUCIO_HOST_OVERWRITE+$RUCIO_HOST+" $CONFIG_RUCIO
+    sed -i "s+RUCIO_AUTH_OVERWRITE+$RUCIO_AUTH+" $CONFIG_RUCIO
+}
+
+# generate the agent config from the basic template
+init_wmagent(){
+    load_secrets_file;
+    init_rucio;
+
+    if [ "x$MYSQL_USER" != "x" ]; then
+        local database_options="--mysql_url=mysql://$MYSQL_USER@localhost/$MYSQL_DATABASE_AG \
+                          --mysql_socket=$MYSQL_SOCK "
+    elif [ "x$ORACLE_USER" != "x" ]; then
+        local database_options="--coredb_url=oracle://$ORACLE_USER:$ORACLE_PASS@$ORACLE_TNS "
+    else
+	echo "No database configured, should never have reached this point..."
+	exit 1;
+    fi
+
+    wmagent-mod-config $database_options \
+	                   --input=$CONFIG_AG/config-template.py \
+                       --output=$CONFIG_AG/config.py \
+                       --working_dir=$INSTALL_AG \
+                       --couch_url=http://$COUCH_USER:$COUCH_PASS@$COUCH_HOST_NAME:$COUCH_PORT \
+                       --global_workqueue_url=$GLOBAL_WORKQUEUE_URL \
+                       --workqueue_db_name=$LOCAL_WORKQUEUE_DBNAME \
+                       --workload_summary_url=$WORKLOAD_SUMMARY_URL \
+                       --grafana_token=$GRAFANA_TOKEN \
+                       --wmstats_url=$WMSTATS_URL \
+                       --reqmgr2_url=$REQMGR2_URL \
+	                   --acdc_url=$ACDC_URL \
+	                   --dbs3_url=$DBS3_URL \
+	                   --dqm_url=$DQM_URL \
+	                   --requestcouch_url=$REQUESTCOUCH_URL \
+	                   --central_logdb_url=$CENTRAL_LOGDB_URL \
+	                   --wmarchive_url=$WMARCHIVE_URL \
+	                   --amq_credentials=$AMQ_CREDENTIALS \
+	                   --rucio_account=$RUCIO_ACCOUNT \
+	                   --rucio_host=$RUCIO_HOST \
+	                   --rucio_auth=$RUCIO_AUTH
+
+    wmcore-db-init --config $CONFIG_AG/config.py --create --modules=WMCore.WMBS,WMCore.Agent.Database,WMComponent.DBS3Buffer,WMCore.BossAir,WMCore.ResourceControl;
+
+    export WMAGENT_CONFIG=$CONFIG_AG/config.py
+    wmagent-couchapp-init
+    unset WMAGENT_CONFIG
+    inited_agent;
+}
+
+#
+# initialise the agent based on the project installed
+#
+init_agent(){
+    if [ $USING_AG -eq 1 ]; then
+        if [ $AG_INIT_DONE -eq 0 ]; then
+            echo "Initialising Agent..."
+            init_wmagent;
+        fi
+    fi
+}
+
+start_agent(){
+    init_agent;
+
+    if [ $USING_AG -eq 1 ]; then
+        echo "Starting WMAgent..."
+        wmcoreD --start --config=$CONFIG_AG/config.py
+    fi
+}
+
+stop_agent(){
+    if [ $USING_AG -eq 1 ]; then
+        echo "Shutting down WMAgent...";
+        wmcoreD --shutdown --config=$CONFIG_AG/config.py;
+    fi
+}
+
+status_of_agent(){
+    if [ $USING_AG -eq 1 ]; then
+        echo "Status of WMAgent:"
+        wmcoreD --status --config=$CONFIG_AG/config.py
+    fi
+}
+
+
+#
+# revert agent back to pre initialised state & wipe out
+# everything currently in existence.
+clean_agent(){
+    load_secrets_file;
+    stop_agent;
+
+    if [ $USING_AG -eq 1 ]; then
+        echo "Cleaning WMAgent..."
+        rm -rf $INSTALL_AG/*
+        rm -f $CONFIG_AG/config.py;
+        rm -f $INSTALL_AG/.init
+
+        if [ "x$MYSQL_USER" != "x" ]; then
+            mysql -u $MYSQL_USER --socket=$MYSQL_SOCK --execute "drop database ${MYSQL_DATABASE_AG}"
+            mysql -u $MYSQL_USER --socket=$MYSQL_SOCK --execute "create database ${MYSQL_DATABASE_AG}"
+	    fi
+    fi
+}
+
+
+status(){
+    load_secrets_file;
+    status_of_couch;
+    if [ "x$MYSQL_USER" != "x" ]; then
+	status_of_mysql;
+    fi
+    status_of_agent;
+}
+
+clean_all(){
+    load_secrets_file;
+    if [ "x$MYSQL_USER" != "x" ]; then
+	clean_mysql;
+    fi
+    clean_couch;
+    clean_agent;
+}
+
+
+execute_command_agent(){
+    shift;
+    local RUNTHIS=$1
+    local WMCORE_BIN_DIR=$WMCORE_ROOT/bin
+    if [ ! -e $WMCORE_BIN_DIR/$1 ]; then
+        echo "$RUNTHIS is not a binary in WMCore/bin"
+        exit 1
+    fi
+    shift;
+    load_secrets_file;
+    export WMAGENT_CONFIG=$CONFIG_AG/config.py
+    echo "Executing $RUNTHIS $@ ..."
+    $RUNTHIS $@;
+}
+
+
+help(){
+    echo "Documentation for this script can be found at: https://svnweb.cern.ch/trac/CMSDMWM/wiki/WMAgentManagement";
+}
+
+
+
+#######################################################
+# Main
+#######################################################
+
+case $1 in
+  status)
+    status ;;
+  activate-agent)
+    activate_agent;;
+  start-services)
+    start_services;;
+  stop-services)
+    stop_services;;
+  start-mysql)
+    start_mysql;;
+  stop-mysql)
+    stop_mysql;;
+  clean-mysql)
+     clean_mysql;;
+  db-prompt)
+     db_prompt $@;;
+  mysql-prompt)
+     db_prompt $@;;
+  start-couch)
+     start_couch;;
+  stop-couch)
+     stop_couch;;
+  clean-couch)
+     clean_couch;;
+  init-agent)
+     init_agent;;
+  start-agent)
+     start_agent;;
+  stop-agent)
+     stop_agent;;
+  clean-agent)
+     clean_agent;;
+  clean-all)
+     clean_all;;
+  execute-agent)
+     execute_command_agent $@;;
+  help)
+    help ;;
+  version)
+    echo "Management script for WMAgent. No idea what version, at least 2 though" ;;
+  * )
+    echo "$0: unknown action '$1', please try '$0 help' or documentation." 1>&2
+    exit 1 ;;
+esac

--- a/docker/pypi/wmagent/etc/local.ini
+++ b/docker/pypi/wmagent/etc/local.ini
@@ -1,0 +1,62 @@
+; WMAgent CouchDB configuration settings
+
+[chttpd]
+port = 6994
+bind_address = 127.0.0.1
+; Maximum period in milliseconds to wait for a change before the response is sent
+changes_timeout = 300000
+
+[couchdb]
+;max_document_size = 4294967296 ; bytes
+database_dir = deploy_project_root/couchdb/database
+view_index_dir = deploy_project_root/couchdb/database
+uri_file = deploy_project_root/couchdb/logs/couch.uri
+os_process_timeout = 1000000
+; single node is only for test purposes, otherwise it will work just like CouchDB 1.x
+; for now, define it in the default config such that _users, _replicator and _global_changes databases are automatically created
+single_node=true
+max_dbs_open = 500
+
+[log]
+level = info
+file = deploy_project_root/couchdb/logs/couch.log
+
+[ssl]
+enable = true
+cert_file = deploy_project_root/couchdb/certs/cert.pem
+key_file = deploy_project_root/couchdb/certs/key.pem
+cacert_file = deploy_project_root/couchdb/certs/cert.pem
+ssl_certificate_max_depth = 10
+verify_ssl_certificates = false
+
+[replicator]
+cert_file = deploy_project_root/couchdb/certs/cert.pem
+key_file = deploy_project_root/couchdb/certs/key.pem
+cacert_file = deploy_project_root/couchdb/certs/cert.pem
+ssl_certificate_max_depth = 10
+verify_ssl_certificates = false
+; checkpoint setup: 10 minutes interval
+use_checkpoints = true
+checkpoint_interval = 120000
+; performance setup (still to be evaluated in the production nodes)
+worker_processes = 4
+http_connections = 10
+worker_batch_size = 2000
+socket_options = [{keepalive, true}, {nodelay, true}]
+; don't give up if replication fails; set timeout to 200secs
+max_replication_retry_count = infinity
+; wait for 300 seconds before timing out (actual timeout is 1/3 of it, since it's used in other parts of the code)
+connection_timeout = 900000
+
+[compactions]
+_default = [{db_fragmentation, "70%"}, {view_fragmentation, "60%"}, {from, "20:00"}, {to, "05:00"}]
+
+[compaction_daemon]
+; check for databases and views every hour
+check_interval = 3600
+; ~200 MB
+min_file_size = 209715200
+
+[admins]
+;produser = prodpasswd
+unittestagent = passwd

--- a/docker/pypi/wmagent/etc/my.cnf
+++ b/docker/pypi/wmagent/etc/my.cnf
@@ -1,0 +1,72 @@
+[mysqld]
+# this is the default setting in >= 10.2.4
+sql_mode="NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES"
+# default: REPEATABLE-READ
+transaction-isolation=READ-COMMITTED
+
+max_heap_table_size=2048M
+max_allowed_packet=128M
+max_connections = 200
+connect_timeout = 60
+
+# default: MIXED
+binlog_format=ROW
+# default: 16MB
+tmp_table_size=2048M
+# default: 10
+long_query_time=5
+
+# default: 134217728
+key_buffer_size=4000M
+
+# default: 0
+# disabling the query cache for now
+# unittests do not work with this enabled
+#query_cache_type=1
+#query_cache_limit=10M
+#query_cache_size=128M
+
+# threading
+# thread_cache_size defaults to 256, if > than max_connections, it is
+# set to max_connections
+thread_cache_size = 64
+thread_cache_size = 16
+thread_stack = 192K
+
+# innodb
+# default: O_DIRECT
+innodb_flush_method=O_DIRECT
+# default: 4
+innodb_read_io_threads = 4
+# default: 4
+innodb_write_io_threads = 4
+# default: full_crc23
+innodb_checksum_algorithm=full_crc32
+# default: 1
+innodb_doublewrite=0
+
+innodb_log_file_size=512M
+innodb_log_buffer_size=8M
+innodb_buffer_pool_size=2G
+# default: 30
+innodb_sync_spin_loops=60
+# default: 0
+innodb_force_recovery = 0
+# default: 50
+innodb_lock_wait_timeout = 100
+
+# Changes to support DYNAMIC / COMPRESSED row format
+# default: Barracuda
+innodb_file_format=Barracuda
+# default: ON
+innodb_file_per_table=ON
+# supports prefix index larger than 767 bytes (might be already implicit in the DYNAMIC mode?)
+# default: ON
+innodb_large_prefix=ON
+# default: ON
+innodb_strict_mode=ON
+#innodb_page_size=32k  # default is 16k
+
+# Introduced in MariaDB 10.1.32, COMP is currently using 10.1.21
+# If COMPRESSED is used, it cannot be set globally and has to be passed in the CREATE TABLE statement
+#innodb_default_row_format=DYNAMIC

--- a/docker/pypi/wmagent/etc/rucio.cfg
+++ b/docker/pypi/wmagent/etc/rucio.cfg
@@ -1,0 +1,20 @@
+# Copyright European Organization for Nuclear Research (CERN)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Authors:
+# - Vincent Garonne, <vgaronne@gmail.com>, 2017
+# - Eric Vaandering, <ewv@fnal.gov>, 2018
+
+[common]
+[client]
+rucio_host = RUCIO_HOST_OVERWRITE
+auth_host = RUCIO_AUTH_OVERWRITE
+auth_type = x509
+ca_cert = /etc/grid-security/certificates/
+client_cert = $X509_USER_CERT
+client_key = $X509_USER_KEY
+client_x509_proxy = $X509_USER_PROXY
+request_retries = 3

--- a/docker/pypi/wmagent/install.sh
+++ b/docker/pypi/wmagent/install.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+
+### This script is used to create a WMAgent Docker image and is based on deploy-wmagent.sh
+### It simply deploys the agent based on the WMAgent version/tag provided at runtime.
+### * Patches can be applied when the agent container is started.
+### * Configuration changes are made when the container is started with `run.sh`.
+###
+### It takes a single parameter as first (and only) argument at runtime - The WMA_TAG
+### Example: install.sh 2.2.0.2
+
+pythonLib=$(python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
+
+help(){
+    echo -e $1
+    cat <<EOF
+
+The basic WMAgent deployment script for Docker image creation:
+Usage: install.sh -v <wmagent_tag>
+
+    -v <wmagent_tag>    The WMAgent version/tag to be used for the Docker image creation
+
+Example: ./install.sh -v 2.2.0.2
+
+EOF
+}
+
+usage(){
+    help $1
+    exit 1
+}
+
+WMA_TAG=None
+
+### Argument parsing:
+while getopts ":v:h" opt; do
+    case ${opt} in
+        v) WMA_TAG=$OPTARG ;;
+        h) help; exit $? ;;
+        \? )
+            msg="Invalid Option: -$OPTARG"
+            usage "$msg" ;;
+        : )
+            msg="Invalid Option: -$OPTARG requires an argument"
+            usage "$msg" ;;
+    esac
+done
+
+WMA_TAG_REG="^[0-9]+\.[0-9]+\.[0-9]{1,2}((\.|rc)[0-9]{1,2})?$"
+[[ $WMA_TAG =~ $WMA_TAG_REG ]] || { echo "WMA_TAG: $WMA_TAG does not match requered expression: $WMA_TAG_REG"; echo "EXIT with Error 1"  ; exit 1 ;}
+
+echo
+echo "======================================================================="
+echo "Starting new WMAgent deployment with the following initialisation data:"
+echo "-----------------------------------------------------------------------"
+echo " - WMAgent Version            : $WMA_TAG"
+echo " - WMAgent User               : $WMA_USER"
+echo " - WMAgent Root path          : $WMA_ROOT_DIR"
+echo " - Python  Version            : $(python --version)"
+echo " - Python  Module path        : $pythonLib"
+echo "======================================================================="
+echo
+
+
+# Installing the wmagent package from pypi
+stepMsg="Installing wmagent:$WMA_TAG at $WMA_DEPLOY_DIR"
+echo "-----------------------------------------------------------------------"
+echo "Start $stepMsg"
+
+# First upgrade pip to the latest version:
+pip install wheel
+pip install --upgrade pip
+
+# Second deploy the package. Interrupt on error:
+pip install wmagent==$WMA_TAG || { err=$?; echo "Failed to install wmagent:$WMA_TAG at $WMA_DEPLOY_DIR" ; exit $err ; }
+echo "Done $stepMsg!" && echo
+echo "-----------------------------------------------------------------------"
+
+# Setup required directories
+stepMsg="Creating required directory structure in the WMAgent image"
+echo "-----------------------------------------------------------------------"
+echo "Start $stepMsg"
+mkdir -p ${WMA_DEPLOY_DIR} || true
+mkdir -p $WMA_BASE_DIR/wmagent/$WMA_TAG || true
+ln -s $WMA_BASE_DIR/wmagent/$WMA_TAG $WMA_CURRENT_DIR
+
+mkdir -p $WMA_ADMIN_DIR $WMA_HOSTADMIN_DIR $WMA_CERTS_DIR $WMA_MANAGE_DIR $WMA_INSTALL_DIR
+chmod 755 $WMA_CERTS_DIR
+
+cd $WMA_BASE_DIR
+echo "Done $stepMsg!" && echo
+echo "-----------------------------------------------------------------------"
+
+stepMsg="Downloading all files required for the containder intialisation at the host"
+echo "-----------------------------------------------------------------------"
+echo "Start $stepMsg"
+
+# Fix for outdated yui library - A really bad workaround. We should get rid of it ASAP:
+wget -nv -P $WMA_DEPLOY_DIR  https://yui.github.io/yui2/archives/yui_2.9.0.zip || { err=$?; echo "Error downloading yui_2.9.0.zip"; exit $err ; }
+unzip -d $WMA_DEPLOY_DIR $WMA_DEPLOY_DIR/yui_2.9.0.zip yui/build/*
+rm -f $WMA_DEPLOY_DIR/yui_2.9.0.zip
+
+echo "Done $stepMsg!" && echo
+echo "-----------------------------------------------------------------------"
+
+stepMsg="Generating and preserving current build id"
+echo "-----------------------------------------------------------------------"
+echo "Start $stepMsg"
+echo $RANDOM |sha256sum |awk '{print $1}' > $WMA_ROOT_DIR/.dockerBuildId
+echo "WMA_BUILD_ID:`cat $WMA_ROOT_DIR/.dockerBuildId`"
+echo "WMA_BUILD_ID preserved at: $WMA_ROOT_DIR/.dockerBuildId "
+echo "Done $stepMsg!" && echo
+echo "-----------------------------------------------------------------------"
+
+stepMsg="Replace the current /data/manage script coming from 'dmwm-base' image with a symlink link"
+echo "-----------------------------------------------------------------------"
+echo "Start $stepMsg"
+[[ -f /data/manage ]] && rm -f /data/manage && ln -s $WMA_MANAGE_DIR/manage /data/manage
+echo "Done $stepMsg!" && echo
+echo "-----------------------------------------------------------------------"
+
+tweakEnv(){
+    # A function to apply environment tweaks for the docker image
+    echo "-------------------------------------------------------"
+    echo "Edit \$WMA_ENV_FILE script to point to \$WMA_ROOT_DIR"
+    sed -i "s|/data/|\$WMA_ROOT_DIR/|g" $WMA_ENV_FILE
+
+    echo "Edit $WMA_DEPLOY_DIR/deploy/renew_proxy.sh script to point to \$WMA_ROOT_DIR"
+    sed -i "s|/data/|\$WMA_ROOT_DIR/|g" $WMA_DEPLOY_DIR/deploy/renew_proxy.sh
+    sed -i "s|source.*env\.sh|source \$WMA_ENV_FILE|g" $WMA_DEPLOY_DIR/deploy/renew_proxy.sh
+    echo "-------------------------------------------------------"
+
+    cat <<EOF >> $WMA_ENV_FILE
+
+alias lll="ls -lathr"
+alias ls="ls --color=auto"
+alias ll='ls -la --color=auto'
+
+alias condorq='condor_q -format "%i." ClusterID -format "%s " ProcId -format " %i " JobStatus  -format " %d " ServerTime-EnteredCurrentStatus -format "%s" UserLog -format " %s\n" DESIRED_Sites'
+alias condorqrunning='condor_q -constraint JobStatus==2 -format "%i." ClusterID -format "%s " ProcId -format " %i " JobStatus  -format " %d " ServerTime-EnteredCurrentStatus -format "%s" UserLog -format " %s\n" DESIRED_Sites'
+alias agentenv='source $WMA_ENV_FILE'
+alias manage=\$manage
+
+# Aliases for Tier0-Ops.
+alias runningagent="ps aux | egrep 'couch|wmcore|mysql|beam'"
+alias foldersize="du -h --max-depth=1 | sort -hr"
+
+# Better curl command
+alias scurl='curl -k --cert ${CERT_DIR}/servicecert.pem --key ${CERT_DIR}/servicekey.pem'
+
+# set WMAgent docker specific bash prompt:
+export PS1="(WMAgent-\$WMA_TAG) [\u@\h:\W]\$ "
+export WMA_BUILD_ID=\$(cat \$WMA_ROOT_DIR/.dockerBuildId)
+export WMAGENTPY3_ROOT=\$WMA_INSTALL_DIR/wmagent
+export WMAGENTPY3_VERSION=\$WMA_TAG
+export PATH=\$WMA_INSTALL_DIR/wmagent/bin\${PATH:+:\$PATH}
+EOF
+}
+
+
+stepMsg="Tweaking runtime environment for the WMA_USER"
+echo "-----------------------------------------------------------------------"
+echo "Start $stepMsg"
+tweakEnv || { err=$?; echo ""; exit $err ; }
+cat <<EOF >> /home/${WMA_USER}/.bashrc
+source $WMA_ENV_FILE
+EOF
+echo "Done $stepMsg!" && echo
+echo "-----------------------------------------------------------------------"
+
+stepMsg="Populating cronjob with utilitarian scripts for the WMA_USER"
+echo "-----------------------------------------------------------------------"
+echo "Start $stepMsg"
+
+# TODO: These executable flags we should consider fixing them for all *.sh
+#       scripts under the /deploy top level area in the WMCore github repository
+chmod +x $WMA_DEPLOY_DIR/deploy/renew_proxy.sh $WMA_DEPLOY_DIR/deploy/restartComponent.sh
+
+crontab -u $WMA_USER - <<EOF
+55 */12 * * * $WMA_DEPLOY_DIR/deploy/renew_proxy.sh
+58 */12 * * * python $WMA_DEPLOY_DIR/deploy/checkProxy.py --proxy /data/certs/myproxy.pem --time 120 --send-mail True --mail alan.malta@cern.ch
+*/15 * * * *  source $WMA_DEPLOY_DIR/deploy/restartComponent.sh > /dev/null
+EOF
+
+echo "Done $stepMsg!" && echo
+echo "-----------------------------------------------------------------------"
+
+
+echo "-----------------------------------------------------------------------"
+echo "WMAgent contaner build finished!!" && echo
+echo "Have a nice day!" && echo
+echo "======================================================================="
+
+
+exit 0

--- a/docker/pypi/wmagent/run.sh
+++ b/docker/pypi/wmagent/run.sh
@@ -1,0 +1,685 @@
+#!/bin/bash
+
+### This script is used to start the WMAgent services inside a Docker container
+### * All agent related configuration parameters are fetched as named arguments
+###   at runtime and used to (re)generate the agent configuration files.
+### * All service credentials and schedd caches are accessed via host mount points
+### * The agent's hostname && HTCondor configuration are taken from the host
+
+WMCoreVersion=$(python -c "from WMCore import __version__ as WMCoreVersion; print(WMCoreVersion)")
+pythonLib=$(python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
+
+help(){
+    echo -e $*
+    cat <<EOF
+
+WMCoreVersion: v$WMCoreVersion
+
+The initial run.sh script for the wmagent container. It is used to:
+ * Check if all needed system mount points are in place
+ * Check if all needed system services (i.e. MariaDB and CouchDB) are up and running
+ * Check and populate the agent's resource-control data based on the hostname on which
+   the container is about to be running
+ * Create or reuse an agent configuration file based on the hostname on which
+   the container is about to be running and the startup parameters sent to the script
+ * Start the agent in the docker container
+
+
+Usage: run.sh [-t <team_name>] [-n <agent_number>] [-f <db_flavour>]
+
+    -t <team_name>    Team name in which the agent should be connected to
+    -n <agent_number> Agent number to be set when more than 1 agent connected to the same team (Default: 0)
+    -f <db_flavour>   Relational Database flavour. Possible optinos are: 'mysql' or 'oracle' (Default: myslq)
+
+Example: ./run.sh -n 30 -t testbed-vocms001 -c cmsweb-testbed.cern.ch -f mysql
+
+EOF
+}
+
+usage(){
+    help $*
+    exit 1
+}
+
+# The container hostname must be properly fetched from the host and passed as `docker run --hostname=$hostname`
+HOSTNAME=`hostname -f`
+HOSTIP=`hostname -i`
+
+# Setup defaults:
+[[ $WMA_TAG == $WMCoreVersion ]] || {
+    echo "WARNING: Container WMA_TAG: $WAM_TAG and actual WMCoreVersion: $WMCoreVersion mismatch."
+    echo "WARNING: Assuming  WMA_TAG=$WMCoreVersion"
+    WMA_TAG=$WMCoreVersion
+}
+
+TEAMNAME=testbed-${HOSTNAME%%.*}
+AGENT_NUMBER=0
+FLAVOR=mysql
+
+# Find the current WMAgent Docker image BuildId:
+# NOTE: The $WMA_BUILD_ID is exported only from $WMA_USER/.bashrc but not from the Dockerfile ENV command
+[[ -n $WMA_BUILD_ID ]] || WMA_BUILD_ID=$(cat $WMA_ROOT_DIR/.dockerBuildId) || { echo "ERROR: Cuold not find/set WMA_UILD_ID"; exit 1 ;}
+
+# TODO: To fix the bellow two exports in the manage script - this will breack backwards compatibility
+# NOTE: The $WMAGENTPY3_ROOT is exported only from $WMA_USER/.bashrc but not from the Dockerfile ENV command
+# NOTE: The $WMAGENTPY3_VERSION is exported only from $WMA_USER/.bashrc but not from the Dockerfile ENV command
+
+### Argument parsing:
+# export OPTIND=1
+while getopts ":t:n:c:f:h" opt; do
+    case ${opt} in
+        t) TEAMNAME=$OPTARG ;;
+        n) AGENT_NUMBER=$OPTARG ;;
+        f) FLAVOR=$OPTARG ;;
+        h) help; exit $? ;;
+        # \? )
+        #     msg="Invalid Option: -$OPTARG"
+        #     usage "$msg" ;;
+        : )
+            msg="Invalid Option: -$OPTARG requires an argument"
+            usage "$msg" ;;
+    esac
+done
+
+# Check runtime arguments:
+TEAMNAME_REG="(^production$|^testbed-.*$|^dev-.*$|^relval.*$)"
+[[ $TEAMNAME =~ $TEAMNAME_REG ]] || { echo "TEAMNAME: $TEAMNAME does not match required expression: $TEAMNAME_REG"; echo "EXIT with Error 1"  ; exit 1 ;}
+
+FLAVOR_REG="(^oracle$|^mysql$)"
+[[ $FLAVOR =~ $FLAVOR_REG ]] || { echo "FLAVOR: $FLAVOR does not match required expression: $FLAVOR_REG"; echo "EXIT with Error 1"  ; exit 1 ;}
+
+
+echo
+echo "======================================================="
+echo "Starting WMAgent with the following initialisation data:"
+echo "-------------------------------------------------------"
+echo " - WMAgent Version            : $WMA_TAG"
+echo " - WMAgent User               : $WMA_USER"
+echo " - WMAgent Root path          : $WMA_ROOT_DIR"
+echo " - WMAgent Host               : $HOSTNAME"
+echo " - WMAgent TeamName           : $TEAMNAME"
+echo " - WMAgent Number             : $AGENT_NUMBER"
+echo " - WMAgent Relational DB type : $FLAVOR"
+echo " - Python  Version            : $(python --version)"
+echo " - Python  Module path        : $pythonLib"
+echo "======================================================="
+echo
+
+source $WMA_ENV_FILE
+
+_check_mounts() {
+    # An auxiliay function to check if a given mountpoint is among the actually
+    # bind mounted volumes from the host
+    # :param $1: The mountpoint to be checked
+    # :return: true/false
+    local mounts=$(mount |grep -E "(/data|/etc/condor|/tmp)" |awk '{print $3}')
+    local mountPoint=$(realpath $1 2>/dev/null)
+    [[ " $mounts " =~  ^.*[[:space:]]+$mountPoint[[:space:]]+.*$  ]] && return $(true) || return $(false)
+}
+
+basic_checks() {
+
+    local stepMsg="Performing basic setup checks..."
+    echo "-------------------------------------------------------"
+    echo "Start: $stepMsg"
+    echo
+
+    local errMsg=""
+    errMsg="ERROR: Could not find $WMA_ENV_FILE."
+    [[ -e $WMA_ENV_FILE ]] || { err=$?; echo -e "$errMsg"; exit $err ;}
+
+    errMsg="ERROR: Could not find $WMA_ADMIN_DIR."
+    [[ -d $WMA_ADMIN_DIR ]] || { err=$?; echo -e "$errMsg"; exit $err ;}
+
+    errMsg="ERROR: Could not find $WMA_HOSTADMIN_DIR mount point"
+    [[ -d $WMA_HOSTADMIN_DIR ]] && _check_mounts $WMA_HOSTADMIN_DIR || { err=$?; echo -e "$errMsg"; exit $err ;}
+
+    errMsg="ERROR: Could not find $WMA_CONFIG_DIR mount point"
+    [[ -d $WMA_CONFIG_DIR ]] && _check_mounts $WMA_CONFIG_DIR || { err=$?; echo -e "$errMsg"; exit $err ;}
+
+    errMsg="ERROR: Could not find $WMA_INSTALL_DIR mount point"
+    [[ -d $WMA_INSTALL_DIR ]] && _check_mounts $WMA_INSTALL_DIR || { err=$?; echo -e "$errMsg"; exit $err ;}
+
+    errMsg="ERROR: Could not find $WMA_CERTS_DIR mount point"
+    [[ -d $WMA_CERTS_DIR ]] && _check_mounts $WMA_CERTS_DIR || { err=$?; echo -e "$errMsg"; exit $err ;}
+    echo "Done: $stepMsg"
+    echo "-------------------------------------------------------"
+    echo
+}
+
+_parse_wmasecrets(){
+    # Auxiliary function to provide basic parsing of the WMAgent.secrets file
+    # :param $1: path to WMAgent.secrets file
+    local errVal=0
+    local value=""
+    local secretsFile=$1
+    # All variables need to be fetched in lowercase through: ${var,,}
+    local badValuesReg="(update-me|updateme|<update-me>|<updateme>|fix-me|fixme|<fix-me>|<fixme>|^$)"
+    local varsToCheck=`awk -F\= '{print $1}' $secretsFile | grep -vE "^[[:blank:]]*#.*$"`
+    for var in $varsToCheck
+    do
+        value=`grep -E "^[[:blank:]]*$var" $secretsFile | awk -F\= '{print $2}'`
+        [[ ${value,,} =~ $badValuesReg ]] && { echo "$FUNCNAME: Bad value for: $var=$value"; let errVal+=1 ;}
+    done
+    return $errVal
+}
+
+_init_valid(){
+    # Auxiliary function to shorten repetitive compares of */.dockerInit files to the current WMA_BUILD_TAG
+    # :param $1: The path tho the .dockerInit file to be checked.
+    # NOTE:      It works both ways: with and without providing the .dockerInit file at the end of the path
+    local dockerInit=${1%.dockerInit}/.dockerInit
+    [[ -n $dockerInit ]] && [[ -f $dockerInit ]] && [[ `cat $dockerInit` == $WMA_BUILD_ID ]]
+}
+
+deploy_to_host(){
+    # This function does all the needed Docker image to Host modifications at Runtime
+    # DONE: Here to execute all local config and manage/copy opertaions from the image deploy area of the container to the host
+    #       * creation of all config directories if missing at the mount point
+    #          * reimplement init_install_dir
+    #          * reimplement init_config_dir
+    #       * copy/override the manage file at the host mount point with the manage file from the image deployment area
+    #       * copy/override all config files if the agent have never been initialised
+    #       * create/touch a .dockerInit file containing the wMA_BUILD_ID of the current docker image
+    #         * eventually the docker container Id may be considered in the future as well (the unique hash id to be used not the contaner name)
+    #
+    # NOTE: On every step we need to check the .dockerInit file content. There are two level of comparision we can make:
+    #       * the current container Id with the already intialised one: if we want reinitailisation on every container kill/start
+    #       * the current image Id with the already initialised one: if we want reinitialisation only on docker image rebuild (New WMAgent deployment).
+    #       THE implementation considers the later - reinitialisation on container rebuild
+    local stepMsg="Performing Docker image to Host initialisation steps"
+    echo "-------------------------------------------------------"
+    echo "Start: $stepMsg"
+
+    # Check if the host has all needed components' logs and job cache areas
+    # TODO: purge job cache if -p run option has been set
+    echo "$FUNCNAME: Initialise install"
+    _init_valid $WMA_INSTALL_DIR || {
+        mkdir -p $WMA_INSTALL_DIR/{wmagent,mysql,couchdb} && echo $WMA_BUILD_ID > $WMA_INSTALL_DIR/.dockerInit
+        [[ -h $WMA_INSTALL_DIR/wmagentpy3 ]] || ln -s $WMA_INSTALL_DIR/wmagent $WMA_INSTALL_DIR/wmagentpy3
+    }
+
+    # Check if the host has all config files and copy them if missing
+    # NOTE: The final config/.dockerInit is to be set after full agent initialisation during `agent_upload_config`
+    echo "$FUNCNAME: Initialise config"
+    local serviceList="wmagent mysql couchdb rucio"
+    local config_mysql=my.cnf
+    local config_couchdb=local.ini
+    local config_wmagent=manage
+    local config_rucio=rucio.cfg
+    for service in $serviceList; do
+        _init_valid $WMA_CONFIG_DIR/$service && continue
+        echo "$FUNCNAME: config service=$service"
+        local errVal=0
+        local config=config_$service && config=${!config}        # expanding to the proper config name
+        if [[ $service = "wmagent" ]]
+        then
+            [[ -d $WMA_CONFIG_DIR/$service ]] || mkdir -p $WMA_CONFIG_DIR/$service ; let errVal+=$?
+            cp -f $WMA_DEPLOY_DIR/bin/${config} $WMA_CONFIG_DIR/$service/ ; let errVal+=$?
+            chmod 755 $WMA_CONFIG_DIR/$service/$config;
+            [[ -h $WMA_CONFIG_DIR/wmagentpy3 ]] || ln -s $WMA_CONFIG_DIR/$service $WMA_CONFIG_DIR/wmagentpy3
+        elif [[ $service = "rucio" ]]
+        then
+            [[ -d $WMA_CONFIG_DIR/$service/etc ]] || mkdir -p $WMA_CONFIG_DIR/$service/etc ; let errVal+=$?
+            cp -f $WMA_DEPLOY_DIR/etc/${config} $WMA_CONFIG_DIR/$service/etc/ ; let errVal+=$?
+        else
+            [[ -d $WMA_CONFIG_DIR/$service ]] || mkdir -p $WMA_CONFIG_DIR/$service ; let errVal+=$?
+            cp -f $WMA_DEPLOY_DIR/etc/${config} $WMA_CONFIG_DIR/$service/ ; let errVal+=$?
+        fi
+        [[ $errVal -eq 0 ]] && echo $WMA_BUILD_ID > $WMA_CONFIG_DIR/$service/.dockerInit
+    done
+
+    # Check if the host has a basic WMAgent.secrets file and copy a template if missing
+    # NOTE: Here we never overwrite any existing WMAGent.secrets file: We follow:
+    #       * Check if there is any at the host, and if so, is it a blank template or a fully configured one
+    #       * In case we find a legit WMAgent.secrets file we set the .dockerInit and move on
+    #       * In case we need to copy a brand new template (based on the agent type - test/prod)
+    #         or a blank one found at the host we halt without updating the .dockerInit file
+    #         and we ask the user to examine/update the file.
+    #       (Re)Initialisation should never pass beyond that step unless properly
+    #       configured WMAgent.secrets file being provided at the host.
+    echo "$FUNCNAME: Initialise WMAgent.secrets"
+    _init_valid $WMA_HOSTADMIN_DIR || {
+        if [[ ! -f $WMA_HOSTADMIN_DIR/WMAgent.secrets ]]; then
+            # NOTE: we consider production templates for relval agents and testbed templates for dev- agents
+            local agentType=${TEAMNAME%%-*}
+            agentType=${agentType/relval*/production}
+            agentType=${agentType/dev*/testbed}
+            echo "$FUNCNAME: copying $WMA_DEPLOY_DIR/etc/WMAgent.$agentType to $WMA_HOSTADMIN_DIR/WMAgent.secrets"
+            cp -f $WMA_DEPLOY_DIR/etc/WMAgent.$agentType $WMA_HOSTADMIN_DIR/WMAgent.secrets
+        fi
+        echo "$FUNCNAME: checking $WMA_HOSTADMIN_DIR/WMAgent.secrets"
+        if (_parse_wmasecrets $WMA_HOSTADMIN_DIR/WMAgent.secrets); then
+            echo $WMA_BUILD_ID > $WMA_HOSTADMIN_DIR/.dockerInit
+        else
+            echo "ERROR: We found a blank WMAgent.secrets file template at the current host!"
+            echo "ERROR: Please update it properly before reinitialising the WMagent container!"
+            return $(false)
+        fi
+    }
+
+    echo "Done: $stepMsg"
+    echo "-------------------------------------------------------"
+}
+
+check_wmasecrets(){
+    # Check if the the current WMAgent.secrets file is the same as the one from the latest agent inititialisation
+    echo "$FUNCNAME: Checking for changes in the WMAgent.secrets file"
+    touch $WMA_HOSTADMIN_DIR/.WMAgent.secrets.md5
+    if (md5sum --quiet -c $WMA_HOSTADMIN_DIR/.WMAgent.secrets.md5); then
+        echo "$FUNCNAME: No change found."
+    else
+        echo "$FUNCNAME: WARNING: Wrong checksum for WMAgent.secrets file. Restarting agent initialisation."
+        rm -f $WMA_HOSTADMIN_DIR/.dockerInit
+        rm -f $WMA_CONFIG_DIR/.dockerInit
+    fi
+}
+
+deploy_to_container() {
+    # This function does all the needed Host to Docker image modifications at Runtime
+    # NOTE: Here we identify the type (prod/test) and flavour (mysql/oracle) and domain (CERN/FNAL) of the agent and then:
+    #       * Copy WMAgent.secrets files from host to the container - it will be needed by the manage script during initialisation and startup steps
+    #       * call check certs and all other authentications
+    #
+    # NOTE: On every step to check the .dockerInit file contend and compare similarly to deploy_to_host
+    #       but do NOT update it
+    local stepMsg="Performing local Docker image initialisation steps"
+    echo "-------------------------------------------------------"
+    echo "Start: $stepMsg"
+
+    # Copy the WMAgent.secrets file from the host admin area to container admin area where $manage is about to search it
+    # DONE: To preserve the md5sum of the initially deployed WMAegnt.secrets file from
+    #       the host, so if we find out that it has been eddited, all the reinitialisation
+    #       steps to be repeated upon container restart.
+    echo "$FUNCNAME: Try Copying the host WMAgent.secrets file into the container admin area"
+    if _init_valid $WMA_HOSTADMIN_DIR; then
+        # grep -vE "^[[:blank:]]*#.*$" $WMA_HOSTADMIN_DIR/WMAgent.secrets > $WMA_ADMIN_DIR/WMAgent.secrets
+        cp -f $WMA_HOSTADMIN_DIR/WMAgent.secrets $WMA_ADMIN_DIR/
+        md5sum $WMA_HOSTADMIN_DIR/WMAgent.secrets > $WMA_HOSTADMIN_DIR/.WMAgent.secrets.md5
+        echo "$FUNCNAME: Done"
+    else
+        echo "$FUNCNAME: Not intialised WMAgent.secrets file. Skipping the current step."
+        return $(false)
+    fi
+
+    # Update WMagent.secrets file:
+    echo "$FUNCNAME: Updating WMAgent.secrets file with the current host's details"
+    sed -i "s/MYSQL_USER=.*/MYSQL_USER=$WMA_USER/g" $WMA_ADMIN_DIR/WMAgent.secrets
+    sed -i "s/COUCH_USER=.*/COUCH_USER=$WMA_USER/g" $WMA_ADMIN_DIR/WMAgent.secrets
+    sed -i "s/COUCH_HOST=127\.0\.0\.1/COUCH_HOST=$HOSTIP/g" $WMA_ADMIN_DIR/WMAgent.secrets
+
+    # Double checking the final result:
+    echo "$FUNCNAME: Double checking the final WMAgent.secrets file"
+    (_parse_wmasecrets $WMA_ADMIN_DIR/WMAgent.secrets) || return $(false)
+
+    # Checking Certificates and proxy;
+    echo "$FUNCNAME: Checking Certificates and Proxy"
+    local certMinLifetimeHours=168
+    local certMinLifetimeSec=$(($certMinLifetimeHours*60*60))
+    # DONE: Here to find out if the agent is CERN or FNAL and change renew_proxy.sh respectively
+    if [[ "$HOSTNAME" == *cern.ch ]]; then
+        local myproxyCredName="amaltaroCERN"
+    elif [[ "$HOSTNAME" == *fnal.gov ]]; then
+        local myproxyCredName="amaltaroFNAL"
+    else
+        echo "$FUNCNAME: ERROR: Sorry, we do not recognize the network domain name of the current host: $HOSTNAME"
+        return $(false)
+    fi
+    sudo sed -i "s/credname=CREDNAME/credname=$myproxyCredName/g" $WMA_DEPLOY_DIR/deploy/renew_proxy.sh
+    sudo chmod 755 $WMA_DEPLOY_DIR/deploy/renew_proxy.sh
+
+    # Here to check certificates and update myproxy if needed:
+    if [[ -f $WMA_CERTS_DIR/servicecert.pem ]] && [[ -f $WMA_CERTS_DIR/servicekey.pem ]]; then
+
+        echo "$FUNCNAME: Checking Certificate lifetime:"
+        local now=$(date +%s)
+        local certEndDate=$(openssl x509 -in $WMA_CERTS_DIR/servicecert.pem -noout -enddate)
+        certEndDate=${certEndDate##*=}
+        echo "$FUNCNAME: Certificate end date: $certEndDate"
+        [[ -z $certEndDate ]] && { echo "ERROR: Failed to determine certificate end date!"; return $(false) ;}
+
+        certEndDate=$(date --date="$certEndDate" +%s)
+        [[ $certEndDate -le $now ]] && { echo "ERROR: Expired certificate at $WMA_CERTS_DIR/servicecert.pem!"; return $(false) ;}
+        [[ $(($certEndDate -$now)) -le $certMinLifetimeSec ]] && { echo "WARNING: The service certificate lifetime is less than certMinLifetimeHours: $certMinLifetimeHours! Please update it ASAP!" ;}
+
+        # Renew myproxy if needed:
+        echo "$FUNCNAME: Checking myproxy lifetime:"
+        local myproxyEndDate=$(openssl x509 -in $WMA_CERTS_DIR/myproxy.pem -noout -enddate)
+        myproxyEndDate=${myproxyEndDate##*=}
+        echo "$FUNCNAME: myproxy end date: $myproxyEndDate"
+        [[ -n $myproxyEndDate ]] || ($WMA_DEPLOY_DIR/deploy/renew_proxy.sh) || { echo "ERROR: Failed to renew invalid myproxy"; return $(false) ;}
+
+        myproxyEndDate=$(date --date="$myproxyEndDate" +%s)
+        [[ $myproxyEndDate -gt $now ]] || ($WMA_DEPLOY_DIR/deploy/renew_proxy.sh) || { echo "ERROR: Failed to renew expired myproxy"; return $(false) ;}
+
+        # Stay safe and always change the service {cert,key} and myproxy mode here:
+        sudo chmod 600 $WMA_CERTS_DIR/*
+        echo "$FUNCNAME: OK"
+    else
+        echo "ERROR: We found no service certificate installed at $WMA_CERTS_DIR!"
+        echo "ERROR: Please install proper cert and key files before restarting the WMAgent container!"
+        return $(false)
+    fi
+
+    # Update flavor/type/domain global variables if needed
+    # (grep -E "^[[:blank:]]*ORACLE_" $WMA_ADMIN_DIR/WMAgent.secrets > /dev/null) && CURR_FLAVOR=oracle || CURR_FLAVOR=mysql
+
+    echo "Done: $stepMsg"
+    echo "-------------------------------------------------------"
+}
+
+_check_oracle()
+{
+    # Auxiliary function to check if the oracle database configured for the current agent is empty
+    # NOTE: Oracle is centraly provided - we require an empty database for every account/agent
+    #       otherwise we cannot guarantie this is the only agent to connect to the so configured database
+    echo "$FUNCNAME: Checking whether the oracle database is clean and not used by other agents ..."
+    $manage db-prompt<<"    EOF">/tmp/db_check_output
+    SELECT COUNT(*) from USER_TABLES;
+    EOF
+    err=$?
+    [[ $err -ne 0 ]] && return $(false)
+    tables=`cat /tmp/db_check_output | grep -A1 '\-\-\-\-' | tail -n 1`
+    rm -rf /tmp/db_check_output
+    if [ "$tables" -gt 0 ]; then
+        echo "WARNING: Non empty database found: $tables tables."; return $(true)
+    else
+        echo "OK"; return $(true)
+    fi
+}
+
+_check_mysql()
+{
+    # Auxiliary function to check if the the MariaDB database for the current agent is properly set
+    # TODO: To be implemented in the issue related to the MariaDB setup fro wmagent
+    echo "$FUNCNAME: Checking whether the mysql schema has been installed"
+    true
+}
+
+check_databases() {
+    # TODO: Here to check all databases - relational and CouchDB
+    #       * call check_oracle or check_sql or similar
+    #       * call check_couchdb
+    local oracleCred=false
+    local mysqlCred=false
+    (grep -E "^[[:blank:]]*(ORACLE_USER)" $WMA_ADMIN_DIR/WMAgent.secrets > /dev/null) && \
+        (grep -E "^[[:blank:]]*(ORACLE_PASS)" $WMA_ADMIN_DIR/WMAgent.secrets > /dev/null) && \
+        (grep -E "^[[:blank:]]*(ORACLE_TNS)" $WMA_ADMIN_DIR/WMAgent.secrets > /dev/null) && \
+        oracleCred=true
+
+    (grep -E "^[[:blank:]]*(MYSQL_USER)" $WMA_ADMIN_DIR/WMAgent.secrets > /dev/null) && \
+        (grep -E "^[[:blank:]]*(MYSQL_PASS)" $WMA_ADMIN_DIR/WMAgent.secrets > /dev/null) && \
+        mysqlCred=true
+
+    # Checking for relational database credentials at WMAgent.secrets file
+    case $FLAVOR in
+        mysql)
+            $mysqlCred   || { echo "ERROR: No Mysql database credentials provided at $WMA_ADMIN_DIR/WMAgent.secrets"; return $(false) ;}
+            _check_mysql || { echo "ERROR: MaridDB database unreachable or not cleaned"; return $(false) ;}
+            ;;
+        oracle)
+            $oracleCred   || { echo "ERROR: No Oracle database credentials provided at $WMA_ADMIN_DIR/WMAgent.secrets"; return $(false) ;}
+            _check_oracle || { echo "ERROR: Oracle database unreachable"; return $(false) ;}
+        ;;
+    esac
+}
+
+check_docker_init() {
+    # A function to check all previously populated */.dockerInit files
+    # from all previous steps and compare them with the /data/.dockerBuildId
+    # if all do not match we cannot continue - we consider configuration/version
+    # mismatch between the host and the container
+
+    local DOCKER_INIT_LIST="
+        $WMA_INSTALL_DIR
+        $WMA_CONFIG_DIR
+        $WMA_CONFIG_DIR/wmagent
+        $WMA_CONFIG_DIR/mysql
+        $WMA_CONFIG_DIR/couchdb
+        $WMA_CONFIG_DIR/rucio
+        $WMA_HOSTADMIN_DIR
+        "
+    local stepMsg="Performing checks for successful Docker initialisation steps..."
+    echo "-------------------------------------------------------"
+    echo "Start: $stepMsg"
+    # touch $DOCKER_INIT_LIST
+    local dockerInitId=""
+    local dockerInitIdValues=""
+    local idValue=""
+    for initFile in $DOCKER_INIT_LIST; do
+        initFile=$initFile/.dockerInit
+        _init_valid $initFile && idValue=$(cat $initFile 2>&1) || idValue=$initFile
+        dockerInitIdValues="$dockerInitIdValues $idValue"
+    done
+    dockerInitId=$(for id in $dockerInitIdValues; do echo $id; done |sort|uniq)
+    echo "WMA_BUILD_ID: $WMA_BUILD_ID"
+    echo "dockerInitId: $dockerInitId"
+    [[ $dockerInitId == $WMA_BUILD_ID ]] && { echo "OK"; return $(true) ;} || { echo "WARNING: dockerInit vs buildId mismatch"; return $(false) ;}
+}
+
+activate_agent() {
+    local stepMsg="Performing $FUNCNAME"
+    echo "-------------------------------------------------------"
+    echo "Start: $stepMsg"
+    _init_valid $WMA_CONFIG_DIR || {
+        echo "$FUNCNAME: triggered."
+        $manage activate-agent || { echo "ERROR: Failed to activate WMAgent!"; return $(false) ;}
+    }
+    echo "Done: $stepMsg"
+    echo "-------------------------------------------------------"
+}
+
+init_agent() {
+    local stepMsg="Performing $FUNCNAME"
+    echo "-------------------------------------------------------"
+    echo "Start: $stepMsg"
+    _init_valid $WMA_CONFIG_DIR || {
+        echo "$FUNCNAME: triggered."
+        $manage init-agent || { echo "ERROR: Failed to initialise WMAgent databases!"; return $(false) ;}
+    }
+    echo "Done: $stepMsg"
+    echo "-------------------------------------------------------"
+}
+
+agent_tweakconfig() {
+    local stepMsg="Performing $FUNCNAME"
+    echo "-------------------------------------------------------"
+    echo "Start: $stepMsg"
+    _init_valid $WMA_CONFIG_DIR || {
+        echo "$FUNCNAME: triggered."
+        [[ -f $WMA_MANAGE_DIR/config.py ]] || { echo "ERROR: Missing WMAgent config!"; return $(false) ;}
+
+        echo "$FUNCNAME: Making agent configuration changes needed for Docker"
+        # make this a docker agent
+        sed -i "s+Agent.isDocker = False+Agent.isDocker = True+" $WMA_MANAGE_DIR/config.py
+        # update the location of submit.sh for docker
+        sed -i "s+config.JobSubmitter.submitScript.*+config.JobSubmitter.submitScript = '$WMA_CURRENT_DIR/install/wmagent/Docker/etc/submit.sh'+" $WMA_MANAGE_DIR/config.py
+        # replace all tags with current
+        sed -i "s+$WMA_TAG+current+" $WMA_MANAGE_DIR/config.py
+
+        echo "$FUNCNAME: Making other agent configuration changes"
+        sed -i "s+REPLACE_TEAM_NAME+$TEAMNAME+" $WMA_MANAGE_DIR/config.py
+        sed -i "s+Agent.agentNumber = 0+Agent.agentNumber = $AGENT_NUMBER+" $WMA_MANAGE_DIR/config.py
+        if [[ "$TEAMNAME" == relval ]]; then
+            sed -i "s+config.TaskArchiver.archiveDelayHours = 24+config.TaskArchiver.archiveDelayHours = 336+" $WMA_MANAGE_DIR/config.py
+        elif [[ "$TEAMNAME" == *testbed* ]] || [[ "$TEAMNAME" == *dev* ]]; then
+            GLOBAL_DBS_URL=https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader
+            sed -i "s+DBSInterface.globalDBSUrl = 'https://cmsweb.cern.ch/dbs/prod/global/DBSReader'+DBSInterface.globalDBSUrl = '$GLOBAL_DBS_URL'+" $WMA_MANAGE_DIR/config.py
+            sed -i "s+DBSInterface.DBSUrl = 'https://cmsweb.cern.ch/dbs/prod/global/DBSReader'+DBSInterface.DBSUrl = '$GLOBAL_DBS_URL'+" $WMA_MANAGE_DIR/config.py
+        fi
+
+        local forceSiteDown=""
+        [[ "$HOSTNAME" == *cern.ch ]] && forceSiteDown="'T3_US_NERSC'"
+
+        if [[ "$HOSTNAME" == *fnal.gov ]]; then
+            sed -i "s+forceSiteDown = \[\]+forceSiteDown = \[$forceSiteDown\]+" $WMA_MANAGE_DIR/config.py
+        else
+            sed -i "s+forceSiteDown = \[\]+forceSiteDown = \[$forceSiteDown\]+" $WMA_MANAGE_DIR/config.py
+        fi
+    }
+    echo "Done: $stepMsg"
+    echo "-------------------------------------------------------"
+}
+
+agent_resource_control() {
+    local stepMsg="Performing $FUNCNAME"
+    echo "-------------------------------------------------------"
+    echo "Start: $stepMsg"
+    _init_valid $WMA_CONFIG_DIR || {
+        echo "$FUNCNAME: triggered."
+        local errVal=0
+        ### Populating resource-control
+        echo "$FUNCNAME: Populating resource-control"
+        if [[ "$TEAMNAME" == relval* || "$TEAMNAME" == *testbed* ]]; then
+            echo "$FUNCNAME: Adding only T1 and T2 sites to resource-control..."
+            $manage execute-agent wmagent-resource-control --add-T1s --plugin=SimpleCondorPlugin --pending-slots=50 --running-slots=50 --down ; let errVal+=$?
+            $manage execute-agent wmagent-resource-control --add-T2s --plugin=SimpleCondorPlugin --pending-slots=50 --running-slots=50 --down ; let errVal+=$?
+        else
+            echo "$FUNCNAME: Adding ALL sites to resource-control..."
+            $manage execute-agent wmagent-resource-control --add-all-sites --plugin=SimpleCondorPlugin --pending-slots=50 --running-slots=50 --down ; let errVal+=$?
+        fi
+        [[ $errVal -eq 0 ]] || { echo "ERROR: Failed to populate WMAgent's resource control!"; return $(false) ;}
+    }
+    echo "Done: $stepMsg"
+    echo "-------------------------------------------------------"
+}
+
+agent_upload_config(){
+    # A function to be used for uploading WMAgentConfig to AuxDB at Central CouchDB
+    # NOTE: The final config/.dockerInit is to be set here after full agent initialisation.
+    #       Once we have reached to the step of uploading the agent config to Cerntral CouchDB
+    #       we consider all previous reintialisation and config steps as successfully complpeted.
+    #       Steps to follow:
+    #       * Checking if the current image WMA_BUILD_ID matches the last one successfully initialised at the host
+    #       * If not, tries to upload the current config to Central CouchDB
+    #       * If agent config successfully uploaded, preserve the WMA_BUILD_ID at config/.dockerInit
+    #       With that, we consider the agent initialisation fully complete. The init steps will not be
+    #       repeated on further container restarts unless any of the */.dockerInit files at the host is altered.
+    local stepMsg="Performing $FUNCNAME"
+    echo "-------------------------------------------------------"
+    echo "Start: $stepMsg"
+
+    _init_valid $WMA_CONFIG_DIR || {
+        echo "$FUNCNAME: triggered."
+        echo "$FUNCNAME: Tweaking central agent configuration befre uploading"
+        if [[ "$TEAMNAME" == production ]]; then
+            echo "$FUNCNAME: Agent connected to the production team, setting it to drain mode"
+            agentExtraConfig='{"UserDrainMode":true}'
+        elif [[ "$TEAMNAME" == *testbed* ]]; then
+            echo "$FUNCNAME: Testbed agent, setting MaxRetries to 0..."
+            agentExtraConfig='{"MaxRetries":0}'
+        elif [[ "$TEAMNAME" == *dev* ]]; then
+            echo "$FUNCNAME: Dev agent, setting MaxRetries to 0..."
+            agentExtraConfig='{"MaxRetries":0}'
+        fi
+        ### Upload WMAgentConfig to AuxDB
+        echo "*** Upload WMAgentConfig to AuxDB ***"
+        $manage execute-agent wmagent-upload-config $agentExtraConfig && echo $WMA_BUILD_ID > $WMA_CONFIG_DIR/.dockerInit
+    }
+    echo "Done: $stepMsg"
+    echo "-------------------------------------------------------"
+}
+
+start_services() {
+    local stepMsg="Performing $FUNCNAME"
+    echo "-------------------------------------------------------"
+    echo "Start: $stepMsg"
+    $manage start-services
+    echo "Done: $stepMsg"
+    echo "-------------------------------------------------------"
+}
+
+start_agent() {
+    local stepMsg="Performing $FUNCNAME"
+    echo "-------------------------------------------------------"
+    echo "Start: $stepMsg"
+    echo "-------------------------------------------------------"
+    echo "Start sleeping now ...zzz..."
+    # TODO: To remove the endless while cycle once we are done with the full containerization issue: #11314
+    while true; do sleep 10; done
+    $manage start-agent || return $(false)
+    echo "Done: $stepMsg"
+    echo "-------------------------------------------------------"
+}
+
+main(){
+    basic_checks
+    check_wmasecrets
+    check_docker_init || {
+        (deploy_to_host)         || { err=$?; echo "ERROR: deploy_to_host"; exit $err ;}
+        (deploy_to_container)    || { err=$?; echo "ERROR: deploy_to_container"; exit $err ;}
+        (activate_agent)         || { err=$?; echo "ERROR: activate_agent"; exit $err ;}
+        start_services
+        sleep 5
+        (check_databases)        || { err=$?; echo "ERROR: check_databases"; exit $err ;}
+        (init_agent)             || { err=$?; echo "ERROR: init_agent"; exit $err ;}
+        sleep 5
+        (agent_tweakconfig)      || { err=$?; echo "ERROR: agent_tweakconfig"; exit $err ;}
+        (agent_resource_control) || { err=$?; echo "ERROR: agent_resource_control"; exit $err ;}
+        (agent_upload_config)    || { err=$?; echo "ERROR: agent_upload_config"; exit $err ;}
+        (check_docker_init)      || { err=$?; echo "ERROR: DockerBuild vs. HostConfiguration version missmatch"; exit $err ; }
+
+        echo && echo "Docker container has been initialised! However you still need to:"
+        echo "  1) Double check agent configuration: less current/config/wmagent/config.py"
+        echo "  2) Start the agent with on of the bellow commands: "
+        echo "      manage start-agent     (from inside a running wmagent container)"
+        echo "      ./wmagent-docker-run & (from the host)"
+        echo "Have a nice day!" && echo
+        return $(true)
+    }
+    (deploy_to_container)        || { err=$?; echo "ERROR: deploy_to_container"; exit $err ;}
+    start_services
+    sleep 5
+    (check_databases)            || { err=$?; echo "ERROR: check_databases"; exit $err ;}
+    (start_agent)                || { err=$?; echo "ERROR: start_agent"; exit $err ;}
+}
+
+main
+
+
+exit 0
+
+
+
+# ###########################################################################################
+# # NOTE: Leftovers - to be adopted/reimplemented in the GH issue dealing with CouchDB setup
+# ###########################################################################################
+
+# DATA_SIZE=`lsblk -bo SIZE,MOUNTPOINT | grep ' /data1' | sort | uniq | awk '{print $1}'`
+# DATA_SIZE_GB=`lsblk -o SIZE,MOUNTPOINT | grep ' /data1' | sort | uniq | awk '{print $1}'`
+# if [[ $DATA_SIZE -gt 200000000000 ]]; then  # greater than ~200GB
+# echo "Partition /data1 available! Total size: $DATA_SIZE_GB"
+# sleep 0.5
+# while true; do
+# read -p "Would you like to deploy couchdb in this /data1 partition (yes/no)? " yn
+# case $yn in
+# [Y/y]* ) DATA1=true; break;;
+# [N/n]* ) DATA1=false; break;;
+# * ) echo "Please answer yes or no.";;
+# esac
+# done
+# else
+# DATA1=false
+# fi && echo
+
+# echo -e "\n*** Applying (for couchdb1.6, etc) cert file permission ***"
+# chmod 600 /data/certs/service{cert,key}.pem
+# echo "Done!"
+
+# echo "*** Checking if couchdb migration is needed ***"
+# echo -e "\n[query_server_config]\nos_process_limit = 50" >> $WMA_CURRENT_DIR/config/couchdb/local.ini
+# if [ "$DATA1" = true ]; then
+# ./manage stop-services
+# sleep 5
+# if [ -d "/data1/database/" ]; then
+# echo "Moving old database away... "
+# mv /data1/database/ /data1/database_old/
+# FINAL_MSG="5) Remove the old database when possible (/data1/database_old/)"
+# fi
+# rsync --remove-source-files -avr /data/srv/wmagent/current/install/couchdb/database /data1
+# sed -i "s+database_dir = .*+database_dir = /data1/database+" $WMA_CURRENT_DIR/config/couchdb/local.ini
+# sed -i "s+view_index_dir = .*+view_index_dir = /data1/database+" $WMA_CURRENT_DIR/config/couchdb/local.ini
+# ./manage start-services
+# fi
+# echo "Done!" && echo
+# ###########################################################################################

--- a/docker/pypi/wmagent/wmagent-docker-build.sh
+++ b/docker/pypi/wmagent/wmagent-docker-build.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+### This script is to be used for building a WMAgent docker imagge based on pypi
+### It depends on a single parameter WMA_TAG, which is to be passed to the basic
+### WMAgent deployment script install.sh at build time through `docker --build-arg`
+
+
+help(){
+    echo -e $*
+    cat <<EOF
+
+The WMAgent docker build script for Docker image creation based on pypi:
+
+Usage: wmagent-docker-build.sh -v <wmagent_tag>
+
+    -v <wmagent_tag>                The WMAgent version/tag to be used for the Docker image creation
+    -p <push_image>                 Push the image to registry.cern.ch
+    -l <latest_tag_toregistry>      Push the curernt tag also as latest to registry.cern.ch
+
+Example: ./wmagent-docker-build.sh -v 2.2.0.2
+
+EOF
+}
+
+usage(){
+    help $*
+    exit 1
+}
+
+WMA_TAG=None
+PUSH=false
+LATEST=false
+
+### Argument parsing:
+while getopts ":v:hpl" opt; do
+    case ${opt} in
+        v) WMA_TAG=$OPTARG ;;
+        p) PUSH=true ;;
+        l) LATEST=true ;;
+        h) help; exit $? ;;
+        \? )
+            msg="Invalid Option: -$OPTARG"
+            usage "$msg" ;;
+        : )
+            msg="Invalid Option: -$OPTARG requires an argument"
+            usage "$msg" ;;
+    esac
+done
+
+
+# NOTE: NO WMA_TAG validation is done in the current script. It is implemented at the install.sh
+
+dockerOpts=" --network=host --progress=plain --build-arg WMA_TAG=$WMA_TAG "
+
+docker build $dockerOpts -t wmagent:$WMA_TAG -t wmagent:latest  .
+
+$PUSH && {
+    docker login registry.cern.ch
+    docker tag wmagent:$WMA_TAG registry.cern.ch/cmsweb/wmagent:$WMA_TAG
+    echo "Uploading image registry.cern.ch/cmsweb/wmagent:$WMA_TAG"
+    docker push registry.cern.ch/cmsweb/wmagent:$WMA_TAG
+    $LATEST &&  {
+        docker tag wmagent:$WMA_TAG registry.cern.ch/cmsweb/wmagent:latest
+        echo "Uploading image registry.cern.ch/cmsweb/wmagent:latest"
+        docker push registry.cern.ch/cmsweb/wmagent:latest
+    }
+}

--- a/docker/pypi/wmagent/wmagent-docker-run.sh
+++ b/docker/pypi/wmagent/wmagent-docker-run.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+### This script is to be used for running the WMAgent docker container at a VM
+### Its sole purpose is to set all the needed mount points from the Host VM and
+### forward all WMAgent runtime parameters to the WMAgent container entrypoint run.sh
+### It accepts only the set of parameters relevant to WMAgent's container run.sh
+### and no build dependent ones. The docker image tag to be searched for execution is
+### always `latest`.
+
+
+# NOTE: In the help call to the current scrit we only repeat the help and usage
+#       information for all the parameters accepted by run.sh.
+help(){
+    echo -e $*
+    cat <<EOF
+
+The script to be used for running a WMAgent docker container at a VM. The full set of arguments
+passed to the current script are to be forwarded to the WMAgent container entrypoint 'run.sh'
+
+Usage: wmagent-docker-run.sh [-t <team_name>] [-n <agent_number>] [-f <db_flavour>]
+
+    -p <pull_image>   Pull the image from registry.cern.ch
+    -v <wmagent_tag>  The WMAgent version/tag to be downloaded from registry.cern.ch [Default:latest]
+
+    -t <team_name>    Team name in which the agent should be connected to
+    -n <agent_number> Agent number to be set when more than 1 agent connected to the same team (Default: 0)
+    -f <db_flavour>   Relational Database flavour. Possible optinos are: 'mysql' or 'oracle' (Default: myslq)
+
+Example: ./wmagent-docker-run.sh -n 30 -t testbed-vocms001 -c cmsweb-testbed.cern.ch -f mysql
+
+EOF
+}
+
+usage(){
+    help $*
+    exit 1
+}
+
+PULL=false
+WMA_TAG=latest
+
+### Argument parsing:
+while getopts ":v:hp" opt; do
+    case ${opt} in
+        v) WMA_TAG=$OPTARG ;;
+        p) PULL=true ;;
+        h) help; exit $? ;;
+        : )
+            msg="Invalid Option: -$OPTARG requires an argument"
+            usage "$msg" ;;
+    esac
+done
+
+# This is the root at the host only, it may differ from the root inside the container.
+# NOTE: this may be parametriesed, so that the container can run on a different mount point.
+WMA_ROOT_DIR=/data/dockerMount
+
+[[ -d $WMA_ROOT_DIR/certs ]] || (mkdir -p $WMA_ROOT_DIR/certs) || exit $?
+[[ -d $WMA_ROOT_DIR/admin/wmagent ]] || (mkdir -p $WMA_ROOT_DIR/admin/wmagent) || exit $?
+[[ -d $WMA_ROOT_DIR/srv/wmagent/current/install ]] || (mkdir -p $WMA_ROOT_DIR/srv/wmagent/current/install) || exit $?
+[[ -d $WMA_ROOT_DIR/srv/wmagent/current/config  ]] || (mkdir -p $WMA_ROOT_DIR/srv/wmagent/current/config)  || exit $?
+
+# NOTE: Before mounting /etc/tnsnames.ora we should check it exists, otherwise the run will fail on the FNAL agents
+tnsMount=""
+[[ -f /etc/tnsnames.ora ]] && tnsMount="--mount type=bind,source=/etc/tnsnames.ora,target=/etc/tnsnames.ora,readonly "
+
+dockerOpts=" \
+--network=host \
+--rm \
+--hostname=`hostname -f` \
+--name=wmagent \
+$tnsMount
+--mount type=bind,source=/etc/condor,target=/etc/condor,readonly \
+--mount type=bind,source=/tmp,target=/tmp \
+--mount type=bind,source=$WMA_ROOT_DIR/certs,target=/data/certs \
+--mount type=bind,source=$WMA_ROOT_DIR/srv/wmagent/current/install,target=/data/srv/wmagent/current/install \
+--mount type=bind,source=$WMA_ROOT_DIR/srv/wmagent/current/config,target=/data/srv/wmagent/current/config \
+--mount type=bind,source=$WMA_ROOT_DIR/admin/wmagent,target=/data/admin/wmagent/hostadmin \
+"
+
+wmaOpts=$*
+
+$PULL && {
+    echo "Pulling Docker image: registry.cern.ch/cmsweb/wmagent:$WMA_TAG"
+    docker login registry.cern.ch
+    docker pull registry.cern.ch/cmsweb/wmagent:$WMA_TAG
+    docker tag registry.cern.ch/cmsweb/wmagent:$WMA_TAG wmagent:$WMA_TAG
+    docker tag registry.cern.ch/cmsweb/wmagent:$WMA_TAG wmagent:latest
+}
+
+# docker run $dockerOpts wmagent:$WMA_TAG $wmaOpts
+echo "Starting the wmagent:$WMA_TAG docker container with the following parameters: $wmaOpts"
+docker run $dockerOpts wmagent:$WMA_TAG $wmaOpts


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/8797
Fixes https://github.com/dmwm/WMCore/issues/11564
Superseeds https://github.com/dmwm/CMSKubernetes/pull/1364

DISCLAIMER: this contains exactly the same changes that @todor-ivanov provided in #1364 (picked with a curl + patch command), plus a 2nd commit that I made to fix how TAG vs WMA_TAG is used in the Dockerfile. This was done just so we can get this merged before the quarter is over :-) Now I am pasting the original description provided by Todor, but please check the original PR for the full discussion and potential open questions.


With the current PR we modify the Dockerfile  such that:
* It calls the install.sh script instead of directly executing `pip install wmagent`
* It accept the WMA_TAG as  a parameter at  build time with `--build-arg WMA_TAG=<WMA_TAG>`
* It creates the expected GUID and UID which should match with the respective ones  at the VM 

The following new scripts are provided as well:
* We also add the basic `install.sh` script, which is configuring the whole deployment structure and the future places for the credentials mount points.

* We also add the `run.sh` script to configure and start the container a the host

* We also provide two wrapper scripts: `wmagent-docer-build.sh` and `wmagent-docker-run.sh`, which are taking care of all docker configs and parameters for both build and runtime.

**NOTE:** 
The minimal WMAgent tag to be used for this PR should be `2.2.1rc3`

**NOTE:**
The files: 
* `etc/local.ini` 
* `etc/my.cnf`
* `etc/rucio.conf`
* `bin/manage`  
Are a one to one copy from the old [deployment repository](https://github.com/dmwm/deployment/tree/master/wmagentpy3) (master branch), except a minor change in the few environment variables read by the `bin/manage` script, which I will explicitly point here: 
```
[user@unit01 data]$ diff -u  /data/CMSKubernetes/docker/pypi/wmagent/bin/manage  /data/deployment/wmagentpy3/manage 
--- /data/CMSKubernetes/docker/pypi/wmagent/bin/manage	2023-05-12 17:53:15.536200825 +0200
+++ /data/deployment/wmagentpy3/manage	2023-05-03 13:10:45.040435640 +0200
@@ -4,7 +4,10 @@
 #
 # Global variables etc
 #
-ROOT_DIR=$WMA_CURRENT_DIR
+THIS_SCRIPT=$(readlink -f $0)
+PROJ_DIR=$(dirname $(dirname $THIS_SCRIPT))
+ROOT_DIR=$(dirname $(dirname $(dirname $THIS_SCRIPT)))

@@ -233,14 +236,14 @@
 # Environment
 #
 
-# . $ROOT_DIR/apps/wmagentpy3/etc/profile.d/init.sh
+. $ROOT_DIR/apps/wmagentpy3/etc/profile.d/init.sh
 
+export WMAGENTPY3_ROOT
 # WMAGENT_ROOT == WMCORE_ROOT now but in old rpms WMCORE_ROOT was seperate,
 # if WMCORE_ROOT already set export it, else set to WMAGENT_ROOT
-export WMAGENTPY3_ROOT=$WMA_DEPLOY_DIR
-export WMCORE_ROOT=$WMA_DEPLOY_DIR
-export YUI_ROOT=$WMA_DEPLOY_DIR/yui/
-export WMAGENTPY3_VERSION=$WMA_TAG
+export WMCORE_ROOT=${WMCORE_ROOT:-$WMAGENTPY3_ROOT}
+export YUI_ROOT
+export COUCHSKEL_ROOT

``` 
 
**This one fixes the following two issues at WMCore:**
Fixes https://github.com/dmwm/WMCore/issues/8797
Fixes https://github.com/dmwm/WMCore/issues/11564
