### PR TITLE
Increase memory and CPU limits in autodqm.yaml

### DIFF
--- a/kubernetes/cmsweb/services/autodqm.yaml
+++ b/kubernetes/cmsweb/services/autodqm.yaml
@@ -44,11 +44,11 @@ spec:
            value: /
         resources:
           requests:
-            memory: "500Mi"
-            cpu: "2000m"
-          limits:
-            memory: "3Gi"
+            memory: "4Gi"
             cpu: "4000m"
+          limits:
+            memory: "8Gi"
+            cpu: "8000m"
         ports:
         - containerPort: 8083
           protocol: TCP

--- a/kubernetes/cmsweb/services/autodqm.yaml
+++ b/kubernetes/cmsweb/services/autodqm.yaml
@@ -22,7 +22,7 @@ spec:
   selector:
     matchLabels:
       app: autodqm
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       labels:


### PR DESCRIPTION
Request increased resources to speed up image-heavy AutoDQM web service, and potentially allow for parallelization, as documented here:
https://its.cern.ch/jira/browse/CMSKUBERNETES-234

Will continue to investigate horizontal scaling and other approaches to reduce memory consumption.  Thanks @vkuznet , @muhammadimranfarooqi , and @arooshap for your valuable feedback.