### PR TITLE
Export USER and WMA_USER variables from $WMA_ENV_FILE

### DIFF
--- a/docker/pypi/wmagent/install.sh
+++ b/docker/pypi/wmagent/install.sh
@@ -144,6 +144,8 @@ export CRYPTOGRAPHY_ALLOW_OPENSSL_102=true
 export YUI_ROOT=$WMA_DEPLOY_DIR/yui/
 export PATH=\$WMA_INSTALL_DIR/bin\${PATH:+:\$PATH}
 export PATH=\$WMA_DEPLOY_DIR/bin\${PATH:+:\$PATH}
+export USER=\$(id -un)
+export WMA_USER=\$(id -un)
 EOF
 }
 


### PR DESCRIPTION
Fixes: https://github.com/dmwm/WMCore/issues/11989 

With the current PR we export  the USER and WMA_USER variables from the $WMA_ENV_FILE in parallel to `run.sh` in order to make no difference in the environment between
* Docker entry point - `run.sh` 
* bash login session  