### PR TITLE
Add MSPileup Url to the agent initialization/configuration

### DIFF
--- a/docker/pypi/wmagent/README.md
+++ b/docker/pypi/wmagent/README.md
@@ -382,7 +382,7 @@ They are set at different moments along the process: i.e. at `buildtime` - when 
    * RUCIO_ACCOUNT=wma_test
    * RUCIO_HOST=http://cms-rucio-int.cern.ch
    * RUCIO_AUTH=https://cms-rucio-auth-int.cern.ch
-
+   * MSPILEUP_URL=https://cmsweb***.cern.ch/ms-pileup/data/pileup
 
 ## WMAgent operational actions
 Basic operational actions, such as agent restarts, may be performed from the host by killing or starting the docker container.

--- a/docker/pypi/wmagent/bin/manage
+++ b/docker/pypi/wmagent/bin/manage
@@ -149,7 +149,9 @@ init_wmagent(){
                        --amq_credentials=$AMQ_CREDENTIALS \
                        --rucio_account=$RUCIO_ACCOUNT \
                        --rucio_host=$RUCIO_HOST \
-                       --rucio_auth=$RUCIO_AUTH
+                       --rucio_auth=$RUCIO_AUTH \
+                       --mspileup_url=$MSPILEUP_URL
+
     let errVal+=$?
 
     wmcore-db-init --config $WMA_CONFIG_DIR/config.py --create --modules=WMCore.WMBS,WMCore.Agent.Database,WMComponent.DBS3Buffer,WMCore.BossAir,WMCore.ResourceControl;


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/11733 (old issue long closed!)
Deployment changes performed in https://github.com/dmwm/deployment/pull/1293, so this ticket makes similar changes but in the Docker-based deployment.

This PR provides a hook to update the MSPileup URL in the WMAgent configuration, as both Andrea and I noticed that it was not getting overwritten in WMA 2.3.4rc4.

PS.: I could update the badly indented lines, but that would likely cause a conflict with the other open PR for Tier0 (where Todor fixes that).