### PR TITLE
Update img version for cron-size-quotas

### DIFF
--- a/kubernetes/monitoring/services/cron-size-quotas.yaml
+++ b/kubernetes/monitoring/services/cron-size-quotas.yaml
@@ -61,7 +61,7 @@ spec:
     spec:
       containers:
         - name: test
-          image: registry.cern.ch/cmsmonitoring/cmsmon-py:drpy-0.0.16
+          image: registry.cern.ch/cmsmonitoring/cmsmon-py:drpy-0.0.17
           command: [ "crond" ]
           args: [ "-n", "-s" ]
           env:


### PR DESCRIPTION
Final update that fixes `cron-size-quotas issue` and puts the changes from the other PRs (https://github.com/dmwm/CMSKubernetes/pull/1424, https://github.com/dmwm/CMSMonitoring/pull/245) into action.