### PR TITLE
Add auth-proxy-server logstash rules

### DIFF
--- a/kubernetes/cmsweb/daemonset/auth-proxy-server.yaml
+++ b/kubernetes/cmsweb/daemonset/auth-proxy-server.yaml
@@ -17,6 +17,7 @@ data:
       scan_frequency: 10s
       backoff: 5s
       max_backoff: 10s
+      tags: ["aps"]
     output.console:
       codec.format:
         string: '%{[message]} - Podname=${MY_POD_NAME}'

--- a/kubernetes/cmsweb/monitoring/logstash.conf
+++ b/kubernetes/cmsweb/monitoring/logstash.conf
@@ -76,7 +76,7 @@ filter {
       mutate { gsub =>  [ "dn","/CN=\d+","" ] }
   }
 
-  if "aps-s3" in [tags] {
+  if "aps" in [tags] {
       mutate { replace => { "type" => "aps" } }
       grok {
         match => { "message" => '\[%{TIMESTAMP_ISO8601:tstamp}\] %{DATA:httpversion} %{NUMBER:code:int} %{WORD:method} %{NOTSPACE:request} \[data: %{NUMBER:bytes_received:int} in %{NUMBER:bytes_sent:int} out\] \[host: %{IPORHOST:frontend}:%{NUMBER:fe_port}\] \[remoteAddr: %{IPORHOST:clientip}:%{NUMBER:clientport:int}\] \[X-Forwarded-For: %{IPORHOST:x_forwarded_ip}:%{NUMBER:x_forwarded_port:int}\] \[X-Forwarded-Host: %{HOSTNAME:x_forwarded_host}\] \[auth: %{DATA:tls} %{DATA:crypto} "%{DATA:dn}" %{DATA:auth_name} %{WORD:auth_protocol}\] \[ref: "%{DATA:cluster}" "%{DATA:client}"\] \[req: %{NUMBER:request_time:float} \(s\) proxy-resp: %{NUMBER:proxy_resp_time:float} \(s\)\]' }

--- a/kubernetes/cmsweb/monitoring/logstash.conf
+++ b/kubernetes/cmsweb/monitoring/logstash.conf
@@ -76,7 +76,8 @@ filter {
       mutate { gsub =>  [ "dn","/CN=\d+","" ] }
   }
 
-  if "aps" in [tags] {
+  if "aps-s3" in [tags] {
+      mutate { replace => { "type" => "aps" } }
       grok {
         match => { "message" => '\[%{TIMESTAMP_ISO8601:tstamp}\] %{DATA:httpversion} %{NUMBER:code:int} %{WORD:method} %{NOTSPACE:request} \[data: %{NUMBER:bytes_received:int} in %{NUMBER:bytes_sent:int} out\] \[host: %{IPORHOST:frontend}:%{NUMBER:fe_port}\] \[remoteAddr: %{IPORHOST:clientip}:%{NUMBER:clientport:int}\] \[X-Forwarded-For: %{IPORHOST:x_forwarded_ip}:%{NUMBER:x_forwarded_port:int}\] \[X-Forwarded-Host: %{HOSTNAME:x_forwarded_host}\] \[auth: %{DATA:tls} %{DATA:crypto} "%{DATA:dn}" %{DATA:auth_name} %{WORD:auth_protocol}\] \[ref: "%{DATA:cluster}" "%{DATA:client}"\] \[req: %{NUMBER:request_time:float} \(s\) proxy-resp: %{NUMBER:proxy_resp_time:float} \(s\)\]' }
       }
@@ -264,6 +265,16 @@ output {
           format => "json_batch"
           # for message please use double quotes for string type and no-double
           # quotes for objects, e.g. %{agent} is an object, while "%{dn}" is a string
+          socket_timeout => 60
+          connect_timeout => 60
+      }
+  }
+  if [type] == "aps" {
+      http {
+          http_method => post
+          url => "http://monit-logs.cern.ch:10012/"
+          content_type => "application/json; charset=UTF-8"
+          format => "json_batch"
           socket_timeout => 60
           connect_timeout => 60
       }

--- a/kubernetes/cmsweb/monitoring/logstash.conf
+++ b/kubernetes/cmsweb/monitoring/logstash.conf
@@ -76,6 +76,72 @@ filter {
       mutate { gsub =>  [ "dn","/CN=\d+","" ] }
   }
 
+  if "aps" in [tags] {
+      grok {
+        match => { "message" => '\[%{TIMESTAMP_ISO8601:tstamp}\] %{DATA:httpversion} %{NUMBER:code:int} %{WORD:method} %{NOTSPACE:request} \[data: %{NUMBER:bytes_received:int} in %{NUMBER:bytes_sent:int} out\] \[host: %{IPORHOST:frontend}:%{NUMBER:fe_port}\] \[remoteAddr: %{IPORHOST:clientip}:%{NUMBER:clientport:int}\] \[X-Forwarded-For: %{IPORHOST:x_forwarded_ip}:%{NUMBER:x_forwarded_port:int}\] \[X-Forwarded-Host: %{HOSTNAME:x_forwarded_host}\] \[auth: %{DATA:tls} %{DATA:crypto} "%{DATA:dn}" %{DATA:auth_name} %{WORD:auth_protocol}\] \[ref: "%{DATA:cluster}" "%{DATA:client}"\] \[req: %{NUMBER:request_time:float} \(s\) proxy-resp: %{NUMBER:proxy_resp_time:float} \(s\)\]' }
+      }
+
+      grok {
+      pattern_definitions => { "WORDHYPHEN" => "\b[\w\-]+\b" }
+      match => { "request" => '/%{WORDHYPHEN:system}%{UNIXPATH:uri_path}%{URIPARAM:uri_params}?' }
+      }
+      if [system] =~ /^(wmstatsserver|reqmgr2|t0_reqmon|ms-pileup|ms-transferor|ms-monitor|ms-output|ms-unmerged|ms-rulecleaner)$/ {
+          grok {
+              match => { "uri_path" => '/[^/]+/%{WORD:api}' }
+          }
+          if [api] == "" {
+              grok {
+                  match => { "uri_path" => '/[^/]+/%{DATA:api}/' }
+              }
+          }
+      }else {
+          if [uri_params] {
+              grok {
+                  match => { "uri_path" => '/.*/%{DATA:api}$' }
+              }
+              if [api] == "" {
+                  grok {
+                      match => { "uri_path" => '/.*/%{DATA:api}/$' }
+                  }
+              }
+          } else {
+              grok {
+                  match => { "request" => '/.*/%{DATA:api}$' }
+              }
+              if [api] == "" {
+                  grok {
+                      match => { "request" => '/.*/%{DATA:api}/$' }
+                  }
+              }
+          }
+      }
+      if [uri_params] and ![api] {
+          grok { match => { "uri_path" => '/.*/%{DATA:api}/$' } }
+      }
+      if ![api] {
+          mutate { replace => { "api" => "%{request}" } }
+          mutate { replace => { "system" => "%{request}" } }
+      }
+      if [client] {
+          grok { match => { "client" => '%{DATA:client_name}/%{DATA:client_version}$' } }
+      }
+
+      date {
+        match => [ "tstamp", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS'Z'", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSZZ" ]
+        target => "date_object"
+      }
+
+      ruby {
+        code => "
+          event.set('rec_timestamp', event.get('date_object').to_i);
+          event.set('rec_date', event.get('date_object'));
+          event.set('timestamp', (event.get('rec_timestamp').to_f * 1000).to_i);
+        "
+      }
+
+      mutate { gsub => [ "dn", "/CN=\\d+", "" ] }
+  }
+
   if "acdcserver" in [tags] {
       mutate { replace => { "type" => "acdcserver" } }
   }


### PR DESCRIPTION
I have updated the logstash rules for the `auth-proxy-server`. However, this filtering is used only if the `tag` is `aps` and the `tag` should come from the fileabeat, but I don't know were the filebeat is running, so I cannot really change the `tag`.

I have tested out the parsing assuming that the `tag` is set to`aps` and [here](https://codimd.web.cern.ch/s/Dxo16MEhh) you can see how the output for some old frontend log that I found in the docs (`tag` is `frontend` in this case) and the output of the auth-proxy-server. There are some other fields that come from the filebeat such as `ephemeral_id` or `agent`, so they are not getting filled in this testing.