### PR TITLE
crabserver - 2threads/pod

### DIFF
--- a/helm/crabserver/values.yaml
+++ b/helm/crabserver/values.yaml
@@ -18,6 +18,8 @@ image:
   env:
   - name: CRABSERVER_LOGSTDOUT
     value: "t"
+  - name: CRABSERVER_THREAD_POOL
+    value: "2"
 
 environment:
 


### PR DESCRIPTION
Persist in helm configuration that we are runnning with 2threads/pod, as it already is in production since about a month already. my bad for not committing this earlier.

So @arooshap this can safely be merged already without any checks :)