### PR TITLE
WMAgent: Install voms-clients-java (same package used in FNAL/CERN hosts)

### DIFF
--- a/docker/pypi/wmagent-base/Dockerfile
+++ b/docker/pypi/wmagent-base/Dockerfile
@@ -3,7 +3,7 @@ FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230525
 
 # Install basic OS package dependencies
 RUN apt-get update
-RUN apt-get install -y libmariadb-dev-compat libmariadb-dev apache2-utils cron mariadb-server myproxy voms-clients rlwrap libaio1 && apt-get clean
+RUN apt-get install -y libmariadb-dev-compat libmariadb-dev apache2-utils cron mariadb-server myproxy voms-clients voms-clients-java rlwrap libaio1 && apt-get clean
 
 # Install some debugging tools
 RUN apt-get install -y hostname net-tools iputils-ping procps && apt-get clean


### PR DESCRIPTION
Fixes [Fixes #11999](https://github.com/dmwm/WMCore/issues/11999)
With a newer version (java based) of voms-proxy-init. This is the same voms clients used by FNAL hosts (3.x)

CPP version:
$ voms-proxy-init2 --version
voms-proxy-init
Version: 2.1.0
Compiled: Jul 24 2020 08:53:00

Java version:
$ voms-proxy-init --version
voms-proxy-init v. 3.3.2 (voms-api-java/3.3.2 canl/2.6.0 bcprov/1.68.0 bcpkix/1.68.00.0)