### PR TITLE
Changes to the frontend docker image and kubernetes manifest to decrease load on the CRIC servers.

### DIFF
--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -54,6 +54,10 @@ RUN crontab /data/crontab.txt
 ADD run.sh $WDIR/run.sh
 ADD monitor.sh $WDIR/monitor.sh
 ADD alerts.sh $WDIR/alerts.sh
+COPY authmap-prod.cron /tmp/authmap-prod.cron
+COPY authmap-preprod.cron /tmp/data/tools/authmap-preprod.cron
+COPY authmap-test.cron /tmp/authmap-test.cron
+
 
 ENV PATH="${WDIR}/cmsweb/bin:${WDIR}:${WDIR}/gopath/bin:${PATH}"
 

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -57,6 +57,8 @@ ADD alerts.sh $WDIR/alerts.sh
 COPY authmap-prod.cron /tmp/authmap-prod.cron
 COPY authmap-preprod.cron /tmp/data/tools/authmap-preprod.cron
 COPY authmap-test.cron /tmp/authmap-test.cron
+COPY copy_cron.sh $WDIR/copy_cron.sh
+
 
 
 ENV PATH="${WDIR}/cmsweb/bin:${WDIR}:${WDIR}/gopath/bin:${PATH}"

--- a/docker/frontend/authmap-preprod.cron
+++ b/docker/frontend/authmap-preprod.cron
@@ -1,0 +1,2 @@
+*/15 * * * * sleep $((RANDOM \% 601)); /data/srv/current/config/frontend/mkauthmap  -c /data/srv/current/config/frontend/mkauth.conf -o /data/srv/state/frontend/etc/authmap.json --cert /etc/robots/robotcert.pem --key /etc/robots/robotkey.pem --ca-cert /etc/ssl/certs/CERN-bundle.pem ; [ $? -ne 0 ] && /bin/bash /data/alerts.sh
+

--- a/docker/frontend/authmap-preprod.cron
+++ b/docker/frontend/authmap-preprod.cron
@@ -1,2 +1,2 @@
-*/15 * * * * sleep $((RANDOM \% 601)); /data/srv/current/config/frontend/mkauthmap  -c /data/srv/current/config/frontend/mkauth.conf -o /data/srv/state/frontend/etc/authmap.json --cert /etc/robots/robotcert.pem --key /etc/robots/robotkey.pem --ca-cert /etc/ssl/certs/CERN-bundle.pem ; [ $? -ne 0 ] && /bin/bash /data/alerts.sh
+*/15 * * * * sleep $((RANDOM % 601)); /data/srv/current/config/frontend/mkauthmap  -c /data/srv/current/config/frontend/mkauth.conf -o /data/srv/state/frontend/etc/authmap.json --cert /etc/robots/robotcert.pem --key /etc/robots/robotkey.pem --ca-cert /etc/ssl/certs/CERN-bundle.pem ; [ $? -ne 0 ] && /bin/bash /data/alerts.sh
 

--- a/docker/frontend/authmap-prod.cron
+++ b/docker/frontend/authmap-prod.cron
@@ -1,0 +1,2 @@
+*/15 * * * * sleep $((RANDOM \% 601)); /data/srv/current/config/frontend/mkauthmap  -c /data/srv/current/config/frontend/mkauth.conf -o /data/srv/state/frontend/etc/authmap.json --cert /etc/robots/robotcert.pem --key /etc/robots/robotkey.pem --ca-cert /etc/ssl/certs/CERN-bundle.pem ; [ $? -ne 0 ] && /bin/bash /data/alerts.sh
+

--- a/docker/frontend/authmap-prod.cron
+++ b/docker/frontend/authmap-prod.cron
@@ -1,2 +1,2 @@
-*/15 * * * * sleep $((RANDOM \% 601)); /data/srv/current/config/frontend/mkauthmap  -c /data/srv/current/config/frontend/mkauth.conf -o /data/srv/state/frontend/etc/authmap.json --cert /etc/robots/robotcert.pem --key /etc/robots/robotkey.pem --ca-cert /etc/ssl/certs/CERN-bundle.pem ; [ $? -ne 0 ] && /bin/bash /data/alerts.sh
+*/15 * * * * sleep $((RANDOM % 601)); /data/srv/current/config/frontend/mkauthmap  -c /data/srv/current/config/frontend/mkauth.conf -o /data/srv/state/frontend/etc/authmap.json --cert /etc/robots/robotcert.pem --key /etc/robots/robotkey.pem --ca-cert /etc/ssl/certs/CERN-bundle.pem ; [ $? -ne 0 ] && /bin/bash /data/alerts.sh
 

--- a/docker/frontend/authmap-test.cron
+++ b/docker/frontend/authmap-test.cron
@@ -1,2 +1,2 @@
-*/30 * * * * sleep $((RANDOM \% 901)); /data/srv/current/config/frontend/mkauthmap  -c /data/srv/current/config/frontend/mkauth.conf -o /data/srv/state/frontend/etc/authmap.json --cert /etc/robots/robotcert.pem --key /etc/robots/robotkey.pem --ca-cert /etc/ssl/certs/CERN-bundle.pem ; [ $? -ne 0 ] && /bin/bash /data/alerts.sh
+*/30 * * * * sleep $((RANDOM % 901)); /data/srv/current/config/frontend/mkauthmap  -c /data/srv/current/config/frontend/mkauth.conf -o /data/srv/state/frontend/etc/authmap.json --cert /etc/robots/robotcert.pem --key /etc/robots/robotkey.pem --ca-cert /etc/ssl/certs/CERN-bundle.pem ; [ $? -ne 0 ] && /bin/bash /data/alerts.sh
 

--- a/docker/frontend/authmap-test.cron
+++ b/docker/frontend/authmap-test.cron
@@ -1,0 +1,2 @@
+*/30 * * * * sleep $((RANDOM \% 901)); /data/srv/current/config/frontend/mkauthmap  -c /data/srv/current/config/frontend/mkauth.conf -o /data/srv/state/frontend/etc/authmap.json --cert /etc/robots/robotcert.pem --key /etc/robots/robotkey.pem --ca-cert /etc/ssl/certs/CERN-bundle.pem ; [ $? -ne 0 ] && /bin/bash /data/alerts.sh
+

--- a/docker/frontend/copy_cron.sh
+++ b/docker/frontend/copy_cron.sh
@@ -1,0 +1,17 @@
+if [ "$ENVIRONMENT" = "k8s-prod" ]; then
+  # Copy the production cron file
+  echo "Copying authmap-prod.cron"
+  cp /tmp/authmap-prod.cron /tmp/authmap.cron
+elif [ "$ENVIRONMENT" = "k8s-preprod" ]; then
+  # Copy the development cron file
+  echo "Copying authmap-preprod.cron"
+  cp /tmp/authmap-preprod.cron /tmp/authmap.cron
+elif [ "$ENVIRONMENT" = "k8s-test" ]; then
+  # Copy the test cron file
+  echo "Copying authmap-test.cron"
+  cp /tmp/authmap-test.cron /tmp/authmap.cron
+  
+else
+  echo "Unsupported environment: $ENVIRONMENT"
+  exit 1
+fi

--- a/docker/frontend/install.sh
+++ b/docker/frontend/install.sh
@@ -121,8 +121,8 @@ crontab -l | \
 # add proxy generation via robot certificate
 crontab -l | egrep -v "reboot|ProxyRenew|LogArchive|ServerMonitor" > /tmp/mycron
 echo "0 0 * * * sudo /usr/sbin/fetch-crl" >> /tmp/mycron
+sed -i '/mkauthmap/d' /tmp/mycron
 chmod +x copy_cron.sh && ./copy_cron.sh && cat /tmp/authmap.cron >> /tmp/mycron
-(crontab -l | grep -v "mkauthmap") | crontab -
 
 crontab /tmp/mycron
 rm /tmp/mycron

--- a/docker/frontend/install.sh
+++ b/docker/frontend/install.sh
@@ -121,5 +121,8 @@ crontab -l | \
 # add proxy generation via robot certificate
 crontab -l | egrep -v "reboot|ProxyRenew|LogArchive|ServerMonitor" > /tmp/mycron
 echo "0 0 * * * sudo /usr/sbin/fetch-crl" >> /tmp/mycron
+chmod +x copy_cron.sh && ./copy_cron.sh && cat /tmp/authmap.cron >> /tmp/mycron
+(crontab -l | grep -v "mkauthmap") | crontab -
+
 crontab /tmp/mycron
 rm /tmp/mycron

--- a/kubernetes/cmsweb/daemonset/frontend-ds.yaml
+++ b/kubernetes/cmsweb/daemonset/frontend-ds.yaml
@@ -76,6 +76,8 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.name
+         - name: ENVIRONMENT
+           value: k8s #k8s#
         ports:
         - containerPort: 80
           name: http


### PR DESCRIPTION
- Tweak the cronjobs to run a bit more "randomly" in the sense that they now run every 4 minutes but based on a clock so it's always 10:04-10:08-10:12 e.t.c. If we could somehow distribute these calls it would maybe stabilize traffic to CRIC.
- For production and testbed: 15 minutes, and random sleep of 10 minutes. For development: 30 minutes and 15 minutes random sleep.
