### PR TITLE
Add _service_gracefull_exit function

### DIFF
--- a/docker/pypi/wmagent/run.sh
+++ b/docker/pypi/wmagent/run.sh
@@ -13,16 +13,20 @@ _find_child_pss() {
 _service_gracefull_exit() {
     # An auxiliary function to handle the WMAgent service graceful exit
     local childPss
-    _find_child_pss childPss
+
+    echo "Full list of currently running processes:"
+    ps auxf
 
     echo "Stopping WMAgent"
     manage stop-agent
 
-    echo "Killing all chilld Processes"
+    echo "List of all child processes upon agent graceful exit: $childPss"
+    _find_child_pss childPss
+
+    echo "Killing all chilld Processes ..."
     for proc in $childPss
     do
         echo killing process $proc
-        ps auxf |grep $proc
         kill -9 $proc
     done
 }

--- a/docker/pypi/wmagent/run.sh
+++ b/docker/pypi/wmagent/run.sh
@@ -3,16 +3,26 @@
 _find_child_pss() {
     # An auxiliary function to find all processes forked from the shell parrent
     # of the current process
-    cat  /proc/$PPID/task/*/children
+    # :param $1: The name of a variable to which the process list would be asssigned
+    # :return:   A list of child processes forked from the current one
+    local -n outList=$1;
+    local currPid=$$
+    outList=$(cat  /proc/$currPid/task/*/children)
 }
 
 _service_gracefull_exit() {
     # An auxiliary function to handle the WMAgent service graceful exit
-    manage stop-agent
-    wait
+    local childPss
+    _find_child_pss childPss
 
-    for proc in _find_child_pss
+    echo "Stopping WMAgent"
+    manage stop-agent
+
+    echo "Killing all chilld Processes"
+    for proc in $childPss
     do
+        echo killing process $proc
+        ps auxf |grep $proc
         kill -9 $proc
     done
 }

--- a/docker/pypi/wmagent/run.sh
+++ b/docker/pypi/wmagent/run.sh
@@ -20,8 +20,8 @@ _service_gracefull_exit() {
     echo "Stopping WMAgent"
     manage stop-agent
 
-    echo "List of all child processes upon agent graceful exit: $childPss"
     _find_child_pss childPss
+    echo "List of all child processes upon agent graceful exit: $childPss"
 
     echo "Killing all chilld Processes ..."
     for proc in $childPss


### PR DESCRIPTION
Fixes: https://github.com/dmwm/WMCore/issues/11979

With the current PR we  are finding all process left in the background to the Docker entrypoint and then upon a gracefull service exit we kill them all in case of trapping a signal sent to the main process.  