### PR TITLE
Do not push central couchapps into WMAgent CouchDB

### DIFF
--- a/docker/pypi/wmagent-couchdb/run.sh
+++ b/docker/pypi/wmagent-couchdb/run.sh
@@ -48,7 +48,7 @@ source ${HOME}/.bashrc
 
 manage init      | tee -a $COUCH_LOG_DIR/run.log
 manage start     | tee -a $COUCH_LOG_DIR/run.log
-manage pushapps  | tee -a $COUCH_LOG_DIR/run.log
+#manage pushapps  | tee -a $COUCH_LOG_DIR/run.log
 
 echo "start sleeping....zzz"
 sleep infinity &


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/11945 (well, one of the fixes)

For WMAgent, we do not need to push the same couchapps (and same databases) that are created in central CouchDB, given that WMAgent initializes that with `wmagent-couchapp-init`, here: https://github.com/dmwm/CMSKubernetes/blob/86492bf/docker/pypi/wmagent/bin/manage#L160