### PR TITLE
WМАgent switch deployment model copy runtime fix 11990

### DIFF
--- a/docker/pypi/wmagent/Dockerfile
+++ b/docker/pypi/wmagent/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile-upstream:master
 FROM registry.cern.ch/cmsweb/wmagent-base:pypi-20230705
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 
@@ -7,6 +8,15 @@ ARG WMA_TAG=$TAG
 ENV WMA_TAG=$WMA_TAG
 ENV WMA_ROOT_DIR=/data
 
+# Parsing the WMA_TAG in parts step by step
+ENV WMA_VER_MINOR=${WMA_TAG#*.*.}
+ENV WMA_VER_MAJOR=${WMA_TAG%.$WMA_VER_MINOR}
+ENV WMA_VER_MINOR=${WMA_VER_MINOR%rc*}
+ENV WMA_VER_MINOR=${WMA_VER_MINOR%.*}
+ENV WMA_VER_RELEASE=${WMA_VER_MAJOR}.${WMA_VER_MINOR}
+ENV WMA_VER_PATCH=${WMA_TAG#$WMA_VER_RELEASE}
+ENV WMA_VER_PATCH=${WMA_VER_PATCH#.}
+
 # Basic WMAgent directory structure passed to all scripts through env variables:
 # NOTE: Those should be static and depend only on $WMA_BASE_DIR
 ENV WMA_BASE_DIR=$WMA_ROOT_DIR/srv/wmagent
@@ -14,7 +24,7 @@ ENV WMA_ADMIN_DIR=$WMA_ROOT_DIR/admin/wmagent
 ENV WMA_CERTS_DIR=$WMA_ROOT_DIR/certs
 
 # ENV WMA_HOSTADMIN_DIR=$WMA_ADMIN_DIR/hostadmin
-ENV WMA_CURRENT_DIR=$WMA_BASE_DIR/$WMA_TAG
+ENV WMA_CURRENT_DIR=$WMA_BASE_DIR/$WMA_VER_RELEASE
 ENV WMA_AUTH_DIR=$WMA_CURRENT_DIR/auth/
 ENV WMA_INSTALL_DIR=$WMA_CURRENT_DIR/install
 ENV WMA_STATE_DIR=$WMA_CURRENT_DIR/state

--- a/docker/pypi/wmagent/bin/manage-common.sh
+++ b/docker/pypi/wmagent/bin/manage-common.sh
@@ -121,9 +121,9 @@ _exec_oracle() {
 _exec_sql() {
     case $AGENT_FLAVOR in
         'mysql')
-           _exec_mysql $*  ;;
+           _exec_mysql "$@" $wmaDBName ;;
         'oracle')
-           _exec_oracle $* ;;
+           _exec_oracle "$@" ;;
     esac
 }
 

--- a/docker/pypi/wmagent/bin/manage-common.sh
+++ b/docker/pypi/wmagent/bin/manage-common.sh
@@ -118,6 +118,15 @@ _exec_oracle() {
     fi
 }
 
+_exec_sql() {
+    case $AGENT_FLAVOR in
+        'mysql')
+           _exec_mysql $*  ;;
+        'oracle')
+           _exec_oracle $* ;;
+    esac
+}
+
 _init_valid(){
     # Auxiliary function to shorten repetitive compares of .init* files to the current WMA_BUILD_ID
     # :param $1: The full path to the .init* file to be checked.

--- a/docker/pypi/wmagent/init.sh
+++ b/docker/pypi/wmagent/init.sh
@@ -331,6 +331,26 @@ EOF
     echo "-----------------------------------------------------------------------"
 }
 
+check_wmatag() {
+    # NOTE: Before even start checking all the rest of the initialization flags we should
+    #       check if this agent has ever been used and if there is any patch version
+    #       or release candidate change between the current one and the one previously
+    #       initialized at the host. If so we should enforce Run time code copy.
+    # eval local -A wmaCurrVer=$(_parse_wmatag $WMA_TAG)
+    # eval local -A wmaPrevVer=$()
+    _init_valid $wmaInitSqlDB && {
+        echo "$FUNCNAME: This agent has been previously initialize. Checking for WMAgent version change since last run."
+        local wmaTagCurr=$WMA_TAG
+        local wmaTagSqlDB=$(_exec_sql "select init_value from wma_init where init_param = 'wma_tag';")
+        [[ $wmaTagCurr == $wmaTagSqlDB ]] || {
+            echo "$FUNCNAME: Found version change since last run: $wmaTagCurr vs. $wmaTagSqlDB"
+            echo "$FUNCNAME: Enforcing Runtime code check and copy if needed."
+            rm $wmaInitSqlDB
+        }
+    }
+    # Here we check the consistency of all initialization flags
+}
+
 check_wmagent_init() {
     # A function to check all previously populated */.init<step> files
     # from all previous steps and compare them with the /data/.wmaBuildId

--- a/docker/pypi/wmagent/init.sh
+++ b/docker/pypi/wmagent/init.sh
@@ -353,13 +353,13 @@ check_wmatag() {
     #       initialized at the host. If such discrepancy is confirmed, we should enforce Runtime
     #       code copy by deleting only the $wmaInitSqlDB and let the rest of the init process take over.
     _init_valid $wmaInitSqlDB && {
-        echo "$FUNCNAME: This agent has been previously initialize. Checking for WMAgent version change since last run."
+        echo "$FUNCNAME: This agent has been previously initialized. Checking for WMAgent version change since last run."
         local wmaTagCurr=$WMA_TAG
         local wmaTagSqlDB=$(_exec_sql "select init_value from wma_init where init_param = 'wma_tag';")
         [[ $wmaTagCurr == $wmaTagSqlDB ]] || {
             echo "$FUNCNAME: Found version change since last run: $wmaTagCurr vs. $wmaTagSqlDB"
             echo "$FUNCNAME: Enforcing Runtime code check and copy if needed."
-            rm $wmaInitSqlDB
+            rm $wmaInitRuntime
         }
     }
 }

--- a/docker/pypi/wmagent/install.sh
+++ b/docker/pypi/wmagent/install.sh
@@ -49,18 +49,18 @@ WMA_TAG_REG="^[0-9]+\.[0-9]+\.[0-9]{1,2}((\.|rc)[0-9]{1,2})?$"
 [[ $WMA_TAG =~ $WMA_TAG_REG ]] || { echo "WMA_TAG: $WMA_TAG does not match requered expression: $WMA_TAG_REG"; echo "EXIT with Error 1"  ; exit 1 ;}
 
 # Parsing the WMA_TAG
-declare -A WMA_VER
-WMA_VER[release]=$(echo $WMA_TAG| sed -nr 's/.*(^[0-9]+\.[0-9]+\.[0-9]+).*$/\1/p')
-WMA_VER[patch]=$(echo $WMA_TAG| sed -nr 's/.*(^[0-9]+\.[0-9]+\.[0-9]+)//p')
-WMA_VER[major]=$(echo $WMA_TAG| sed -nr 's/.*(^[0-9]+\.[0-9]+).*/\1/p')
-WMA_VER[minor]=$(echo $WMA_TAG| sed -nr 's/^[0-9]+\.[0-9]+\.([0-9]+).*$/\1/p')
+# declare -A WMA_VER
+# WMA_VER[release]=$(echo $WMA_TAG| sed -nr 's/.*(^[0-9]+\.[0-9]+\.[0-9]+).*$/\1/p')
+# WMA_VER[patch]=$(echo $WMA_TAG| sed -nr 's/.*(^[0-9]+\.[0-9]+\.[0-9]+)//p')
+# WMA_VER[major]=$(echo $WMA_TAG| sed -nr 's/.*(^[0-9]+\.[0-9]+).*/\1/p')
+# WMA_VER[minor]=$(echo $WMA_TAG| sed -nr 's/^[0-9]+\.[0-9]+\.([0-9]+).*$/\1/p')
 
 echo
 echo "======================================================================="
 echo "Starting new WMAgent deployment with the following initialisation data:"
 echo "-----------------------------------------------------------------------"
 echo " - WMAgent Version            : $WMA_TAG"
-echo " - WMAgent Release Cycle      : ${WMA_VER[release]}"
+echo " - WMAgent Release Cycle      : $WMA_VER_RELEASE"
 echo " - WMAgent User               : $WMA_USER"
 echo " - WMAgent Root path          : $WMA_ROOT_DIR"
 echo " - Python  Version            : $(python --version)"
@@ -114,9 +114,10 @@ stepMsg="Generating and preserving current build id"
 echo "-----------------------------------------------------------------------"
 echo "Start $stepMsg"
 
-echo ${WMA_VER[release]} | sha256sum | awk '{print $1}' > $WMA_ROOT_DIR/.wmaBuildId
+echo $WMA_VER_RELEASE | sha256sum | awk '{print $1}' > $WMA_ROOT_DIR/.wmaBuildId
 echo "WMA_BUILD_ID:`cat $WMA_ROOT_DIR/.wmaBuildId`"
 echo "WMA_BUILD_ID preserved at: $WMA_ROOT_DIR/.wmaBuildId "
+
 echo "Done $stepMsg!" && echo
 echo "-----------------------------------------------------------------------"
 

--- a/docker/pypi/wmagent/install.sh
+++ b/docker/pypi/wmagent/install.sh
@@ -48,13 +48,6 @@ done
 WMA_TAG_REG="^[0-9]+\.[0-9]+\.[0-9]{1,2}((\.|rc)[0-9]{1,2})?$"
 [[ $WMA_TAG =~ $WMA_TAG_REG ]] || { echo "WMA_TAG: $WMA_TAG does not match requered expression: $WMA_TAG_REG"; echo "EXIT with Error 1"  ; exit 1 ;}
 
-# Parsing the WMA_TAG
-# declare -A WMA_VER
-# WMA_VER[release]=$(echo $WMA_TAG| sed -nr 's/.*(^[0-9]+\.[0-9]+\.[0-9]+).*$/\1/p')
-# WMA_VER[patch]=$(echo $WMA_TAG| sed -nr 's/.*(^[0-9]+\.[0-9]+\.[0-9]+)//p')
-# WMA_VER[major]=$(echo $WMA_TAG| sed -nr 's/.*(^[0-9]+\.[0-9]+).*/\1/p')
-# WMA_VER[minor]=$(echo $WMA_TAG| sed -nr 's/^[0-9]+\.[0-9]+\.([0-9]+).*$/\1/p')
-
 echo
 echo "======================================================================="
 echo "Starting new WMAgent deployment with the following initialisation data:"


### PR DESCRIPTION
Fixes: https://github.com/dmwm/WMCore/issues/11990

With the current PR we are changing few more things in addition to change of behavior for triggering the agent initialization process only on release change, but rather on any change in the patch version or release candidate.
The additional changes are as follows:

* We shift and now we base the host mount point on the release version, rather than on the full `WMA_TAG` as up to now
* We Enforce copying the Runtime code in case the following two conditions are fulfilled:
    * The agent has been previously initialized
    * There is a change between the full WMA_TAG of the currently starting container and the one previously initialized at the host in the mount area pointed by the current release.        