### PR TITLE
Adding cron functionality.

### DIFF
--- a/docker/mongodb/source/dockerfile
+++ b/docker/mongodb/source/dockerfile
@@ -1,5 +1,5 @@
 FROM debian:stable-slim as tools
-RUN apt-get update && apt-get -y install curl && apt-get -y install krb5-user
+RUN apt-get update && apt-get -y install curl
 ENV WDIR=/data/tools
 WORKDIR $WDIR
 # download mongodb tools
@@ -26,11 +26,15 @@ WORKDIR /root
 ENV MONGODB_ID mongo-0
 
 RUN apt update
-RUN apt install -y iproute2
+RUN apt install -y iproute2 && apt-get -y install krb5-user && apt-get install -y cron
 
 COPY --from=tools /data/tools /data/tools
 COPY /startup-script-mongo /root
+ADD mongo.cron /data/tools/mongo.cron
 COPY /mongotools /data/tools
+
+RUN crontab /data/tools/mongo.cron
+
 ENV PATH=/data/tools:$PATH
 
 CMD ./startup-$MONGODB_ID.sh

--- a/docker/mongodb/source/mongo.cron
+++ b/docker/mongodb/source/mongo.cron
@@ -1,0 +1,1 @@
+0 2 * * * export AGE_KEY="/data/tools/age-key.txt" && /data/tools/mongo_manage.sh backup mongo.ini 


### PR DESCRIPTION
The image is also present in registry.cern.ch/cmsweb/mongodb, and tagged as HG2309d.
```
[apervaiz@aroosha-test docker]$ docker run -it registry.cern.ch/cmsweb/mongodb:HG2309d bash
root@77a5a906f43f:/root# crontab -l
0 2 * * * export AGE_KEY="/data/tools/age-key.txt" && /data/tools/mongo_manage.sh backup mongo.ini
root@77a5a906f43f:/root#

```