### PR TITLE
Make APS run on standard 443 port and use X509 for auth

### DIFF
--- a/kubernetes/cmsweb/daemonset/auth-proxy-server.yaml
+++ b/kubernetes/cmsweb/daemonset/auth-proxy-server.yaml
@@ -60,11 +60,15 @@ spec:
         # NOTE: to migrate CMSWEB frontend to Go APS using x509 auth on port 443
         #       we explicitly specify this port and -useX509 flag below
         #       when we'll transition to tokens we should remove these two options
+        # NOTE: we explicitly use port, metricsPort and logFile options
+        #       to re-use single config.json between APS and XPS
         args:
           - /data/auth-proxy-server
           - -config=/etc/secrets/config.json
           - -port=443
           - -useX509
+          - -metricsPort=9091
+          - -logFile=/data/srv/logs/frontend/auth-proxy-server.log
         resources:
           requests:
             memory: "50Mi"

--- a/kubernetes/cmsweb/daemonset/auth-proxy-server.yaml
+++ b/kubernetes/cmsweb/daemonset/auth-proxy-server.yaml
@@ -57,9 +57,14 @@ spec:
       - image: registry.cern.ch/cmsweb/auth-proxy-server #imagetag
         name: auth-proxy-server
 #         imagePullPolicy: Always
+        # NOTE: to migrate CMSWEB frontend to Go APS using x509 auth on port 443
+        #       we explicitly specify this port and -useX509 flag below
+        #       when we'll transition to tokens we should remove these two options
         args:
           - /data/auth-proxy-server
           - -config=/etc/secrets/config.json
+          - -port=443
+          - -useX509
         resources:
           requests:
             memory: "50Mi"

--- a/kubernetes/cmsweb/daemonset/x509-proxy-server.yaml
+++ b/kubernetes/cmsweb/daemonset/x509-proxy-server.yaml
@@ -66,10 +66,15 @@ spec:
       - image: registry.cern.ch/cmsweb/auth-proxy-server #imagetag
         name: x509-proxy-server
 #         imagePullPolicy: Always
+        # NOTE: we explicitly use port, metricsPort and logFile options
+        #       to re-use single config.json between APS and XPS
         args:
           - /data/auth-proxy-server
           - -config=/etc/secrets/config.json
           - -useX509
+          - -port=8443
+          - -metricsPort=9092
+          - -logFile=/data/srv/logs/frontend/x509-proxy-server.log
         resources:
           requests:
             memory: "50Mi"

--- a/kubernetes/cmsweb/services/auth-proxy-server.yaml
+++ b/kubernetes/cmsweb/services/auth-proxy-server.yaml
@@ -42,11 +42,15 @@ spec:
         # NOTE: to migrate CMSWEB frontend to Go APS using x509 auth on port 443
         #       we explicitly specify this port and -useX509 flag below
         #       when we'll transition to tokens we should remove these two options
+        # NOTE: we explicitly use port, metricsPort and logFile options
+        #       to re-use single config.json between APS and XPS
         args:
           - /data/auth-proxy-server
           - -config=/etc/secrets/config.json
           - -port=443
           - -useX509
+          - -metricsPort=9091
+          - -logFile=/data/srv/logs/frontend/auth-proxy-server.log
         resources:
           requests:
             memory: "256Mi"

--- a/kubernetes/cmsweb/services/auth-proxy-server.yaml
+++ b/kubernetes/cmsweb/services/auth-proxy-server.yaml
@@ -39,9 +39,14 @@ spec:
       - image: registry.cern.ch/cmsweb/auth-proxy-server:20200714-x509
         name: auth-proxy-server
         imagePullPolicy: Always
+        # NOTE: to migrate CMSWEB frontend to Go APS using x509 auth on port 443
+        #       we explicitly specify this port and -useX509 flag below
+        #       when we'll transition to tokens we should remove these two options
         args:
           - /data/auth-proxy-server
           - -config=/etc/secrets/config.json
+          - -port=443
+          - -useX509
         resources:
           requests:
             memory: "256Mi"

--- a/kubernetes/cmsweb/services/x509-proxy-server.yaml
+++ b/kubernetes/cmsweb/services/x509-proxy-server.yaml
@@ -39,10 +39,15 @@ spec:
       - image: registry.cern.ch/cmsweb/auth-proxy-server:20200714-x509
         name: x509-proxy-server
         imagePullPolicy: Always
+        # NOTE: we explicitly use port, metricsPort and logFile options
+        #       to re-use single config.json between APS and XPS
         args:
           - /data/auth-proxy-server
           - -config=/etc/secrets/config.json
           - -useX509
+          - -port=8443
+          - -metricsPort=9092
+          - -logFile=/data/srv/logs/frontend/x509-proxy-server.log
         resources:
           requests:
             memory: "256Mi"


### PR DESCRIPTION
To perform migration from CC7 to Alma9 we have two options:
- use Go based APS with x509 on standard port (443), or
- migrate apache with CMS patches

This PR implements necessary changes for former solution (APS+X509). I put appropriate comment about added options for APS. It also requires APS version 0.2.49 or above (current version is 0.2.50) where support for port option was provided. In this version the port option will overwrite port provided via configuration and therefore it allows us to re-use single configuration for both APS+X509 and XPS servers. The unification of configuration should be done within gitlab repo.

@arooshap please review and we can merge the changes. I'll provide further details via private chat.