### PR TITLE
Start cron daemon with root externally upon docker run

### DIFF
--- a/docker/pypi/wmagent/Dockerfile
+++ b/docker/pypi/wmagent/Dockerfile
@@ -62,5 +62,8 @@ EOF
 # allow dynamic users to create homefolders and .bashrc
 RUN chmod 777 /home
 
+# preserve the whole env for later use by the cron daemon
+RUN env > /etc/environment
+
 # Define the entrypoint (Using exec form):
 ENTRYPOINT ["./run.sh", "2>&1"]

--- a/docker/pypi/wmagent/init.sh
+++ b/docker/pypi/wmagent/init.sh
@@ -59,6 +59,7 @@ echo " - WMAgent Number             : $AGENT_NUMBER"
 echo " - WMAgent Relational DB type : $AGENT_FLAVOR"
 echo " - Python  Version            : $(python --version)"
 echo " - Python  Module path        : $pythonLib"
+echo " - Current time               : $(date -Im)"
 echo "======================================================="
 echo
 
@@ -324,14 +325,14 @@ set_cronjob() {
 
     # Populating proxy related cronjobs
     crontab -u $WMA_USER - <<EOF
-55 */12 * * * $WMA_MANAGE_DIR/manage renew-proxy
+55 */12 * * * date -Im >> $WMA_LOG_DIR/renew-proxy.log && $WMA_MANAGE_DIR/manage renew-proxy 2>&1 >> $WMA_LOG_DIR/renew-proxy.log
 58 */12 * * * python $WMA_DEPLOY_DIR/deploy/checkProxy.py --proxy /data/certs/myproxy.pem --time 120 --send-mail True --mail alan.malta@cern.ch
 */15 * * * *  source $WMA_DEPLOY_DIR/deploy/restartComponent.sh > /dev/null
 EOF
     let errVal+=$?
 
     # Populating CouchDB related cronjobs
-    wmagent-couchapp-init
+    wmagent-couchapp-init --only-cron
     let errVal+=$?
 
     [[ $errVal -eq 0 ]] || {

--- a/docker/pypi/wmagent/wmagent-docker-run.sh
+++ b/docker/pypi/wmagent/wmagent-docker-run.sh
@@ -132,3 +132,4 @@ echo "Checking if there is no other wmagent container running and creating a lin
 
 echo "Starting wmagent:$WMA_TAG docker container with user: $wmaUser:$wmaGroup"
 docker run $dockerOpts $registry/$repository:$WMA_TAG
+docker exec -u root -it wmagent service cron start


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/12000

Due to the lack of normal `sysVinit` or `systemd` mechanisms enabled in the docker containers (a concept and a standard design choice for any containerized environment, not just ours)  we must think in one the following three  direction in order to fix the issue at hand:
* Either to run the `cron` daemon from inside the container, regardless if it is about to be forked  from the `run.sh` process  with some environment equilibritic to give `sudo` access to the apriory unknown user at runtime, or it is about to be started through the use of the standard init scripts coming with the `cron` package itself which should be executed as root through an external call to the container upon docker run.
* Or to run the `cron` daemon from an external container and juggle with inter container communication through extra mount points  etc.
* Or to run the `cron` daemon at the host and again increase the host to container communication through extra mount points and alternatives.     

With the current change we suggest an extra operation upon starting the container to fire up the `cron` daemon through the normal init scripts which come with the standard `cron` package. The command should be executed through a connection to the container with root. Upon that the daemon gets into its normal operational mode. 