### PR TITLE
Start WMAgent container with dynamic account

### DIFF
--- a/docker/pypi/wmagent-base/Dockerfile
+++ b/docker/pypi/wmagent-base/Dockerfile
@@ -3,7 +3,8 @@ FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230525
 
 # Install basic OS package dependencies
 RUN apt-get update
-RUN apt-get install -y libmariadb-dev-compat libmariadb-dev apache2-utils cron mariadb-server myproxy voms-clients rlwrap libaio1 && apt-get clean
+RUN apt-get install -y libmariadb-dev-compat libmariadb-dev apache2-utils cron mariadb-server \
+   myproxy voms-clients rlwrap libaio1 sssd && apt-get clean
 
 # Install some debugging tools
 RUN apt-get install -y hostname net-tools iputils-ping procps && apt-get clean
@@ -13,3 +14,11 @@ COPY --from=oracle /usr/lib/oracle /usr/lib/oracle
 ENV LD_LIBRARY_PATH=/usr/lib/oracle
 ENV PATH=$PATH:/usr/lib/oracle
 ENV PKG_CONFIG_PATH=/usr/lib/oracle
+
+# overwrite /etc/pam.d/login such that we can access accounts at CERN
+RUN printf "\n\
+auth required pam_sss.so\n\
+account required pam_sss.so\n\
+password required pam_sss.so\n\
+session required pam_sss.so\n\
+" > /etc/pam.d/login

--- a/docker/pypi/wmagent/Dockerfile
+++ b/docker/pypi/wmagent/Dockerfile
@@ -5,19 +5,20 @@ MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 ARG TAG=None
 ARG WMA_TAG=$TAG
 ENV WMA_TAG=$WMA_TAG
-ENV WMA_USER=cmst1
-ENV WMA_GROUP=zh
-ENV WMA_UID=31961
-ENV WMA_GID=1399
 ENV WMA_ROOT_DIR=/data
 
+# WMA_USER argument to be passed at build time with `--build-arg WMA_USER=blah`. Default: wma_docker
+ARG WMA_USER=wma_docker
+RUN groupadd -g 55444 -r $WMA_USER
+RUN useradd -u 55444 --create-home -g $WMA_USER $WMA_USER
+RUN usermod -aG mysql ${WMA_USER}
+RUN rm -f /etc/mysql/mariadb.conf.d/50-server.cnf
 
 # Basic WMAgent directory structure passed to all scripts through env variables:
 # NOTE: Those should be static and depend only on $WMA_BASE_DIR
 ENV WMA_BASE_DIR=$WMA_ROOT_DIR/srv/wmagent
 ENV WMA_ADMIN_DIR=$WMA_ROOT_DIR/admin/wmagent
 ENV WMA_CERTS_DIR=$WMA_ROOT_DIR/certs
-
 
 # ENV WMA_HOSTADMIN_DIR=$WMA_ADMIN_DIR/hostadmin
 ENV WMA_CURRENT_DIR=$WMA_BASE_DIR/$WMA_TAG
@@ -32,17 +33,6 @@ ENV WMA_ENV_FILE=$WMA_DEPLOY_DIR/deploy/env.sh
 ENV WMA_SECRETS_FILE=$WMA_ADMIN_DIR/WMAgent.secrets
 ENV ORACLE_PATH=$WMA_DEPLOY_DIR/etc/oracle
 
-
-# Setting up users and previleges
-RUN groupadd -g ${WMA_GID} ${WMA_GROUP}
-RUN useradd -u ${WMA_UID} -g ${WMA_GID} -m ${WMA_USER}
-RUN install -o ${WMA_USER} -g ${WMA_GID} -d ${WMA_ROOT_DIR}
-RUN usermod -aG mysql ${WMA_USER}
-RUN rm -f /etc/mysql/mariadb.conf.d/50-server.cnf
-
-# Add WMA_USER to sudoers
-RUN echo "${WMA_USER} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
-
 # Add all deployment needed directories
 ADD bin $WMA_DEPLOY_DIR/bin
 ADD etc $WMA_DEPLOY_DIR/etc
@@ -56,12 +46,20 @@ ADD init.sh ${WMA_ROOT_DIR}/init.sh
 
 # Install the requested WMA_TAG.
 RUN ${WMA_ROOT_DIR}/install.sh -t ${WMA_TAG}
-RUN chown -R ${WMA_USER}:${WMA_GID} ${WMA_ROOT_DIR}
 
-# Switch to the runtime directory and user
+# Switch to the runtime directory
 WORKDIR ${WMA_ROOT_DIR}
-USER ${WMA_USER}
-ENV USER=$WMA_USER
+
+# Set WMAgent docker specific bash prompt and manage alias for all users:
+RUN <<EOF cat >>/root/.bashrc
+alias manage=$WMA_MANAGE_DIR/manage
+export PS1="(WMAgent-$TAG) [\u@\h:\W]\$([[ \$(id -u) -eq 0 ]] && echo \# || echo \$) "
+EOF
+
+RUN <<EOF cat >> ~/.bashrc
+alias manage=$WMA_MANAGE_DIR/manage
+export PS1="(WMAgent-$TAG) [\u@\h:\W]\$([[ \$(id -u) -eq 0 ]] && echo \# || echo \$) "
+EOF
 
 # Define the entrypoint (Using exec Form):
 ENTRYPOINT ["./run.sh", "2>&1"]

--- a/docker/pypi/wmagent/init.sh
+++ b/docker/pypi/wmagent/init.sh
@@ -19,7 +19,7 @@ HOSTIP=`hostname -i`
 
 # Setup defaults:
 [[ $WMA_TAG == $WMCoreVersion ]] || {
-    echo "WARNING: Container WMA_TAG: $WAM_TAG and actual WMCoreVersion: $WMCoreVersion mismatch."
+    echo "WARNING: Container WMA_TAG: $WMA_TAG and actual WMCoreVersion: $WMCoreVersion mismatch."
     echo "WARNING: Assuming  WMA_TAG=$WMCoreVersion"
     WMA_TAG=$WMCoreVersion
 }

--- a/docker/pypi/wmagent/run.sh
+++ b/docker/pypi/wmagent/run.sh
@@ -1,11 +1,22 @@
 #!/bin/bash
 
 ### Basic initialization wrapper for WMAgent to serve as the main entry point for the WMAgent Docker container
+wmaUser=`id -un`
+wmaGroup=`id -gn`
+wmaUserID=`id -u`
+wmaGroupID=`id -g`
+export WMA_USER=$wmaUser
+echo "Running WMAgent container with user: $wmaUser (ID: $wmaUserID) and group: $wmaGroup (ID: $wmaGroupID)"
+
+echo "Correcting ownership for WMA_ROOT_DIR: $WMA_ROOT_DIR"
+find $WMA_ROOT_DIR \! \( -user $wmaUser -group $wmaGroup \) -exec chown -f $wmaUser:$wmaGroup '{}' +;
+
+# append the WMAgent user to the mysql group
+usermod -aG mysql ${WMA_USER}
 
 
 echo "Start initialization"
 ./init.sh | tee -a $WMA_LOG_DIR/init.log || true
 
 echo "Start sleeping now ...zzz..."
-
-while true; do sleep 10; done
+sleep infinity

--- a/docker/pypi/wmagent/wmagent-docker-run.sh
+++ b/docker/pypi/wmagent/wmagent-docker-run.sh
@@ -107,4 +107,4 @@ echo "Checking if there is no other wmagent container running and creating a lin
     ln -s $HOST_MOUNT_DIR/srv/wmagent/$WMA_TAG $HOST_MOUNT_DIR/srv/wmagent/current )
 
 echo "Starting the wmagent:$WMA_TAG docker container with the following user parameter: $userOpts"
-docker run $dockerOpts local/wmagent:$WMA_TAG $userOpts
+docker run $dockerOpts $userOpts local/wmagent:$WMA_TAG


### PR DESCRIPTION
Proposal to fix https://github.com/dmwm/WMCore/issues/11944

Similar changes are required for MariaDB and CouchDB, but it will only be done if we decide to move forward with this alternative to detect the user name during execution of the containers.

Reference: https://github.com/Enchufa2/docker-host-auth?tab=readme-ov-file