### PR TITLE
Support deployment of a new crabserver pypi image

### DIFF
--- a/helm/crabserver/templates/deployment.yaml
+++ b/helm/crabserver/templates/deployment.yaml
@@ -50,8 +50,14 @@ spec:
             name: crabserver-mon
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.image.command }}
           command:
           {{- toYaml .Values.image.command | nindent 10 }}
+          {{- end }}
+          {{- if .Values.image.args }}
+          args:
+          {{- toYaml .Values.image.args | nindent 10 }}
+          {{- end }}
           env:
           {{- toYaml .Values.image.env | nindent 10 }}
           livenessProbe:

--- a/helm/crabserver/values-test12-pypi.yaml
+++ b/helm/crabserver/values-test12-pypi.yaml
@@ -1,0 +1,26 @@
+---
+environment: "test"
+
+image:
+  path: registry.cern.ch/cmscrab/crabserver
+  pullPolicy: IfNotPresent
+  tag: "pypi-devthree-1715075269"
+  command:
+    - /data/entrypoint.sh
+  args:
+    - /bin/bash
+    - -c
+    - |
+        sudo cp /host/etc/grid-security/* /etc/grid-security \
+        && echo 'INFO Files in /etc/grid-security' \
+        && ls -lahZ /etc/grid-security \
+        && /data/run.sh
+
+# disable liveness/readiness
+# https://helm.sh/docs/chart_template_guide/values_files/#deleting-a-default-key
+livenessProbePreProd: null
+readinessProbePreProd: null
+livenessProbeTest: null
+readinessProbeTest: null
+livenessProbe: null
+readinessProbe: null

--- a/helm/crabserver/values-test12.yaml
+++ b/helm/crabserver/values-test12.yaml
@@ -1,0 +1,14 @@
+---
+environment: "test"
+
+image:
+  tag: "v3.240530"
+
+# disable liveness/readiness
+# https://helm.sh/docs/chart_template_guide/values_files/#deleting-a-default-key
+livenessProbePreProd: null
+readinessProbePreProd: null
+livenessProbeTest: null
+readinessProbeTest: null
+livenessProbe: null
+readinessProbe: null


### PR DESCRIPTION
Relate to https://github.com/dmwm/CRABServer/issues/8267 

The current helm allows overriding the `command` key, but not `args` of the container specs. This PR allows you to override both. If the value(s) is absent, the corresponding key will not be generated.

