### PR TITLE
Increase memory requirements for t0_reqmon to 10GB

### DIFF
--- a/kubernetes/cmsweb/services/t0_reqmon.yaml
+++ b/kubernetes/cmsweb/services/t0_reqmon.yaml
@@ -91,7 +91,7 @@ spec:
 #PROD#      memory: "3Gi"
 #PROD#      cpu: "1"
 #PROD#    limits:
-#PROD#      memory: "8Gi"
+#PROD#      memory: "10Gi"
 #PROD#      cpu: "2"
         livenessProbe:
           exec:


### PR DESCRIPTION
With the current heavy ion runs, t0_reqmon is having spikes exceeding 8GB of memory ram. Hopefully the now 10GB of memory will be enough to keep this service in a stable state.

@arooshap could you please merge it?