### PR TITLE
Set WMAgent/MariaDB/CouchDB user during container runtime

### DIFF
--- a/docker/pypi/wmagent-couchdb/Dockerfile
+++ b/docker/pypi/wmagent-couchdb/Dockerfile
@@ -13,16 +13,6 @@ RUN apt-get install -y hostname net-tools iputils-ping procps emacs-nox tcpdump 
 
 RUN pip install CMSCouchapp
 
-# ENV USER=couchdb
-# ENV GROUP=couchdb
-ENV USER=cmst1
-ENV GROUP=zh
-ENV COUCH_UID=31961
-ENV COUCH_GID=1399
-ENV COUCH_PORT=5984
-# ENV COUCH_UID=5984
-# ENV COUCH_GID=5984
-
 ENV COUCH_ROOT_DIR=/data
 
 ENV COUCH_BASE_DIR=$COUCH_ROOT_DIR/srv/couchdb
@@ -46,16 +36,6 @@ ENV WMA_SECRETS_FILE=$WMA_ADMIN_DIR/WMAgent.secrets
 
 # RUN mkdir -p /etc/grid-security
 
-# # Setting up users and previleges
-# # THIS MUST HAPPEN MANUALLY ON THE HOST:
-RUN groupadd -g ${COUCH_GID} ${GROUP}
-RUN useradd -u ${COUCH_UID} -g ${COUCH_GID} -m ${USER}
-RUN install -o ${USER} -g ${COUCH_GID} -d ${COUCH_ROOT_DIR}
-
-
-# add user to sudoers file
-RUN echo "$USER ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
-
 # start the setup
 RUN mkdir -p $COUCH_ROOT_DIR
 
@@ -63,9 +43,6 @@ ENV PATH="${COUCH_ROOT_DIR}:${PATH}"
 
 RUN mkdir -p $COUCH_CURRENT_DIR $COUCH_CONFIG_DIR $COUCH_MANAGE_DIR $COUCH_LOG_DIR $COUCH_DATABASE_DIR $COUCH_STATE_DIR $COUCH_AUTH_DIR
 RUN ln -s $COUCH_CURRENT_DIR $COUCH_BASE_DIR/current
-
-# ENV COUCHDB_USER=admin
-# ENV COUCHDB_PASSWORD=adminpass
 
 # add necessary scripts
 ADD run.sh ${COUCH_ROOT_DIR}/
@@ -79,8 +56,7 @@ RUN ln -s ${COUCH_CONFIG_DIR}/local.ini /opt/couchdb/etc/local.d/
 ENV PATH="/opt/couchdb/bin:/usr/local/bin/:${PATH}"
 ENV CRYPTOGRAPHY_ALLOW_OPENSSL_102=true
 
-# RUN <<EOF cat >> /opt/couchdb/.bashrc
-RUN <<EOF cat >> /home/$USER/.bashrc
+RUN <<EOF cat >> ~/.bashrc
 
 alias lll="ls -lathr"
 alias ls="ls --color=auto"
@@ -92,9 +68,17 @@ alias manage=$COUCH_MANAGE_DIR/manage
 export PS1="(CouchDB-$TAG) [\u@\h:\W]\$ "
 EOF
 
-RUN chown -R ${USER}:${GROUP} ${COUCH_ROOT_DIR}
+# set CouchDB docker specific bash prompt and manage alias for all users:
+RUN <<EOF cat >>/root/.bashrc
+alias manage=$COUCH_MANAGE_DIR/manage
+export PS1="(CouchDB-$TAG) [\u@\h:\W]\$([[ \$(id -u) -eq 0 ]] && echo \# || echo \$) "
+EOF
+
+RUN <<EOF cat >> ~/.bashrc
+alias manage=$COUCH_MANAGE_DIR/manage
+export PS1="(CouchDB-$TAG) [\u@\h:\W]\$([[ \$(id -u) -eq 0 ]] && echo \# || echo \$) "
+EOF
 
 # setup final environment
-USER $USER
 WORKDIR $COUCH_ROOT_DIR
 ENTRYPOINT ["./run.sh"]

--- a/docker/pypi/wmagent-couchdb/Dockerfile
+++ b/docker/pypi/wmagent-couchdb/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get install -y hostname net-tools iputils-ping procps emacs-nox tcpdump 
 
 RUN pip install CMSCouchapp
 
+ENV COUCH_PORT=5984
 ENV COUCH_ROOT_DIR=/data
 
 ENV COUCH_BASE_DIR=$COUCH_ROOT_DIR/srv/couchdb
@@ -50,7 +51,7 @@ ADD manage ${COUCH_MANAGE_DIR}/manage
 RUN ln -s ${COUCH_MANAGE_DIR}/manage ${COUCH_ROOT_DIR}/manage
 
 # The $COUCH_CONFIG_DIR is to be mounted from the host and locla.ini read from there
-ADD local.ini ${COUCH_CONFIG_DIR}/local.ini
+ADD local.ini ${COUCH_DEPLOY_DIR}/local.ini
 RUN ln -s ${COUCH_CONFIG_DIR}/local.ini /opt/couchdb/etc/local.d/
 
 ENV PATH="/opt/couchdb/bin:/usr/local/bin/:${PATH}"

--- a/docker/pypi/wmagent-couchdb/Dockerfile
+++ b/docker/pypi/wmagent-couchdb/Dockerfile
@@ -56,28 +56,13 @@ RUN ln -s ${COUCH_CONFIG_DIR}/local.ini /opt/couchdb/etc/local.d/
 ENV PATH="/opt/couchdb/bin:/usr/local/bin/:${PATH}"
 ENV CRYPTOGRAPHY_ALLOW_OPENSSL_102=true
 
-RUN <<EOF cat >> ~/.bashrc
-
-alias lll="ls -lathr"
-alias ls="ls --color=auto"
-alias ll='ls -la --color=auto'
-
-alias manage=$COUCH_MANAGE_DIR/manage
-
-# set CouchDB docker specific bash prompt:
-export PS1="(CouchDB-$TAG) [\u@\h:\W]\$ "
+# Set command prompt for root
+RUN <<EOF cat >> /root/.bashrc
+export PS1="(CouchDB-$TAG) [\u@\h:\W]# "
 EOF
 
-# set CouchDB docker specific bash prompt and manage alias for all users:
-RUN <<EOF cat >>/root/.bashrc
-alias manage=$COUCH_MANAGE_DIR/manage
-export PS1="(CouchDB-$TAG) [\u@\h:\W]\$([[ \$(id -u) -eq 0 ]] && echo \# || echo \$) "
-EOF
-
-RUN <<EOF cat >> ~/.bashrc
-alias manage=$COUCH_MANAGE_DIR/manage
-export PS1="(CouchDB-$TAG) [\u@\h:\W]\$([[ \$(id -u) -eq 0 ]] && echo \# || echo \$) "
-EOF
+# allow dynamic users to create homefolders and .bashrc
+RUN chmod 777 /home
 
 # setup final environment
 WORKDIR $COUCH_ROOT_DIR

--- a/docker/pypi/wmagent-couchdb/couchdb-docker-run.sh
+++ b/docker/pypi/wmagent-couchdb/couchdb-docker-run.sh
@@ -75,9 +75,10 @@ groupEntry=$(getent group $thisGroup)
 
 [[ -d $HOST_MOUNT_DIR/certs ]] || mkdir -p $HOST_MOUNT_DIR/certs || exit $?
 [[ -d $HOST_MOUNT_DIR/admin/couchdb ]] || mkdir -p $HOST_MOUNT_DIR/admin/couchdb || exit $?
-# [[ -d $HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/config  ]] || mkdir -p $HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/config  || exit $?
-[[ -d $HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/install/database ]] || mkdir -p $HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/install/database || exit $?
+[[ -d $HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/config  ]] || mkdir -p $HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/config  || exit $?
+[[ -d $HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/install ]] || mkdir -p $HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/install || exit $?
 [[ -d $HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/logs ]] || mkdir -p $HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/logs || exit $?
+[[ -d $HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/state ]] || mkdir -p $HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/state || exit $?
 
 
 dockerOpts="
@@ -89,8 +90,10 @@ dockerOpts="
 --name=couchdb \
 --mount type=bind,source=/tmp,target=/tmp \
 --mount type=bind,source=$HOST_MOUNT_DIR/certs,target=/data/certs \
---mount type=bind,source=$HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/install/database,target=/data/srv/couchdb/current/install/database \
+--mount type=bind,source=$HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/install,target=/data/srv/couchdb/current/install \
 --mount type=bind,source=$HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/logs,target=/data/srv/couchdb/current/logs \
+--mount type=bind,source=$HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/state,target=/data/srv/couchdb/current/state \
+--mount type=bind,source=$HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/config,target=/data/srv/couchdb/current/config \
 --mount type=bind,source=$HOST_MOUNT_DIR/admin/wmagent,target=/data/admin/wmagent/ \
 --mount type=bind,source=$HOST_MOUNT_DIR/admin/couchdb,target=/data/admin/couchdb/ \
 --mount type=bind,source=$HOST_MOUNT_DIR/admin/etc/passwd,target=/etc/passwd,readonly \
@@ -100,6 +103,7 @@ dockerOpts="
 "
 
 # --mount type=bind,source=$HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/config,target=/data/srv/couchdb/current/config \
+# --mount type=bind,source=$HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/install/database,target=/data/srv/couchdb/current/install/database \
 
 registry=local
 repository=wmagent-couchdb

--- a/docker/pypi/wmagent-couchdb/couchdb-docker-run.sh
+++ b/docker/pypi/wmagent-couchdb/couchdb-docker-run.sh
@@ -69,6 +69,7 @@ dockerOpts="
 --detach \
 --network=host \
 --rm \
+--user $UID:`id -g` \
 --hostname=`hostname -f` \
 --name=couchdb \
 --mount type=bind,source=/tmp,target=/tmp \
@@ -77,6 +78,12 @@ dockerOpts="
 --mount type=bind,source=$HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/logs,target=/data/srv/couchdb/current/logs \
 --mount type=bind,source=$HOST_MOUNT_DIR/admin/wmagent,target=/data/admin/wmagent/ \
 --mount type=bind,source=$HOST_MOUNT_DIR/admin/couchdb,target=/data/admin/couchdb/ \
+--mount type=bind,source=/etc/group,target=/etc/group,readonly \
+--mount type=bind,source=/etc/passwd,target=/etc/passwd,readonly \
+--mount type=bind,source=/etc/shadow,target=/etc/shadow,readonly \
+--mount type=bind,source=/etc/sudoers,target=/etc/sudoers,readonly \
+--mount type=bind,source=/etc/sudoers.d,target=/etc/sudoers.d,readonly \
+--mount type=bind,source=/etc/profile,target=/etc/profile,readonly \
 "
 
 # --mount type=bind,source=$HOST_MOUNT_DIR/srv/couchdb/$COUCH_TAG/config,target=/data/srv/couchdb/current/config \

--- a/docker/pypi/wmagent-couchdb/manage
+++ b/docker/pypi/wmagent-couchdb/manage
@@ -680,6 +680,8 @@ init_couchdb() {
     # i.e. check if COUCHDB_SECRETS_FILE and WMAGENT_SECRETS_FILE from the host
     # have been parsed correctly and the passwords propagated to local.ini
 
+    [[ -f $COUCH_CONFIG_DIR/local.ini ]] || cp -v $COUCH_DEPLOY_DIR/local.ini $COUCH_CONFIG_DIR/local.ini
+
     # First check if all variables in the local.ini file are properly set
     local parseOk=true
     _parse_localini $COUCH_CONFIG_DIR/local.ini || parseOk=false

--- a/docker/pypi/wmagent-couchdb/run.sh
+++ b/docker/pypi/wmagent-couchdb/run.sh
@@ -1,60 +1,36 @@
 #!/bin/bash
 
+# Basic initialization for CouchDB
+thisUser=$(id -un)
+thisGroup=$(id -gn)
+thisUserID=$(id -u)
+thisGroupID=$(id -g)
+echo "Running CouchDB container with user: $thisUser (ID: $thisUserID) and group: $thisGroup (ID: $thisGroupID)"
+
+export USER=$thisUser
+[[ -d ${HOME} ]] || mkdir -p ${HOME}
+
+<<EOF cat >> ~/.bashrc
+export USER=$thisUser
+
+alias lll="ls -lathr"
+alias ls="ls --color=auto"
+alias ll='ls -la --color=auto'
+alias scurl='curl -k --cert ${COUCH_CERTS_DIR}/servicecert.pem --key ${COUCH_CERTS_DIR}/servicekey.pem'
+
+alias manage=$COUCH_MANAGE_DIR/manage
+
+# Set command prompt for the running user inside the container
+export PS1="(CouchDB-$TAG) [\u@\h:\W]\$ "
+EOF
+source ${HOME}/.bashrc
+
 manage init      | tee -a $COUCH_LOG_DIR/run.log
 manage start     | tee -a $COUCH_LOG_DIR/run.log
 manage pushapps  | tee -a $COUCH_LOG_DIR/run.log
 
 echo "start sleeping....zzz"
-while true; do sleep 10; done
-
+sleep infinity
 
 # # start the service
 # manage start
-
-
-
-
-
-# ###########################################################################################
-# # NOTE: Leftovers - to be adopted/reimplemented in the GH issue dealing with CouchDB setup
-# #       all of those steps were previously done with the old wmagent deployment procedures
-# ###########################################################################################
-
-# DATA_SIZE=`lsblk -bo SIZE,MOUNTPOINT | grep ' /data1' | sort | uniq | awk '{print $1}'`
-# DATA_SIZE_GB=`lsblk -o SIZE,MOUNTPOINT | grep ' /data1' | sort | uniq | awk '{print $1}'`
-# if [[ $DATA_SIZE -gt 200000000000 ]]; then  # greater than ~200GB
-# echo "Partition /data1 available! Total size: $DATA_SIZE_GB"
-# sleep 0.5
-# while true; do
-# read -p "Would you like to deploy couchdb in this /data1 partition (yes/no)? " yn
-# case $yn in
-# [Y/y]* ) DATA1=true; break;;
-# [N/n]* ) DATA1=false; break;;
-# * ) echo "Please answer yes or no.";;
-# esac
-# done
-# else
-# DATA1=false
-# fi && echo
-
-# echo -e "\n*** Applying (for couchdb1.6, etc) cert file permission ***"
-# chmod 600 /data/certs/service{cert,key}.pem
-# echo "Done!"
-
-# echo "*** Checking if couchdb migration is needed ***"
-# echo -e "\n[query_server_config]\nos_process_limit = 50" >> $WMA_CURRENT_DIR/config/couchdb/local.ini
-# if [ "$DATA1" = true ]; then
-# ./manage stop-services
-# sleep 5
-# if [ -d "/data1/database/" ]; then
-# echo "Moving old database away... "
-# mv /data1/database/ /data1/database_old/
-# FINAL_MSG="5) Remove the old database when possible (/data1/database_old/)"
-# fi
-# rsync --remove-source-files -avr /data/srv/wmagent/current/install/couchdb/database /data1
-# sed -i "s+database_dir = .*+database_dir = /data1/database+" $WMA_CURRENT_DIR/config/couchdb/local.ini
-# sed -i "s+view_index_dir = .*+view_index_dir = /data1/database+" $WMA_CURRENT_DIR/config/couchdb/local.ini
-# ./manage start-services
-# fi
-# echo "Done!" && echo
-# ###########################################################################################

--- a/docker/pypi/wmagent-mariadb/Dockerfile
+++ b/docker/pypi/wmagent-mariadb/Dockerfile
@@ -32,10 +32,6 @@ ENV MDB_SECRETS_FILE=$MDB_ADMIN_DIR/MariaDB.secrets
 ENV WMA_SECRETS_FILE=$WMA_ADMIN_DIR/WMAgent.secrets
 ENV WMA_DATABASE=wmagent
 
-# create the system user to run the database
-RUN groupadd -g 1399 zh
-RUN useradd -u 31961  -g 1399 -G 999 -m cmst1
-
 # start the setup
 RUN mkdir -p $MDB_ROOT_DIR $MDB_CURRENT_DIR $MDB_CONFIG_DIR $MDB_MANAGE_DIR \
     $MDB_LOG_DIR $MDB_DATABASE_DIR $MDB_STATE_DIR $MDB_AUTH_DIR
@@ -58,14 +54,11 @@ alias manage=$MDB_MANAGE_DIR/manage
 export PS1="(MariaDB-$MDB_TAG) [\u@\h:\W]\$([[ \$(id -u) -eq 0 ]] && echo \# || echo \$) "
 EOF
 
-RUN <<EOF cat >>/home/cmst1/.bashrc
+RUN <<EOF cat >> ~/.bashrc
 alias manage=$MDB_MANAGE_DIR/manage
 export PS1="(MariaDB-$MDB_TAG) [\u@\h:\W]\$([[ \$(id -u) -eq 0 ]] && echo \# || echo \$) "
 EOF
 
-# RUN chown -R ${USER} ${MDB_ROOT_DIR}
-
 # setup final environment
-# USER $USER
 WORKDIR $MDB_ROOT_DIR
 ENTRYPOINT ["./run.sh", "2>&1"]

--- a/docker/pypi/wmagent-mariadb/Dockerfile
+++ b/docker/pypi/wmagent-mariadb/Dockerfile
@@ -48,16 +48,13 @@ ADD my.cnf ${MDB_CONFIG_DIR}/my.cnf
 
 ENV PATH="/usr/local/bin/:${MDB_ROOT_DIR}:${PATH}"
 
-# set MariaDB docker specific bash prompt and manage alias for all users:
-RUN <<EOF cat >>/root/.bashrc
-alias manage=$MDB_MANAGE_DIR/manage
-export PS1="(MariaDB-$MDB_TAG) [\u@\h:\W]\$([[ \$(id -u) -eq 0 ]] && echo \# || echo \$) "
+# Set command prompt for root
+RUN <<EOF cat >> /root/.bashrc
+export PS1="(MariaDB-$MDB_TAG) [\u@\h:\W]# "
 EOF
 
-RUN <<EOF cat >> ~/.bashrc
-alias manage=$MDB_MANAGE_DIR/manage
-export PS1="(MariaDB-$MDB_TAG) [\u@\h:\W]\$([[ \$(id -u) -eq 0 ]] && echo \# || echo \$) "
-EOF
+# allow dynamic users to create homefolders and .bashrc
+RUN chmod 777 /home
 
 # setup final environment
 WORKDIR $MDB_ROOT_DIR

--- a/docker/pypi/wmagent-mariadb/mariadb-docker-run.sh
+++ b/docker/pypi/wmagent-mariadb/mariadb-docker-run.sh
@@ -49,13 +49,29 @@ while getopts ":t:hp" opt; do
     esac
 done
 
-
-mariadbUser=`id -un`
-mariadbOpts=" --user $mariadbUser -e USER=$mariadbUser"
-
 # This is the root at the host only, it may differ from the root inside the container.
 # NOTE: this may be parametriesed, so that the container can run on a different mount point.
 HOST_MOUNT_DIR=/data/dockerMount
+
+thisUser=$(id -un)
+thisGroup=$(id -gn)
+
+# create the passwd and group mount point dynamically at runtime
+passwdEntry=$(getent passwd $thisUser | awk -F : -v thisHome="/home/$thisUser" '{print $1 ":" $2 ":" $3 ":" $4 ":" $5 ":" thisHome ":" $7}')
+groupEntry=$(getent group $thisGroup)
+
+# workaround case where Unix account is not in the local system (e.g. sssd)
+[[ -d $HOST_MOUNT_DIR/admin/etc/ ]] || (mkdir -p $HOST_MOUNT_DIR/admin/etc) || exit $?
+[[ -f $HOST_MOUNT_DIR/admin/etc/passwd ]] || {
+    echo "Creating passwd file"
+    getent passwd > $HOST_MOUNT_DIR/admin/etc/passwd
+    echo $passwdEntry >> $HOST_MOUNT_DIR/admin/etc/passwd
+}
+[[ -f $HOST_MOUNT_DIR/admin/etc/group ]] || {
+    echo "Creating group file"
+    getent group > $HOST_MOUNT_DIR/admin/etc/group
+    echo $groupEntry >> $HOST_MOUNT_DIR/admin/etc/group
+}
 
 [[ -d $HOST_MOUNT_DIR/certs ]] || (mkdir -p $HOST_MOUNT_DIR/certs) || exit $?
 [[ -d $HOST_MOUNT_DIR/admin/mariadb ]] || (mkdir -p $HOST_MOUNT_DIR/admin/mariadb) || exit $?
@@ -63,14 +79,13 @@ HOST_MOUNT_DIR=/data/dockerMount
 [[ -d $HOST_MOUNT_DIR/srv/mariadb/$MDB_TAG/install/database ]] || { mkdir -p $HOST_MOUNT_DIR/srv/mariadb/$MDB_TAG/install/database ;} || exit $?
 [[ -d $HOST_MOUNT_DIR/srv/mariadb/$MDB_TAG/logs ]] || { mkdir -p $HOST_MOUNT_DIR/srv/mariadb/$MDB_TAG/logs ;} || exit $?
 
-# sudo chown -R $mariadbUser $HOST_MOUNT_DIR/srv/mariadb/$MDB_TAG
 
 dockerOpts="
 --detach \
 --network=host \
 --rm \
---user $UID:`id -g` \
---hostname=`hostname -f` \
+--hostname=$(hostname -f) \
+--user $(id -u):$(id -g) \
 --name=mariadb \
 --mount type=bind,source=/tmp,target=/tmp \
 --mount type=bind,source=$HOST_MOUNT_DIR/certs,target=/data/certs \
@@ -78,12 +93,10 @@ dockerOpts="
 --mount type=bind,source=$HOST_MOUNT_DIR/srv/mariadb/$MDB_TAG/logs,target=/data/srv/mariadb/current/logs \
 --mount type=bind,source=$HOST_MOUNT_DIR/admin/mariadb,target=/data/admin/mariadb/ \
 --mount type=bind,source=$HOST_MOUNT_DIR/admin/wmagent,target=/data/admin/wmagent/ \
---mount type=bind,source=/etc/group,target=/etc/group,readonly \
---mount type=bind,source=/etc/passwd,target=/etc/passwd,readonly \
---mount type=bind,source=/etc/shadow,target=/etc/shadow,readonly \
+--mount type=bind,source=$HOST_MOUNT_DIR/admin/etc/passwd,target=/etc/passwd,readonly \
+--mount type=bind,source=$HOST_MOUNT_DIR/admin/etc/group,target=/etc/group,readonly \
 --mount type=bind,source=/etc/sudoers,target=/etc/sudoers,readonly \
 --mount type=bind,source=/etc/sudoers.d,target=/etc/sudoers.d,readonly \
---mount type=bind,source=/etc/profile,target=/etc/profile,readonly \
 "
 
 # --mount type=bind,source=$HOST_MOUNT_DIR/srv/mariadb/$MDB_TAG/config,target=/data/srv/mariadb/current/config \
@@ -101,7 +114,7 @@ $PULL && {
     docker tag  $registry/$project/$repository:$MDB_TAG $registry/$repository:latest
 }
 
-echo "Starting the $registry/$repository:$MDB_TAG docker container with the following parameters: $mariadbOpts"
-docker run $dockerOpts $mariadbOpts $registry/$repository:$MDB_TAG && (
+echo "Starting $repository:$MDB_TAG docker container with user: $thisUser:$thisGroup"
+docker run $dockerOpts $registry/$repository:$MDB_TAG && (
     [[ -h $HOST_MOUNT_DIR/srv/mariadb/current ]] && rm -f $HOST_MOUNT_DIR/srv/mariadb/current
     ln -s $HOST_MOUNT_DIR/srv/mariadb/$MDB_TAG $HOST_MOUNT_DIR/srv/mariadb/current )

--- a/docker/pypi/wmagent-mariadb/mariadb-docker-run.sh
+++ b/docker/pypi/wmagent-mariadb/mariadb-docker-run.sh
@@ -69,6 +69,7 @@ dockerOpts="
 --detach \
 --network=host \
 --rm \
+--user $UID:`id -g` \
 --hostname=`hostname -f` \
 --name=mariadb \
 --mount type=bind,source=/tmp,target=/tmp \
@@ -77,6 +78,12 @@ dockerOpts="
 --mount type=bind,source=$HOST_MOUNT_DIR/srv/mariadb/$MDB_TAG/logs,target=/data/srv/mariadb/current/logs \
 --mount type=bind,source=$HOST_MOUNT_DIR/admin/mariadb,target=/data/admin/mariadb/ \
 --mount type=bind,source=$HOST_MOUNT_DIR/admin/wmagent,target=/data/admin/wmagent/ \
+--mount type=bind,source=/etc/group,target=/etc/group,readonly \
+--mount type=bind,source=/etc/passwd,target=/etc/passwd,readonly \
+--mount type=bind,source=/etc/shadow,target=/etc/shadow,readonly \
+--mount type=bind,source=/etc/sudoers,target=/etc/sudoers,readonly \
+--mount type=bind,source=/etc/sudoers.d,target=/etc/sudoers.d,readonly \
+--mount type=bind,source=/etc/profile,target=/etc/profile,readonly \
 "
 
 # --mount type=bind,source=$HOST_MOUNT_DIR/srv/mariadb/$MDB_TAG/config,target=/data/srv/mariadb/current/config \

--- a/docker/pypi/wmagent-mariadb/run.sh
+++ b/docker/pypi/wmagent-mariadb/run.sh
@@ -1,7 +1,31 @@
 #!/bin/bash
 
+# Basic initialization for MariaDB
+thisUser=$(id -un)
+thisGroup=$(id -gn)
+thisUserID=$(id -u)
+thisGroupID=$(id -g)
+echo "Running MariaDB container with user: $thisUser (ID: $thisUserID) and group: $thisGroup (ID: $thisGroupID)"
+
+export USER=$thisUser
+[[ -d ${HOME} ]] || mkdir -p ${HOME}
+
+<<EOF cat >> ~/.bashrc
+export USER=$thisUser
+
+alias lll="ls -lathr"
+alias ls="ls --color=auto"
+alias ll='ls -la --color=auto'
+
+alias manage=$MDB_MANAGE_DIR/manage
+
+# Set command prompt for the running user inside the container
+export PS1="(MariaDB-$MDB_TAG) [\u@\h:\W]\$ "
+EOF
+source ${HOME}/.bashrc
+
 manage init-mariadb  2>&1 | tee -a $MDB_LOG_DIR/run.log
 manage start-mariadb 2>&1 | tee -a $MDB_LOG_DIR/run.log
 
 echo "Start sleeping....zzz"
-while true; do sleep 10; done
+sleep infinity

--- a/docker/pypi/wmagent/Dockerfile
+++ b/docker/pypi/wmagent/Dockerfile
@@ -5,19 +5,13 @@ MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 ARG TAG=None
 ARG WMA_TAG=$TAG
 ENV WMA_TAG=$WMA_TAG
-ENV WMA_USER=cmst1
-ENV WMA_GROUP=zh
-ENV WMA_UID=31961
-ENV WMA_GID=1399
 ENV WMA_ROOT_DIR=/data
-
 
 # Basic WMAgent directory structure passed to all scripts through env variables:
 # NOTE: Those should be static and depend only on $WMA_BASE_DIR
 ENV WMA_BASE_DIR=$WMA_ROOT_DIR/srv/wmagent
 ENV WMA_ADMIN_DIR=$WMA_ROOT_DIR/admin/wmagent
 ENV WMA_CERTS_DIR=$WMA_ROOT_DIR/certs
-
 
 # ENV WMA_HOSTADMIN_DIR=$WMA_ADMIN_DIR/hostadmin
 ENV WMA_CURRENT_DIR=$WMA_BASE_DIR/$WMA_TAG
@@ -32,17 +26,6 @@ ENV WMA_ENV_FILE=$WMA_DEPLOY_DIR/deploy/env.sh
 ENV WMA_SECRETS_FILE=$WMA_ADMIN_DIR/WMAgent.secrets
 ENV ORACLE_PATH=$WMA_DEPLOY_DIR/etc/oracle
 
-
-# Setting up users and previleges
-RUN groupadd -g ${WMA_GID} ${WMA_GROUP}
-RUN useradd -u ${WMA_UID} -g ${WMA_GID} -m ${WMA_USER}
-RUN install -o ${WMA_USER} -g ${WMA_GID} -d ${WMA_ROOT_DIR}
-RUN usermod -aG mysql ${WMA_USER}
-RUN rm -f /etc/mysql/mariadb.conf.d/50-server.cnf
-
-# Add WMA_USER to sudoers
-RUN echo "${WMA_USER} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
-
 # Add all deployment needed directories
 ADD bin $WMA_DEPLOY_DIR/bin
 ADD etc $WMA_DEPLOY_DIR/etc
@@ -56,16 +39,17 @@ ADD init.sh ${WMA_ROOT_DIR}/init.sh
 
 # Install the requested WMA_TAG.
 RUN ${WMA_ROOT_DIR}/install.sh -t ${WMA_TAG}
-RUN chown -R ${WMA_USER}:${WMA_GID} ${WMA_ROOT_DIR}
 
-# Switch to the runtime directory and user
+# Switch to the runtime directory
 WORKDIR ${WMA_ROOT_DIR}
-USER ${WMA_USER}
-ENV USER=$WMA_USER
 
-# Define the entrypoint (Using exec Form):
+# Set command prompt for root
+RUN <<EOF cat >> /root/.bashrc
+export PS1="(WMAgent-\$WMA_TAG) [\u@\h:\W]# "
+EOF
+
+# allow dynamic users to create homefolders and .bashrc
+RUN chmod 777 /home
+
+# Define the entrypoint (Using exec form):
 ENTRYPOINT ["./run.sh", "2>&1"]
-
-# # Define the entrypoint (Using shell Form):
-# SHELL ["/bin/bash", "-c"]
-# ENTRYPOINT /data/run.sh 2>&1

--- a/docker/pypi/wmagent/bin/manage-common.sh
+++ b/docker/pypi/wmagent/bin/manage-common.sh
@@ -317,7 +317,7 @@ _renew_proxy(){
                 echo "$FUNCNAME: ERROR: Failed to renew expired myproxy"; return $(false) ;}
 
         # Stay safe and always change the service {cert,key} and myproxy mode here:
-        sudo chmod 400 $WMA_CERTS_DIR/*
+        chmod 400 $WMA_CERTS_DIR/*
         echo "$FUNCNAME: OK"
     else
         echo "$FUNCNAME: ERROR: We found no service certificate installed at $WMA_CERTS_DIR!"

--- a/docker/pypi/wmagent/etc/wmagent_bashrc
+++ b/docker/pypi/wmagent/etc/wmagent_bashrc
@@ -1,0 +1,29 @@
+### Template .bashrc file to be used for the user running WMAgent
+alias agentenv='source $WMA_ENV_FILE'
+alias manage=\$WMA_MANAGE_DIR/manage
+
+alias lll="ls -lathr"
+alias ls="ls --color=auto"
+alias ll='ls -la --color=auto'
+
+alias condorq='condor_q -format "%i." ClusterID -format "%s " ProcId -format " %i " JobStatus  -format " %d " ServerTime-EnteredCurrentStatus -format "%s" UserLog -format " %s\n" DESIRED_Sites'
+alias condorqrunning='condor_q -constraint JobStatus==2 -format "%i." ClusterID -format "%s " ProcId -format " %i " JobStatus  -format " %d " ServerTime-EnteredCurrentStatus -format "%s" UserLog -format " %s\n" DESIRED_Sites'
+
+alias runningagent="ps aux | egrep 'couch|wmcore|mysql|beam'"
+alias foldersize="du -h --max-depth=1 | sort -hr"
+
+# Better curl command
+alias scurl='curl -k --cert ${WMA_CERTS_DIR}/servicecert.pem --key ${WMA_CERTS_DIR}/servicekey.pem'
+
+# Set command prompt for the running user inside the container
+export PS1="(WMAgent-\$WMA_TAG) [\u@\h:\W]\$ "
+
+# debugging tool
+unpkl ()
+{
+    python3 -c 'import pickle,sys,pprint;d=pickle.load(open(sys.argv[1],"rb"));print(d);pprint.pprint(d)' "\$1"
+}
+
+# load the agent environment and utilitarian functions
+source $WMA_ENV_FILE
+source $WMA_DEPLOY_DIR/bin/manage-common.sh

--- a/docker/pypi/wmagent/install.sh
+++ b/docker/pypi/wmagent/install.sh
@@ -120,11 +120,9 @@ echo "-----------------------------------------------------------------------"
 
 tweakEnv(){
     # A function to apply environment tweaks for the docker image
-    echo "-------------------------------------------------------"
     echo "Edit \$WMA_ENV_FILE script to point to \$WMA_ROOT_DIR"
     sed -i "s|/data/|\$WMA_ROOT_DIR/|g" $WMA_ENV_FILE
 
-    echo "-------------------------------------------------------"
     echo "Edit \$WMA_ENV_FILE script to point to the correct install, config and manage"
     sed -i "s|install=.*|install=\$WMA_INSTALL_DIR|g" $WMA_ENV_FILE
     sed -i "s|config=.*|config=\$WMA_CONFIG_DIR|g" $WMA_ENV_FILE
@@ -134,7 +132,6 @@ tweakEnv(){
     echo "Edit $WMA_DEPLOY_DIR/deploy/renew_proxy.sh script to point to \$WMA_ROOT_DIR"
     sed -i "s|/data/|\$WMA_ROOT_DIR/|g" $WMA_DEPLOY_DIR/deploy/renew_proxy.sh
     sed -i "s|source.*env\.sh|source \$WMA_ENV_FILE|g" $WMA_DEPLOY_DIR/deploy/renew_proxy.sh
-    echo "-------------------------------------------------------"
 
     cat <<EOF >> $WMA_ENV_FILE
 
@@ -154,58 +151,14 @@ stepMsg="Tweaking runtime environment for user: $WMA_USER"
 echo "-----------------------------------------------------------------------"
 echo "Start $stepMsg"
 tweakEnv || { err=$?; echo ""; exit $err ; }
-cat <<EOF >> /home/${WMA_USER}/.bashrc
-
-alias lll="ls -lathr"
-alias ls="ls --color=auto"
-alias ll='ls -la --color=auto'
-
-alias condorq='condor_q -format "%i." ClusterID -format "%s " ProcId -format " %i " JobStatus  -format " %d " ServerTime-EnteredCurrentStatus -format "%s" UserLog -format " %s\n" DESIRED_Sites'
-alias condorqrunning='condor_q -constraint JobStatus==2 -format "%i." ClusterID -format "%s " ProcId -format " %i " JobStatus  -format " %d " ServerTime-EnteredCurrentStatus -format "%s" UserLog -format " %s\n" DESIRED_Sites'
-alias agentenv='source $WMA_ENV_FILE'
-alias manage=\$WMA_MANAGE_DIR/manage
-
-# Aliases for Tier0-Ops.
-alias runningagent="ps aux | egrep 'couch|wmcore|mysql|beam'"
-alias foldersize="du -h --max-depth=1 | sort -hr"
-
-# Better curl command
-alias scurl='curl -k --cert ${CERT_DIR}/servicecert.pem --key ${CERT_DIR}/servicekey.pem'
-
-# set WMAgent docker specific bash prompt:
-export PS1="(WMAgent-\$WMA_TAG) [\u@\h:\W]\$ "
-
-unpkl ()
-{
-    python3 -c 'import pickle,sys,pprint;d=pickle.load(open(sys.argv[1],"rb"));print(d);pprint.pprint(d)' "\$1"
-}
 
 source $WMA_ENV_FILE
 source $WMA_DEPLOY_DIR/bin/manage-common.sh
-EOF
 echo "Done $stepMsg!" && echo
 echo "-----------------------------------------------------------------------"
 
-stepMsg="Populating cronjob with utilitarian scripts for the WMA_USER"
 echo "-----------------------------------------------------------------------"
-echo "Start $stepMsg"
-
-# TODO: These executable flags we should consider fixing them for all *.sh
-#       scripts under the /deploy top level area in the WMCore github repository
-chmod +x $WMA_DEPLOY_DIR/deploy/renew_proxy.sh $WMA_DEPLOY_DIR/deploy/restartComponent.sh
-
-crontab -u $WMA_USER - <<EOF
-55 */12 * * * $WMA_MANAGE_DIR/manage renew-proxy
-58 */12 * * * python $WMA_DEPLOY_DIR/deploy/checkProxy.py --proxy /data/certs/myproxy.pem --time 120 --send-mail True --mail alan.malta@cern.ch
-*/15 * * * *  source $WMA_DEPLOY_DIR/deploy/restartComponent.sh > /dev/null
-EOF
-
-echo "Done $stepMsg!" && echo
-echo "-----------------------------------------------------------------------"
-
-
-echo "-----------------------------------------------------------------------"
-echo "WMAgent contaner build finished!!" && echo
+echo "WMAgent image build finished!!" && echo
 echo "Have a nice day!" && echo
 echo "======================================================================="
 

--- a/docker/pypi/wmagent/run.sh
+++ b/docker/pypi/wmagent/run.sh
@@ -1,11 +1,23 @@
 #!/bin/bash
 
 ### Basic initialization wrapper for WMAgent to serve as the main entry point for the WMAgent Docker container
+wmaUser=$(id -un)
+wmaGroup=$(id -gn)
+wmaUserID=$(id -u)
+wmaGroupID=$(id -g)
 
+echo "Running WMAgent container with user: $wmaUser (ID: $wmaUserID) and group: $wmaGroup (ID: $wmaGroupID)"
+
+echo "Setting up bashrc for user: $wmaUser under home directory: $HOME"
+export WMA_USER=$wmaUser
+export USER=$wmaUser
+[[ -d ${HOME} ]] || mkdir -p ${HOME}
+
+mv ${WMA_CONFIG_DIR}/etc/wmagent_bashrc $HOME/.bashrc
+source $HOME/.bashrc
 
 echo "Start initialization"
-./init.sh | tee -a $WMA_LOG_DIR/init.log || true
+$WMA_ROOT_DIR/init.sh | tee -a $WMA_LOG_DIR/init.log || true
 
 echo "Start sleeping now ...zzz..."
-
-while true; do sleep 10; done
+sleep infinity

--- a/docker/pypi/wmagent/wmagent-docker-run.sh
+++ b/docker/pypi/wmagent/wmagent-docker-run.sh
@@ -43,12 +43,8 @@ while getopts ":t:hp" opt; do
     esac
 done
 
-
-wmaUser=`id -un`
-wmaUserID=`id -u`
-wmaGroup=`id -gn`
-wmaGroupID=`id -g`
-wmaOpts=" --user $wmaUser"
+wmaUser=$(id -un)
+wmaGroup=$(id -gn)
 
 # This is the root at the host only, it may differ from the root inside the container.
 # NOTE: This is parametriesed, so that the container can run on a different mount point.
@@ -59,16 +55,21 @@ HOST_MOUNT_DIR=/data/dockerMount
 ln -s $HOST_MOUNT_DIR/srv/wmagent /data/srv/wmagent
 
 # create the passwd and group mount point dynamically at runtime
-passwdEntry=`getent passwd $wmaUser  |awk -F : -v wmaUser=$wmaUser '{print $1":"$2":"$3":"$4":"$5":""/home/"wmaUser":"$7}'`
-groupEntry=`getent group $wmaGroup`
+passwdEntry=$(getent passwd $wmaUser | awk -F : -v wmaHome="/home/$wmaUser" '{print $1 ":" $2 ":" $3 ":" $4 ":" $5 ":" wmaHome ":" $7}')
+groupEntry=$(getent group $wmaGroup)
 
-[[ -d $HOST_MOUNT_DIR/admin/ ]] || (mkdir -p $HOST_MOUNT_DIR/admin) || exit $?
-
-getent passwd > $HOST_MOUNT_DIR/admin/passwd
-getent group > $HOST_MOUNT_DIR/admin/group
-
-echo $passwdEntry >> $HOST_MOUNT_DIR/admin/passwd
-echo $groupEntry >> $HOST_MOUNT_DIR/admin/group
+# workaround case where Unix account is not in the local system (e.g. sssd)
+[[ -d $HOST_MOUNT_DIR/admin/etc/ ]] || (mkdir -p $HOST_MOUNT_DIR/admin/etc) || exit $?
+if ! [ -f $HOST_MOUNT_DIR/admin/etc/passwd ]; then
+    echo "Creating passwd file"
+    getent passwd > $HOST_MOUNT_DIR/admin/etc/passwd
+    echo $passwdEntry >> $HOST_MOUNT_DIR/admin/etc/passwd
+fi
+if ! [ -f $HOST_MOUNT_DIR/admin/etc/group ]; then
+    echo "Creating group file"
+    getent group > $HOST_MOUNT_DIR/admin/etc/group
+    echo $groupEntry >> $HOST_MOUNT_DIR/admin/etc/group
+fi
 
 # create regular mount points at runtime
 [[ -d $HOST_MOUNT_DIR/certs ]] || (mkdir -p $HOST_MOUNT_DIR/certs) || exit $?
@@ -77,34 +78,30 @@ echo $groupEntry >> $HOST_MOUNT_DIR/admin/group
 [[ -d $HOST_MOUNT_DIR/srv/wmagent/$WMA_TAG/config  ]] || (mkdir -p $HOST_MOUNT_DIR/srv/wmagent/$WMA_TAG/config)  || exit $?
 [[ -d $HOST_MOUNT_DIR/srv/wmagent/$WMA_TAG/logs ]] || { mkdir -p $HOST_MOUNT_DIR/srv/wmagent/$WMA_TAG/logs ;} || exit $?
 
-chown -R $wmaUser $HOST_MOUNT_DIR/srv/wmagent/$WMA_TAG || exit $?
-
 # NOTE: Before mounting /etc/tnsnames.ora we should check it exists, otherwise the run will fail on the FNAL agents
 tnsMount=""
 [[ -f /etc/tnsnames.ora ]] && tnsMount="--mount type=bind,source=/etc/tnsnames.ora,target=/etc/tnsnames.ora,readonly "
 
 dockerOpts=" \
---detach
+--detach \
 --network=host \
 --rm \
---user $wmaUserID:$wmaGroupID \
---hostname=`hostname -f` \
+--hostname=$(hostname -f) \
+--user $(id -u):$(id -g) \
 --name=wmagent \
-$tnsMount
+$tnsMount \
 --mount type=bind,source=/etc/condor,target=/etc/condor,readonly \
 --mount type=bind,source=/tmp,target=/tmp \
 --mount type=bind,source=$HOST_MOUNT_DIR/certs,target=/data/certs \
 --mount type=bind,source=$HOST_MOUNT_DIR/srv/wmagent/$WMA_TAG/install,target=/data/srv/wmagent/current/install \
 --mount type=bind,source=$HOST_MOUNT_DIR/srv/wmagent/$WMA_TAG/config,target=/data/srv/wmagent/current/config \
 --mount type=bind,source=$HOST_MOUNT_DIR/srv/wmagent/$WMA_TAG/logs,target=/data/srv/wmagent/current/logs \
---mount type=bind,source=$HOST_MOUNT_DIR/admin/wmagent,target=/data/admin/wmagent/ \
---mount type=bind,source=$HOST_MOUNT_DIR/admin/group,target=/etc/group,readonly \
---mount type=bind,source=$HOST_MOUNT_DIR/admin/passwd,target=/etc/passwd,readonly \
+--mount type=bind,source=$HOST_MOUNT_DIR/admin/wmagent,target=/data/admin/wmagent \
+--mount type=bind,source=$HOST_MOUNT_DIR/admin/etc/passwd,target=/etc/passwd,readonly \
+--mount type=bind,source=$HOST_MOUNT_DIR/admin/etc/group,target=/etc/group,readonly \
 --mount type=bind,source=/etc/sudoers,target=/etc/sudoers,readonly \
 --mount type=bind,source=/etc/sudoers.d,target=/etc/sudoers.d,readonly \
 "
-
-wmaOpts="$wmaOpt $*"
 
 $PULL && {
     echo "Pulling Docker image: registry.cern.ch/cmsweb/wmagent:$WMA_TAG"
@@ -115,9 +112,9 @@ $PULL && {
 }
 
 echo "Checking if there is no other wmagent container running and creating a link to the $WMA_TAG in the host mount area."
-[[ `docker container inspect -f '{{.State.Status}}' wmagent 2>/dev/null ` == 'running' ]] || (
+[[ $(docker container inspect -f '{{.State.Status}}' wmagent 2>/dev/null) == 'running' ]] || (
     [[ -h $HOST_MOUNT_DIR/srv/wmagent/current ]] && rm -f $HOST_MOUNT_DIR/srv/wmagent/current
     ln -s $HOST_MOUNT_DIR/srv/wmagent/$WMA_TAG $HOST_MOUNT_DIR/srv/wmagent/current )
 
-echo "Starting the wmagent:$WMA_TAG docker container with the following parameters: $wmaOpts"
-docker run $dockerOpts local/wmagent:$WMA_TAG $wmaOpts
+echo "Starting wmagent:$WMA_TAG docker container with user: $wmaUser:$wmaGroup"
+docker run $dockerOpts local/wmagent:$WMA_TAG


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/11944
Superseeds https://github.com/dmwm/CMSKubernetes/pull/1464

First commit contains all the changes that Valentin has in #1464; while 2nd commit onward contains additional changes to get the whole setup working.

Short summary of the changes are:
* create a template for bashrc which will be copied over to the user running the container (remove bashrc juggling from the `install.sh` script)
* workaround account access based on SSSD daemon by juggling with /etc/passwd and /etc/group and mounting them into the container. Implemented in `wmagent-docker-run.sh` script.
* remove any referece to service accounts in the dockerfiles
* use the docker `--user` parameter to start up the container with the current/correct user.
* move cronjob creation to the `init.sh` script (to properly create it against the correct user)

Similar fixes have been provided to the `wmagent-couchdb` and `wmagent-mariadb` images.

TODO: at some point we should release a `latest` tag for CouchDB, to ensure the image does not get deleted by the automatic cmsweb retention policy.