### PR TITLE
Update wmagent-base image to tag 20240604, including voms-clients-java

### DIFF
--- a/docker/pypi/wmagent/Dockerfile
+++ b/docker/pypi/wmagent/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile-upstream:master
-FROM registry.cern.ch/cmsweb/wmagent-base:pypi-20240524
+FROM registry.cern.ch/cmsweb/wmagent-base:pypi-20240604
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 
 # TAG to be passed at build time through `--build-arg TAG=<WMA_TAG>`. Default: None


### PR DESCRIPTION
Complement to https://github.com/dmwm/CMSKubernetes/pull/1497

I have just uploaded this new image to CERN registry: `wmagent-base:pypi-20240604` . It increased the image size (compressed in the registry) from 546MiB to 617MiB.

Note that the WMAgent docker image `2.3.4rc8` was built with the old `pypi-20240524` tag, so I will have to rebuild it and overwrite it in CERN registry once these changes go in.