### PR TITLE
Fix check for docker environment in wmagent

### DIFF
--- a/docker/pypi/wmagent/bin/manage-common.sh
+++ b/docker/pypi/wmagent/bin/manage-common.sh
@@ -38,7 +38,7 @@ _is_venv() {
 
 _is_docker() {
     # Auxiliary function to determine if we are running within a docker env
-    [[ -f /.dockerenv ]] && grep -q docker /proc/1/cgroup
+    [[ -f /.dockerenv ]]
 }
 
 _exec_mysql() {


### PR DESCRIPTION
Fix regression inserted by https://github.com/dmwm/CMSKubernetes/pull/1466

The current implementation does not work as expected, as I managed to find through the run logs (or jobs failing to find the Unpacker.py module):
```
-------------------------------------------------------
Start: Performing agent_tweakconfig
agent_tweakconfig: triggered.
agent_tweakconfig: Making other agent configuration changes
Done: Performing agent_tweakconfig
-------------------------------------------------------
```

Reason is that that grep command returns exit status 1, hence not identifying docker environments as docker (issue visible in WMAgent 2.3.4rc5).