### PR TITLE
crabserver helm - new crabserver version

### DIFF
--- a/helm/crabserver/Chart.yaml
+++ b/helm/crabserver/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "v3.220727"
+appVersion: "v3.230913-stable"

--- a/helm/crabserver/values.yaml
+++ b/helm/crabserver/values.yaml
@@ -10,7 +10,7 @@ image:
   path: registry.cern.ch/cmsweb/crabserver
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v3.230221"
+  tag: "v3.231006"
   command:
   - /bin/bash
   - /opt/setup-certs-and-run/setup-certs-and-run.sh


### PR DESCRIPTION
Update the version of crabserver in helm charts:

- Chart.yaml: version that we are currently running in production
- values.yaml: latest tag, that we should start using in our test and preprod clusters

fyi: @novicecpp 