### PR TITLE
Add dev dbs2go-global migration services to deploy-srv

### DIFF
--- a/kubernetes/cmsweb/scripts/deploy-srv.sh
+++ b/kubernetes/cmsweb/scripts/deploy-srv.sh
@@ -192,7 +192,7 @@ elif  [ "$cmsweb_env" == "k8s-preprod" ] ; then
 
             cat $srv.yaml | sed -e "s,1 #PROD#,,g" | sed -e "s,#PROD#,      ,g" |  sed -e "s,logs-cephfs-claim,$cmsweb_log,g" | sed -e "s, #imagetag,$cmsweb_image_tag,g" | sed -e "s,k8s #k8s#,$cmsweb_env,g" | sed -e 's+crabserver/prod+crabserver/preprod+g' |  kubectl apply -f -
  
-        elif [[ "$srv" == "dbs2go-global-r" || "$srv" == "dbs2go-global-w" || "$srv" == "dbs2go-phys03-r" || "$srv" == "dbs2go-phys03-w" || "$srv" == "dbs2go-global-m" || "$srv" == "dbs2go-phys03-m" || "$srv" == "dbs2go-global-migration" || "$srv" == "dbs2go-phys03-migration" ]] ; then
+        elif [[ "$srv" == "dbs-global-r"  || "$srv" == "dbs-global-w"  ||  "$srv" == "dbs-migrate"  ||  "$srv" == "dbs-phys03-r" || "$srv" == "dbs-phys03-w" || "$srv" == "dbs2go-global-r" || "$srv" == "dbs2go-global-w" || "$srv" == "dbs2go-phys03-r" || "$srv" == "dbs2go-phys03-w" || "$srv" == "dbs2go-global-m" || "$srv" == "dbs2go-phys03-m" || "$srv" == "dbs2go-global-migration" || "$srv" == "dbs2go-phys03-migration" ]] ; then
             cat $srv.yaml | sed -e "s,1 #PROD#,,g" | sed -e "s,#PROD#,      ,g" |  sed -e "s,logs-cephfs-claim,$cmsweb_log,g" | sed -e "s, #imagetag,$cmsweb_image_tag,g" | sed -e "s,k8s #k8s#,$cmsweb_env,g" | sed -e 's+dbs/prod+dbs/int+g' >  $srv.yaml.new
 
             cat $srv.yaml | sed -e "s,1 #PROD#,,g" | sed -e "s,#PROD#,      ,g" |  sed -e "s,logs-cephfs-claim,$cmsweb_log,g" | sed -e "s, #imagetag,$cmsweb_image_tag,g" | sed -e "s,k8s #k8s#,$cmsweb_env,g" | sed -e 's+dbs/prod+dbs/int+g' |  kubectl apply -f -
@@ -210,7 +210,7 @@ elif [ "$srv" == "crabserver" ]; then
 elif  [[ "$cmsweb_env" == "k8s-auth" ]] && [[ "$srv" == "dbs2go-global-r" || "$srv" == "dbs2go-global-w" || "$srv" == "dbs2go-phys03-r" || "$srv" == "dbs2go-phys03-w" || "$srv" == "dbs2go-global-m" || "$srv" == "dbs2go-phys03-m" || "$srv" == "dbs2go-global-migration" || "$srv" == "dbs2go-phys03-migration" ]] ; then
         cat $srv.yaml | sed -e "s, #imagetag,$cmsweb_image_tag,g" |  sed -e 's+dbs/prod+dbs/int+g' | sed -e "s,k8s #k8s#,$cmsweb_env,g"  >  $srv.yaml.new
         cat $srv.yaml | sed -e "s, #imagetag,$cmsweb_image_tag,g" |  sed -e 's+dbs/prod+dbs/int+g' | sed -e "s,k8s #k8s#,$cmsweb_env,g"  | kubectl apply -f - 
-elif [[ "$srv" == "dbs2go-global-r" || "$srv" == "dbs2go-global-w" || "$srv" == "dbs2go-phys03-r" || "$srv" == "dbs2go-phys03-w" || "$srv" == "dbs2go-global-m" || "$srv" == "dbs2go-phys03-m" || "$srv" == "dbs2go-global-migration" || "$srv" == "dbs2go-phys03-migration" ]] ; then
+elif [[ "$srv" == "dbs-global-r"  || "$srv" == "dbs-global-w"  ||  "$srv" == "dbs-migrate"  ||  "$srv" == "dbs-phys03-r" || "$srv" == "dbs-phys03-w" || "$srv" == "dbs2go-global-r" || "$srv" == "dbs2go-global-w" || "$srv" == "dbs2go-phys03-r" || "$srv" == "dbs2go-phys03-w" || "$srv" == "dbs2go-global-m" || "$srv" == "dbs2go-phys03-m" || "$srv" == "dbs2go-global-migration" || "$srv" == "dbs2go-phys03-migration" ]] ; then
         cat $srv.yaml | sed -e "s, #imagetag,$cmsweb_image_tag,g" |  sed -e 's+dbs/prod+dbs/dev+g' | sed -e "s,k8s #k8s#,$cmsweb_env,g"  >  $srv.yaml.new
         cat $srv.yaml | sed -e "s, #imagetag,$cmsweb_image_tag,g" |  sed -e 's+dbs/prod+dbs/dev+g' | sed -e "s,k8s #k8s#,$cmsweb_env,g"  | kubectl apply -f -
 else 

--- a/kubernetes/cmsweb/scripts/deploy-srv.sh
+++ b/kubernetes/cmsweb/scripts/deploy-srv.sh
@@ -192,7 +192,7 @@ elif  [ "$cmsweb_env" == "k8s-preprod" ] ; then
 
             cat $srv.yaml | sed -e "s,1 #PROD#,,g" | sed -e "s,#PROD#,      ,g" |  sed -e "s,logs-cephfs-claim,$cmsweb_log,g" | sed -e "s, #imagetag,$cmsweb_image_tag,g" | sed -e "s,k8s #k8s#,$cmsweb_env,g" | sed -e 's+crabserver/prod+crabserver/preprod+g' |  kubectl apply -f -
  
-        elif [[ "$srv" == "dbs-global-r"  || "$srv" == "dbs-global-w"  ||  "$srv" == "dbs-migrate"  ||  "$srv" == "dbs-phys03-r" || "$srv" == "dbs-phys03-w" || "$srv" == "dbs2go-global-r" || "$srv" == "dbs2go-global-w" || "$srv" == "dbs2go-phys03-r" || "$srv" == "dbs2go-phys03-w" || "$srv" == "dbs2go-global-m" || "$srv" == "dbs2go-global-migration" || "$srv" == "dbs2go-phys03-migration" || "$srv" == "dbs2go-phys03-m" ]] ; then
+        elif [[ "$srv" == "dbs2go-global-r" || "$srv" == "dbs2go-global-w" || "$srv" == "dbs2go-phys03-r" || "$srv" == "dbs2go-phys03-w" || "$srv" == "dbs2go-global-m" || "$srv" == "dbs2go-phys03-m" || "$srv" == "dbs2go-global-migration" || "$srv" == "dbs2go-phys03-migration" ]] ; then
             cat $srv.yaml | sed -e "s,1 #PROD#,,g" | sed -e "s,#PROD#,      ,g" |  sed -e "s,logs-cephfs-claim,$cmsweb_log,g" | sed -e "s, #imagetag,$cmsweb_image_tag,g" | sed -e "s,k8s #k8s#,$cmsweb_env,g" | sed -e 's+dbs/prod+dbs/int+g' >  $srv.yaml.new
 
             cat $srv.yaml | sed -e "s,1 #PROD#,,g" | sed -e "s,#PROD#,      ,g" |  sed -e "s,logs-cephfs-claim,$cmsweb_log,g" | sed -e "s, #imagetag,$cmsweb_image_tag,g" | sed -e "s,k8s #k8s#,$cmsweb_env,g" | sed -e 's+dbs/prod+dbs/int+g' |  kubectl apply -f -
@@ -207,10 +207,10 @@ elif [ "$srv" == "crabserver" ]; then
             cat $srv.yaml | sed -e "s, #imagetag,$cmsweb_image_tag,g" |  sed -e 's+crabserver/prod+crabserver/preprod+g' | sed -e "s,k8s #k8s#,$cmsweb_env,g"  >  $srv.yaml.new
             cat $srv.yaml | sed -e "s, #imagetag,$cmsweb_image_tag,g" |  sed -e 's+crabserver/prod+crabserver/preprod+g' | sed -e "s,k8s #k8s#,$cmsweb_env,g" | kubectl apply -f -
  
-elif  [[ "$cmsweb_env" == "k8s-auth" ]] && [[ "$srv" == "dbs2go-global-r" || "$srv" == "dbs2go-global-w" || "$srv" == "dbs2go-phys03-r" || "$srv" == "dbs2go-phys03-w" || "$srv" == "dbs2go-global-m" || "$srv" == "dbs2go-global-migration" || "$srv" == "dbs2go-phys03-migration" || "$srv" == "dbs2go-phys03-m" ]] ; then
+elif  [[ "$cmsweb_env" == "k8s-auth" ]] && [[ "$srv" == "dbs2go-global-r" || "$srv" == "dbs2go-global-w" || "$srv" == "dbs2go-phys03-r" || "$srv" == "dbs2go-phys03-w" || "$srv" == "dbs2go-global-m" || "$srv" == "dbs2go-phys03-m" || "$srv" == "dbs2go-global-migration" || "$srv" == "dbs2go-phys03-migration" ]] ; then
         cat $srv.yaml | sed -e "s, #imagetag,$cmsweb_image_tag,g" |  sed -e 's+dbs/prod+dbs/int+g' | sed -e "s,k8s #k8s#,$cmsweb_env,g"  >  $srv.yaml.new
         cat $srv.yaml | sed -e "s, #imagetag,$cmsweb_image_tag,g" |  sed -e 's+dbs/prod+dbs/int+g' | sed -e "s,k8s #k8s#,$cmsweb_env,g"  | kubectl apply -f - 
-elif [[ "$srv" == "dbs-global-r"  || "$srv" == "dbs-global-w"  ||  "$srv" == "dbs-migrate"  ||  "$srv" == "dbs-phys03-r" || "$srv" == "dbs-phys03-w" || "$srv" == "dbs2go-global-r" || "$srv" == "dbs2go-global-w" || "$srv" == "dbs2go-phys03-r" || "$srv" == "dbs2go-phys03-w"  ]] ; then
+elif [[ "$srv" == "dbs2go-global-r" || "$srv" == "dbs2go-global-w" || "$srv" == "dbs2go-phys03-r" || "$srv" == "dbs2go-phys03-w" || "$srv" == "dbs2go-global-m" || "$srv" == "dbs2go-phys03-m" || "$srv" == "dbs2go-global-migration" || "$srv" == "dbs2go-phys03-migration" ]] ; then
         cat $srv.yaml | sed -e "s, #imagetag,$cmsweb_image_tag,g" |  sed -e 's+dbs/prod+dbs/dev+g' | sed -e "s,k8s #k8s#,$cmsweb_env,g"  >  $srv.yaml.new
         cat $srv.yaml | sed -e "s, #imagetag,$cmsweb_image_tag,g" |  sed -e 's+dbs/prod+dbs/dev+g' | sed -e "s,k8s #k8s#,$cmsweb_env,g"  | kubectl apply -f -
 else 


### PR DESCRIPTION
Dennis and I found out today that, depending on the dbs2go instance that is deployed in a development environment (k8s cluster different than prod and preprod), the service manifest file does not have the same string replacements (sed) as the other read and write services, affecting especially the livenessprobe setup and causing the service to be constantly restarted.

With this PR, we treat the migrate (m) and migration dbs2go services equally to the read (r) and write (w) instances

@arooshap could you please review it?
FYI @d-ylee @vkuznet 