### PR TITLE
Add opensearchpy lib to dockerfile

### DIFF
--- a/docker/cmsmon-spark/install.sh
+++ b/docker/cmsmon-spark/install.sh
@@ -26,6 +26,6 @@ fi
 zip -r CMSMonitoring.zip CMSMonitoring/src/python/CMSMonitoring/*
 
 # -- Install python modules
-pip install --no-cache-dir stomp.py==7.0.0 click pyspark pandas numpy schema seaborn matplotlib plotly requests==2.29
+pip install --no-cache-dir click matplotlib numpy opensearch-py~=2.1 pandas plotly pyspark requests==2.29 schema seaborn stomp.py==7.0.0
 
 echo "Info: CMSSPARK_TAG=${CMSSPARK_TAG} , CMSMON_TAG=${CMSMON_TAG}, HADOOP_CONF_DIR=${HADOOP_CONF_DIR}, PATH=${PATH}, PYTHONPATH=${PYTHONPATH}, PYSPARK_PYTHON=${PYSPARK_PYTHON}, PYSPARK_DRIVER_PYTHON=${PYSPARK_DRIVER_PYTHON}"


### PR DESCRIPTION
`cron4wma_agent_count` job has been failing for a few months because the docker image was missing `opensearch-py` module (see CMSMONIT-553).

Changes:
- Added `opensearch-py`
- Rearranged modules in alphabetical order

FYI @leggerf @brij01 @mrceyhun 