### PR TITLE
Update sqoop image version

### DIFF
--- a/kubernetes/monitoring/services/sqoop.yaml
+++ b/kubernetes/monitoring/services/sqoop.yaml
@@ -43,7 +43,7 @@ spec:
             - /data/sqoop/log
             - "7"
             - "7200"
-          image: registry.cern.ch/cmsmonitoring/sqoop:sqoop-0.1.12
+          image: registry.cern.ch/cmsmonitoring/sqoop:sqoop-0.1.13
           name: sqoop
           env:
             - name: CMSSQOOP_ENV


### PR DESCRIPTION
After some fixes of the monit tool (https://github.com/dmwm/CMSMonitoring/pull/236), sqoop image (that uses this tool) was updated and therefore these changes need to be done.

FYI @leggerf @brij01 