### PR TITLE
crabserver helm - test liveness readiness probes

### DIFF
--- a/helm/crabserver/Chart.yaml
+++ b/helm/crabserver/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/crabserver/templates/deployment.yaml
+++ b/helm/crabserver/templates/deployment.yaml
@@ -55,14 +55,18 @@ spec:
           livenessProbe:
           {{- if eq (toString $environment) "prod" }}
           {{- toYaml .Values.livenessProbe | nindent 12 }}
-          {{- else }}
+          {{- else if eq (toString $environment) "preprod" }}
           {{- toYaml .Values.livenessProbePreProd | nindent 12 }}
+          {{- else }}
+          {{- toYaml .Values.livenessProbeTest | nindent 12 }}
           {{- end }}
           readinessProbe:
           {{- if eq (toString $environment) "prod" }}
           {{- toYaml .Values.readinessProbe | nindent 12 }}
-          {{- else }}
+          {{- else if eq (toString $environment) "preprod" }}
           {{- toYaml .Values.readinessProbePreProd | nindent 12 }}
+          {{- else }}
+          {{- toYaml .Values.readinessProbeTest | nindent 12 }}
           {{- end }}
           volumeMounts:
           - name: proxy-secrets

--- a/helm/crabserver/values.yaml
+++ b/helm/crabserver/values.yaml
@@ -143,6 +143,28 @@ readinessProbePreProd:
   periodSeconds: 60  
   timeoutSeconds: 60
 
+livenessProbeTest:
+  exec:
+    command:
+    - /bin/sh
+    - -c
+    - |
+      cmsweb-ping --url=http://localhost:8270/crabserver/dev/info --authz=/etc/hmac/hmac -verbose 0 | egrep "^[2-4]"
+  failureThreshold: 3
+  initialDelaySeconds: 120
+  periodSeconds: 60
+  timeoutSeconds: 60
+
+readinessProbeTest:
+  exec:
+    command:
+    - /bin/sh
+    - -c
+    - |
+      cmsweb-ping --url=http://localhost:8270/crabserver/dev/info --authz=/etc/hmac/hmac -verbose 0 | egrep "^[2-4]"
+  periodSeconds: 60  
+  timeoutSeconds: 60
+
 autoscaling:
   enabled: false
   minReplicas: 1


### PR DESCRIPTION
We use specific oracle schema owners for test clusters, which differ from the one we use for preprod. 

In order not to use the preprod schema for the liveness and readiness probe in test clusters, we need to use new liveness and readiness probes endpoints just for test clusters, identified as all the clusters that are not `prod` or `preprod`.

tested in `test11`.