### PR TITLE
Update WMAgent dockerfile with a new tag for wmagent-base

### DIFF
--- a/docker/pypi/wmagent/Dockerfile
+++ b/docker/pypi/wmagent/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile-upstream:master
-FROM registry.cern.ch/cmsweb/wmagent-base:pypi-20230705
+FROM registry.cern.ch/cmsweb/wmagent-base:pypi-20240524
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 
 # TAG to be passed at build time through `--build-arg TAG=<WMA_TAG>`. Default: None


### PR DESCRIPTION
Follow up of https://github.com/dmwm/CMSKubernetes/pull/1488

Now that a new `wmagent-base` image is available:
https://registry.cern.ch/harbor/projects/1771/repositories/wmagent-base/artifacts-tab

update the wmagent Dockerfile as well.