### PR TITLE
Fixes wmagent tagging during run.sh; aesthetic changes

### DIFF
--- a/docker/pypi/wmagent/etc/wmagent_bashrc
+++ b/docker/pypi/wmagent/etc/wmagent_bashrc
@@ -17,6 +17,7 @@ alias wma_unregister='manage execute-agent wmagent-unregister-wmstats $(hostname
 alias wma_stop_component='manage execute-agent wmcoreD --shutdown --component '   # comma separated component names
 alias wma_start_component='manage execute-agent wmcoreD --start --component '     # comma separated component names
 alias wma_restart_component='manage execute-agent wmcoreD --restart --component ' # comma separated component names
+alias wma_resource_control='manage execute-agent wmagent-resource-control -p --site-name '  # + site name
 
 # agent drain check
 alias wma_drain='python /usr/local/bin/adhoc-scripts/drainAgent.py'

--- a/docker/pypi/wmagent/init.sh
+++ b/docker/pypi/wmagent/init.sh
@@ -313,6 +313,7 @@ check_databases() {
 
     # Checking CouchDB:
     _check_couch
+    echo "-----------------------------------------------------------------------"
 }
 
 set_cronjob() {
@@ -658,7 +659,7 @@ main(){
         echo
         echo "     b) From the host - by restarting the whole container"
         echo "          * Kill the currently running container:"
-        echo "            docker kill wmagent"
+        echo "            docker stop wmagent -t 30"
         echo "          * Start a fresh instance of wmagent:"
         echo "            ./wmagent-docker-run.sh -t <WMA_TAG> && docker logs -f wmagent"
         echo

--- a/docker/pypi/wmagent/wmagent-docker-run.sh
+++ b/docker/pypi/wmagent/wmagent-docker-run.sh
@@ -112,12 +112,17 @@ $tnsMount \
 --mount type=bind,source=/etc/sudoers.d,target=/etc/sudoers.d,readonly \
 "
 
+registry=local
+repository=wmagent
 $PULL && {
+    registry=registry.cern.ch
+    project=cmsweb
+    repository=wmagent
     echo "Pulling Docker image: registry.cern.ch/cmsweb/wmagent:$WMA_TAG"
     docker login registry.cern.ch
-    docker pull registry.cern.ch/cmsweb/wmagent:$WMA_TAG
-    docker tag registry.cern.ch/cmsweb/wmagent:$WMA_TAG local/wmagent:$WMA_TAG
-    docker tag registry.cern.ch/cmsweb/wmagent:$WMA_TAG local/wmagent:latest
+    docker pull $registry/$project/$repository:$WMA_TAG
+    docker tag $registry/$project/$repository:$WMA_TAG $registry/$repository:$WMA_TAG
+    docker tag $registry/$project/$repository:$WMA_TAG $registry/$repository:latest
 }
 
 echo "Checking if there is no other wmagent container running and creating a link to the $WMA_VER_RELEASE in the host mount area."
@@ -126,4 +131,4 @@ echo "Checking if there is no other wmagent container running and creating a lin
     ln -s $HOST_MOUNT_DIR/srv/wmagent/$WMA_VER_RELEASE $HOST_MOUNT_DIR/srv/wmagent/current )
 
 echo "Starting wmagent:$WMA_TAG docker container with user: $wmaUser:$wmaGroup"
-docker run $dockerOpts local/wmagent:$WMA_TAG
+docker run $dockerOpts $registry/$repository:$WMA_TAG


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/11992

Short summary of changes:
* added another alias to bashrc called `wma_resource_control`, to print resource information from the database;
* fix tagging of the wmagent image on the running node (which was always reporting as local/wmagent)