### PR TITLE
Copy bashrc template instead of moving it, for wmagent

### DIFF
--- a/docker/pypi/wmagent/run.sh
+++ b/docker/pypi/wmagent/run.sh
@@ -13,7 +13,7 @@ export WMA_USER=$wmaUser
 export USER=$wmaUser
 [[ -d ${HOME} ]] || mkdir -p ${HOME}
 
-mv ${WMA_CONFIG_DIR}/etc/wmagent_bashrc $HOME/.bashrc
+cp -f ${WMA_DEPLOY_DIR}/etc/wmagent_bashrc $HOME/.bashrc
 source $HOME/.bashrc
 
 echo "Start initialization"


### PR DESCRIPTION
If we run the `wmagent` container multiple times with the same tag, it fails to create the `.bashrc` file, as can be seen in this log error:
```
mv: cannot stat '/data/srv/wmagent/2.3.3/config/etc/wmagent_bashrc': No such file or directory
./run.sh: line 17: /home/cmst1/.bashrc: No such file or directory
```

so instead of moving it out of the mounted directory, just copy it to ensure future docker run will be able to create it under the home directory.