### PR TITLE
Tune MariaDB settings for better performance

### DIFF
--- a/docker/pypi/wmagent-mariadb/README.md
+++ b/docker/pypi/wmagent-mariadb/README.md
@@ -67,6 +67,18 @@ local/mariadb              latest    4efa646aea3e   6 minutes ago    950MB
 ./mariadb-docker-build.sh -t 10.6.5 -p
 ```
 
+#### Building MariaDB on small nodes (e.g.: testbed)
+
+If you test on a machine/VM with less than 10G of memory, uncomment the following lines in my.cnf configuration
+(and comment the production ones for the same settings)
+
+```
+# Testbed (small nodes) with low memory
+#innodb_log_file_size=512M
+#innodb_log_buffer_size=8M
+#innodb_buffer_pool_size=2G
+```
+
 ### Running a MariaDB container
 
 We can run from the local repository or from upstream CERN registry. The typical

--- a/docker/pypi/wmagent-mariadb/my.cnf
+++ b/docker/pypi/wmagent-mariadb/my.cnf
@@ -46,9 +46,19 @@ innodb_checksum_algorithm=full_crc32
 # default: 1
 innodb_doublewrite=0
 
+
+# Production nodes
+# Settings based on benchmark tests:
+# https://gitlab.cern.ch/dmwm/wmcore-docs/-/blob/master/docs/databases/MariaDB-benchmark.md
 innodb_log_file_size=2G
 innodb_log_buffer_size=16M
 innodb_buffer_pool_size=8G
+
+# Testbed (small nodes) with low memory
+#innodb_log_file_size=512M
+#innodb_log_buffer_size=8M
+#innodb_buffer_pool_size=2G
+
 # default: 30
 innodb_sync_spin_loops=60
 # default: 0

--- a/docker/pypi/wmagent-mariadb/my.cnf
+++ b/docker/pypi/wmagent-mariadb/my.cnf
@@ -46,9 +46,9 @@ innodb_checksum_algorithm=full_crc32
 # default: 1
 innodb_doublewrite=0
 
-innodb_log_file_size=512M
-innodb_log_buffer_size=8M
-innodb_buffer_pool_size=2G
+innodb_log_file_size=2G
+innodb_log_buffer_size=16M
+innodb_buffer_pool_size=8G
 # default: 30
 innodb_sync_spin_loops=60
 # default: 0


### PR DESCRIPTION
Tune MariaDB settings for better performance
More details: https://github.com/dmwm/WMCore/issues/11977

The performance with these settings increased from -5 to 30% with these changes (comparing docker deployment on Alma9 vs CC7 RPM host-based deployment):
https://gitlab.cern.ch/dmwm/wmcore-docs/-/blob/master/docs/databases/MariaDB-benchmark.md 