### PR TITLE
MariaDB/CouchDB: Add _service_gracefull_exit function

### DIFF
--- a/docker/pypi/wmagent-couchdb/Dockerfile
+++ b/docker/pypi/wmagent-couchdb/Dockerfile
@@ -11,6 +11,9 @@ RUN apt-get update && apt-get install -y vim less sudo wget unzip python pip
 # # Install some debugging tools
 RUN apt-get install -y hostname net-tools iputils-ping procps emacs-nox tcpdump && apt-get clean
 
+# Install recursive ps utility tool
+RUN apt-get install -y pslist && apt-get clean
+
 RUN pip install CMSCouchapp
 
 ENV COUCH_PORT=5984

--- a/docker/pypi/wmagent-mariadb/Dockerfile
+++ b/docker/pypi/wmagent-mariadb/Dockerfile
@@ -7,7 +7,7 @@ ENV MDB_TAG=$MDB_TAG
 RUN echo MDB_TAG=$MDB_TAG
 
 RUN apt-get update && apt-get install -y vim less sudo wget unzip python3 pip \
-    hostname net-tools iputils-ping procps emacs-nox tcpdump && apt-get clean
+    hostname net-tools iputils-ping procps emacs-nox tcpdump pslist && apt-get clean
 
 # ENV MDB_PORT=
 ENV MDB_ROOT_DIR=/data


### PR DESCRIPTION
Fixes: https://github.com/dmwm/WMCore/issues/11979
(for MariaDB/CouchDB services)

MariaDB/CouchDB: Kill all leftover children when invoking `docker stop`
When `docker stop` invokes the SIGTERM signal, services will be stopped and leftover children from the main run.sh process will be killed with rkill. Dependency: pslist (part of the docker image).