### PR TITLE
Enable cron service; save env vars into /etc/environment

### DIFF
--- a/docker/pypi/wmagent/run.sh
+++ b/docker/pypi/wmagent/run.sh
@@ -34,11 +34,17 @@ export WMA_USER=$wmaUser
 export USER=$wmaUser
 [[ -d ${HOME} ]] || mkdir -p ${HOME}
 
+echo "Saving environment variables into /etc/environment"
+printenv > /etc/environment && chmod 666 /etc/environment
+
 cp -f ${WMA_DEPLOY_DIR}/etc/wmagent_bashrc $HOME/.bashrc
 source $HOME/.bashrc
 
 echo "Start initialization"
 $WMA_ROOT_DIR/init.sh | tee -a $WMA_LOG_DIR/init.log || true
+
+echo "Starting cron service"
+sudo service cron restart
 
 echo "Start sleeping now ...zzz..."
 sleep infinity &

--- a/docker/pypi/wmagent/wmagent-docker-run.sh
+++ b/docker/pypi/wmagent/wmagent-docker-run.sh
@@ -81,6 +81,12 @@ if ! [ -f $HOST_MOUNT_DIR/admin/etc/group ]; then
     echo $groupEntry >> $HOST_MOUNT_DIR/admin/etc/group
 fi
 
+# workaround for being able to start cron service with ordinary user
+if ! [ -f $HOST_MOUNT_DIR/admin/etc/sudoers ]; then
+    echo "Creating sudoers file"
+    echo "$wmaUser ALL=(ALL:ALL) NOPASSWD: ALL" >> $HOST_MOUNT_DIR/admin/etc/sudoers
+fi
+
 # create regular mount points at runtime
 [[ -d $HOST_MOUNT_DIR/admin/wmagent ]] || (mkdir -p $HOST_MOUNT_DIR/admin/wmagent) || exit $?
 [[ -d $HOST_MOUNT_DIR/srv/wmagent/$WMA_VER_RELEASE/install ]] || (mkdir -p $HOST_MOUNT_DIR/srv/wmagent/$WMA_VER_RELEASE/install) || exit $?
@@ -108,8 +114,7 @@ $tnsMount \
 --mount type=bind,source=$HOST_MOUNT_DIR/admin/wmagent,target=/data/admin/wmagent \
 --mount type=bind,source=$HOST_MOUNT_DIR/admin/etc/passwd,target=/etc/passwd,readonly \
 --mount type=bind,source=$HOST_MOUNT_DIR/admin/etc/group,target=/etc/group,readonly \
---mount type=bind,source=/etc/sudoers,target=/etc/sudoers,readonly \
---mount type=bind,source=/etc/sudoers.d,target=/etc/sudoers.d,readonly \
+--mount type=bind,source=$HOST_MOUNT_DIR/admin/etc/sudoers,target=/etc/sudoers,readonly \
 "
 
 $PULL && {


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/12000

Enable cron service in the Dockerfile;
And save environment variables into `/etc/environment`, which AFAIU is used when executing crontab.