### PR TITLE
Updated dbs2go Dockerfile

### DIFF
--- a/docker/dbs2go/Dockerfile
+++ b/docker/dbs2go/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/oracle:21_5 as oracle
+FROM registry.cern.ch/cmsweb/oracle:21_5-stable as oracle
 #FROM cmssw/oracle:21_1 as oracle
 FROM cmssw/exporters:latest as exporters
 FROM cmssw/filebeat:latest as filebeat


### PR DESCRIPTION
Since oracle:21_5 is not available in the registry, the dbs2go Dockerfile has updated the image version to oracle:21_5-stable