### PR TITLE
Fix CouchDB manage restart option

### DIFF
--- a/docker/pypi/wmagent-couchdb/manage
+++ b/docker/pypi/wmagent-couchdb/manage
@@ -266,12 +266,12 @@ sysboot()
 # Start the service.
 start()
 {
+  echo "Starting CouchDB service..."
   _parse_localini $COUCH_CONFIG_DIR/local.ini || { echo "$FUNCNAME: ERROR: Not configured database. Try manage init first"; return 1 ;}
   cd $STATEDIR
-  echo -n "Which couchdb: "
-  which couchdb
-  echo "  With configuration directory: $CFGDIR"
-  echo "  With logdir: $LOGDIR"
+  echo "  which couchdb:           $(which couchdb)"
+  echo "  configuration directory: $CFGDIR"
+  echo "  log directory:           $LOGDIR"
   echo "  nohup couchdb -couch_ini $CFGDIR >> ${LOGDIR}/couch.log 2>&1 &"
   nohup couchdb -couch_ini $CFGDIR >> ${LOGDIR}/couch.log 2>&1 &
 
@@ -283,7 +283,7 @@ start()
 stop()
 {
   echo "Stopping CouchDB service..."
-  for couch_pid in $(ps aux | egrep 'couchdb|couchjs' | awk '{print $2}'); do
+  for couch_pid in $(ps aux | grep -E 'couchdb|couchjs' | grep -Ev 'grep|/manage' | awk '{print $2}'); do
     echo "  killing CouchDB process... ${couch_pid}"
     kill -s SIGTERM $couch_pid || true
   done

--- a/docker/pypi/wmagent/etc/wmagent_bashrc
+++ b/docker/pypi/wmagent/etc/wmagent_bashrc
@@ -12,6 +12,18 @@ alias condorqrunning='condor_q -constraint JobStatus==2 -format "%i." ClusterID 
 alias runningagent="ps aux | egrep 'couch|wmcore|mysql|beam'"
 alias foldersize="du -h --max-depth=1 | sort -hr"
 
+# agent operations
+alias wma_unregister='manage execute-agent wmagent-unregister-wmstats $(hostname -f)'
+alias wma_stop_component='manage execute-agent wmcoreD --shutdown --component '   # comma separated component names
+alias wma_start_component='manage execute-agent wmcoreD --start --component '     # comma separated component names
+alias wma_restart_component='manage execute-agent wmcoreD --restart --component ' # comma separated component names
+
+# agent drain check
+alias wma_drain='python /usr/local/bin/adhoc-scripts/drainAgent.py'
+
+# agent tail of all component logs
+alias wma_tail_logs='for comp in $(ls $WMA_INSTALL_DIR | grep -v Docker); do echo $comp; tail -n100 $WMA_INSTALL_DIR/$comp/ComponentLog; echo ""; done | less'
+
 # Better curl command
 alias scurl='curl -k --cert ${WMA_CERTS_DIR}/servicecert.pem --key ${WMA_CERTS_DIR}/servicekey.pem'
 


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/11945

* 1st commit resolves a regression injected with https://github.com/dmwm/CMSKubernetes/pull/1484, which makes the manage script terminates itself when executing the `stop` function. With this fix, when listing couchdb processes with grep, we filter out `grep` and `/manage` now.
* 2nd commit adds some useful aliases to the bashrc template copied to the container. Note that the condor aliases could be deleted, given that we don't have any of the condor binaries in the path.