### PR TITLE
Update all WM Pypi Dockerfiles to take TAG as build argument

### DIFF
--- a/docker/pypi/global-workqueue/Dockerfile
+++ b/docker/pypi/global-workqueue/Dockerfile
@@ -1,6 +1,7 @@
 FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230525
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
-ENV TAG=X.Y.Z
+# TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
+ARG TAG=None
 RUN pip install global-workqueue==$TAG
 ENV WDIR=/data
 ENV USER=_workqueue

--- a/docker/pypi/reqmgr2/Dockerfile
+++ b/docker/pypi/reqmgr2/Dockerfile
@@ -1,6 +1,7 @@
 FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230525
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
-ENV TAG=X.Y.Z
+# TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
+ARG TAG=None
 RUN pip install reqmgr2==$TAG
 ENV WDIR=/data
 ENV USER=_reqmgr2

--- a/docker/pypi/reqmgr2ms-monitor/Dockerfile
+++ b/docker/pypi/reqmgr2ms-monitor/Dockerfile
@@ -1,6 +1,7 @@
 FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230525
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
-ENV TAG=X.Y.Z
+# TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
+ARG TAG=None
 RUN pip install reqmgr2ms-monitor==$TAG
 RUN sed -i -e "s,-config.py,-config-monitor.py,g" /data/run.sh
 RUN sed -i -e "s,config.py,config-monitor.py,g" /data/manage

--- a/docker/pypi/reqmgr2ms-output/Dockerfile
+++ b/docker/pypi/reqmgr2ms-output/Dockerfile
@@ -1,6 +1,7 @@
 FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230525
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
-ENV TAG=X.Y.Z
+# TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
+ARG TAG=None
 RUN pip install reqmgr2ms-output==$TAG
 RUN sed -i -e "s,-config.py,-config-output.py,g" /data/run.sh
 RUN sed -i -e "s,config.py,config-output.py,g" /data/manage

--- a/docker/pypi/reqmgr2ms-pileup/Dockerfile
+++ b/docker/pypi/reqmgr2ms-pileup/Dockerfile
@@ -1,6 +1,7 @@
 FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230525
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
-ENV TAG=X.Y.Z
+# TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
+ARG TAG=None
 RUN pip install reqmgr2ms-pileup==$TAG
 #RUN sed -i -e "s,-config.py,-config-pielup.py,g" /data/run.sh
 #RUN sed -i -e "s,config.py,config-pielup.py,g" /data/manage

--- a/docker/pypi/reqmgr2ms-rulecleaner/Dockerfile
+++ b/docker/pypi/reqmgr2ms-rulecleaner/Dockerfile
@@ -1,6 +1,7 @@
 FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230525
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
-ENV TAG=X.Y.Z
+# TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
+ARG TAG=None
 RUN pip install reqmgr2ms-rulecleaner==$TAG
 RUN sed -i -e "s,-config.py,-config-ruleCleaner.py,g" /data/run.sh
 RUN sed -i -e "s,config.py,config-ruleCleaner.py,g" /data/manage

--- a/docker/pypi/reqmgr2ms-transferor/Dockerfile
+++ b/docker/pypi/reqmgr2ms-transferor/Dockerfile
@@ -1,6 +1,7 @@
 FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230525
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
-ENV TAG=X.Y.Z
+# TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
+ARG TAG=None
 RUN pip install reqmgr2ms-transferor==$TAG
 RUN sed -i -e "s,-config.py,-config-transferor.py,g" /data/run.sh
 RUN sed -i -e "s,config.py,config-transferor.py,g" /data/manage

--- a/docker/pypi/reqmgr2ms-unmerged/Dockerfile
+++ b/docker/pypi/reqmgr2ms-unmerged/Dockerfile
@@ -5,7 +5,8 @@ COPY --from=gfal /data/miniconda /data/miniconda
 ENV WDIR=/data
 ENV PATH $PATH:$WDIR/miniconda/bin
 ENV PYTHONPATH $WDIR/miniconda/lib/python3.8/site-packages/
-ENV TAG=X.Y.Z
+# TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
+ARG TAG=None
 WORKDIR $WDIR
 # since we install gfal via external image we'll skip it for installation
 # of reqmgr2ms-unmerged, but to satisfy dependencies we'll install them first

--- a/docker/pypi/reqmon/Dockerfile
+++ b/docker/pypi/reqmon/Dockerfile
@@ -1,6 +1,7 @@
 FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230525
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
-ENV TAG=X.Y.Z
+# TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
+ARG TAG=None
 RUN pip install reqmon==$TAG
 ENV WDIR=/data
 ENV USER=_reqmon

--- a/docker/pypi/t0_reqmon/Dockerfile
+++ b/docker/pypi/t0_reqmon/Dockerfile
@@ -1,6 +1,7 @@
 FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230525
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
-ENV TAG=X.Y.Z
+# TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
+ARG TAG=None
 RUN pip install reqmon==$TAG
 ENV WDIR=/data
 ENV USER=_t0_reqmon

--- a/docker/pypi/wmagent/Dockerfile
+++ b/docker/pypi/wmagent/Dockerfile
@@ -12,11 +12,9 @@ ENV LD_LIBRARY_PATH=/usr/lib/oracle
 ENV PATH=$PATH:/usr/lib/oracle
 ENV PKG_CONFIG_PATH=/usr/lib/oracle
 
-# This TAG is overwritten by WMCore GH actions workflow
-ENV TAG=X.Y.Z
-# WMA_TAG to be passed at build time through `--build-arg WMA_TAG=<WMA_TAG>`. Default: None
-ARG WMA_TAG=${TAG}
-ENV WMA_TAG=${WMA_TAG}
+# TAG to be passed at build time through `--build-arg TAG=<WMA_TAG>`. Default: None
+ARG TAG=None
+ENV WMA_TAG=${TAG}
 ENV WMA_USER=cmst1
 ENV WMA_GROUP=zh
 ENV WMA_UID=31961


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/11646
Depends on https://github.com/dmwm/WMCore/pull/11638

With this PR, we can start building the the WM docker images with the build argument such as `--build-arg TAG=${PYPI_TAG}`, removing the need to `sed` the Dockerfile whenever we want to build a new image.