### PR TITLE
Find and gracefully stop WMAgent CouchDB processes

### DIFF
--- a/docker/pypi/wmagent-couchdb/manage
+++ b/docker/pypi/wmagent-couchdb/manage
@@ -283,9 +283,9 @@ start()
 stop()
 {
   echo "Stopping CouchDB service..."
-  for couch_pid in $(ps aux | grep '_couchdb' | egrep -v 'grep|couchdb\/manage|ps aux' | awk '{print $2}'); do
+  for couch_pid in $(ps aux | egrep 'couchdb|couchjs' | awk '{print $2}'); do
     echo "  killing CouchDB process... ${couch_pid}"
-    kill -9 $couch_pid || true
+    kill -s SIGTERM $couch_pid || true
   done
 }
 


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/11991

WMAgent CouchDB does not run under the _couchdb account, so I refactored the `ps aux` command and I also decided to change the SIGKILL by a more soft SIGTERM signal (even though [this post](https://github.com/apache/couchdb/issues/873) suggests a sigkill not to be a problem).

Just tested it and all of the couchdb/couchjs processes are terminated; I also tested restarting the CouchDB process and status and everything looks fine.