### PR TITLE
Copy WMRuntime scripts at the host during WMAgent initialization.

### DIFF
--- a/docker/pypi/wmagent/bin/manage-common.sh
+++ b/docker/pypi/wmagent/bin/manage-common.sh
@@ -21,7 +21,9 @@ wmaInitCouchDB=$WMA_CONFIG_DIR/.initCouchDB                 # set immediately af
 wmaInitConfig=$WMA_CONFIG_DIR/.initConfig                   # set upon final WMAgent config file tweaks have been applied
 wmaInitResourceControl=$WMA_CONFIG_DIR/.initResourceControl # set once the resource control of the agent has been populated
 wmaInitUpload=$WMA_CONFIG_DIR/.initUpload                   # set once the agent config has been uploaded to central CouchDB
+wmaInitRuntime=$WMA_CONFIG_DIR/.initRuntime                 # set once the runtime scripts needed for HTCondor are copied at the host
 wmaInitUsing=$WMA_CONFIG_DIR/.initUsing                     # Final init flag to mark that the agent is fully activated, initialized, and already in use by the system
+
 
 # Setting database name and schema dump location.
 wmaSchemaFile=$WMA_CONFIG_DIR/.wmaSchemaFile.sql

--- a/docker/pypi/wmagent/init.sh
+++ b/docker/pypi/wmagent/init.sh
@@ -125,6 +125,7 @@ deploy_to_host(){
         if [[ $pythonLib =~ ^$WMA_DEPLOY_DIR ]]; then
             mkdir -p $WMA_INSTALL_DIR/Docker/
             cp -rav $pythonLib/WMCore/WMRuntime $WMA_INSTALL_DIR/Docker/
+            cp -rav $WMA_DEPLOY_DIR/etc/ $WMA_CONFIG_DIR/
             echo $WMA_BUILD_ID > $wmaInitRuntime
         else
             echo "$FUNCNAME: ERROR: \$WMA_DEPLOY_DIR: $WMA_DEPLOY_DIR is not a root path for \$pythonLib: $pithonLib"
@@ -383,7 +384,7 @@ agent_tweakconfig() {
         # make this a docker agent
         sed -i "s+Agent.isDocker = False+Agent.isDocker = True+" $WMA_CONFIG_DIR/config.py
         # update the location of submit.sh for docker
-        sed -i "s+config.JobSubmitter.submitScript.*+config.JobSubmitter.submitScript = '$WMA_DEPLOY_DIR/etc/submit.sh'+" $WMA_CONFIG_DIR/config.py
+        sed -i "s+config.JobSubmitter.submitScript.*+config.JobSubmitter.submitScript = '$WMA_CONFIG_DIR/etc/submit.sh'+" $WMA_CONFIG_DIR/config.py
         # replace all tags with current
         sed -i "s+$WMA_TAG+current+" $WMA_CONFIG_DIR/config.py
 

--- a/docker/pypi/wmagent/init.sh
+++ b/docker/pypi/wmagent/init.sh
@@ -119,6 +119,20 @@ deploy_to_host(){
     echo "$FUNCNAME: Copy the proper manage file"
     cp -fv $WMA_DEPLOY_DIR/bin/manage $WMA_MANAGE_DIR/manage && chmod 755 $WMA_MANAGE_DIR/manage
 
+    echo "$FUNCNAME: Copy the Runtime scripts"
+    _init_valid $wmaInitRuntime || {
+        # checking if $WMA_DEPLOY_DIR is root path for $pythonLib:
+        if [[ $pythonLib =~ ^$WMA_DEPLOY_DIR ]]; then
+            mkdir -p $WMA_INSTALL_DIR/Docker/
+            cp -rav $pythonLib/WMCore/WMRuntime $WMA_INSTALL_DIR/Docker/
+            echo $WMA_BUILD_ID > $wmaInitRuntime
+        else
+            echo "$FUNCNAME: ERROR: \$WMA_DEPLOY_DIR: $WMA_DEPLOY_DIR is not a root path for \$pythonLib: $pithonLib"
+            echo "$FUNCNAME: ERROR: We cannot find the correct WMCore/WMRuntime source to copy at the current host!"
+            return $(false)
+        fi
+    }
+
     # Check if the host has a basic WMAgent.secrets file and copy a template if missing
     # NOTE: Here we never overwrite any existing WMAGent.secrets file: We follow:
     #       * Check if there is any at the host, and if so, is it a blank template or a fully configured one
@@ -291,6 +305,7 @@ check_docker_init() {
         $wmaInitActive
         $wmaInitAgent
         $wmaInitConfig
+        $wmaInitRuntime
         $wmaInitUpload
         $wmaInitResourceControl
         $wmaInitCouchDB

--- a/docker/pypi/wmagent/init.sh
+++ b/docker/pypi/wmagent/init.sh
@@ -384,7 +384,7 @@ agent_tweakconfig() {
         # make this a docker agent
         sed -i "s+Agent.isDocker = False+Agent.isDocker = True+" $WMA_CONFIG_DIR/config.py
         # update the location of submit.sh for docker
-        sed -i "s+config.JobSubmitter.submitScript.*+config.JobSubmitter.submitScript = '$WMA_CONFIG_DIR/etc/submit.sh'+" $WMA_CONFIG_DIR/config.py
+        sed -i "s+config.JobSubmitter.submitScript.*+config.JobSubmitter.submitScript = '$WMA_CONFIG_DIR/etc/submit_py3.sh'+" $WMA_CONFIG_DIR/config.py
         # replace all tags with current
         sed -i "s+$WMA_TAG+current+" $WMA_CONFIG_DIR/config.py
 

--- a/docker/pypi/wmagent/install.sh
+++ b/docker/pypi/wmagent/install.sh
@@ -175,6 +175,11 @@ alias scurl='curl -k --cert ${CERT_DIR}/servicecert.pem --key ${CERT_DIR}/servic
 # set WMAgent docker specific bash prompt:
 export PS1="(WMAgent-\$WMA_TAG) [\u@\h:\W]\$ "
 
+unpkl ()
+{
+    python3 -c 'import pickle,sys,pprint;d=pickle.load(open(sys.argv[1],"rb"));print(d);pprint.pprint(d)' "\$1"
+}
+
 source $WMA_ENV_FILE
 EOF
 echo "Done $stepMsg!" && echo


### PR DESCRIPTION
Fixes: https://github.com/dmwm/WMCore/issues/11946 

TESTED, READY

With this  PR we are  fixing an issue related lack of visibility from the host of the WMRuntime scripts deployed inside the WMAgent docker container. This completely fails the HTCondor at the host. 
   
The current change copies the relevant WMRuntime scripts during agent initialization at the host inside the path where those scripts are searched for by the `simpleCondorPlugin` during submission.

