### PR TITLE
Mount vomses from host to container

### DIFF
--- a/docker/pypi/wmagent/bin/manage-common.sh
+++ b/docker/pypi/wmagent/bin/manage-common.sh
@@ -311,7 +311,7 @@ _renew_proxy(){
 
     # Here to forge the myproxy command string to be used for the operation.
     local myproxyCmd="myproxy-get-delegation \
-                    -v -l amaltaro -t 168 -s myproxy.cern.ch -k $myproxyCredName -n \
+                    -v -l amaltaro -t 169 -s myproxy.cern.ch -k $myproxyCredName -n \
                     -o $WMA_CERTS_DIR/mynewproxy.pem"
     local vomsproxyCmd="voms-proxy-init -rfc \
                     -voms cms:/cms/Role=production -valid 168:00 -bits 2048 -noregen \

--- a/docker/pypi/wmagent/wmagent-docker-run.sh
+++ b/docker/pypi/wmagent/wmagent-docker-run.sh
@@ -110,7 +110,8 @@ $tnsMount \
 --mount type=bind,source=$HOST_MOUNT_DIR/admin/etc/group,target=/etc/group,readonly \
 --mount type=bind,source=/etc/sudoers,target=/etc/sudoers,readonly \
 --mount type=bind,source=/etc/sudoers.d,target=/etc/sudoers.d,readonly \
---mount type=bind,source=/etc/vomses,target=/etc/vomses \
+--mount type=bind,source=/etc/grid-security,target=/etc/grid-security,readonly \
+--mount type=bind,source=/etc/vomses,target=/etc/vomses,readonly \
 "
 
 registry=local

--- a/docker/pypi/wmagent/wmagent-docker-run.sh
+++ b/docker/pypi/wmagent/wmagent-docker-run.sh
@@ -110,6 +110,7 @@ $tnsMount \
 --mount type=bind,source=$HOST_MOUNT_DIR/admin/etc/group,target=/etc/group,readonly \
 --mount type=bind,source=/etc/sudoers,target=/etc/sudoers,readonly \
 --mount type=bind,source=/etc/sudoers.d,target=/etc/sudoers.d,readonly \
+--mount type=bind,source=/etc/vomses,target=/etc/vomses \
 "
 
 registry=local


### PR DESCRIPTION
This PR solves the DMWM issue https://github.com/dmwm/WMCore/issues/12030.

After mounting the `/etc/vomses` from the host, I have run
```
./wmagent-docker-run.sh -t 2.3.4rc12 -p && docker logs -f wmagent
```
and I got:
```
MyProxy v6.2 Aug 2019 PAM SASL KRB5 LDAP VOMS OCSP
Attempting to connect to xxx:yyy 
Successfully connected to ***.cern.ch:yyy 
using trusted certificates directory /etc/grid-security/certificates
Using Host cert file (/data/certs/servicecert.pem), key file (/data/certs/servicekey.pem)
server name: /DC=ch/DC=cern/OU=computers/CN=xxx.cern.ch
checking that server name is acceptable...
server name matches "xxx.cern.ch"
authenticated server name is acceptable
A credential has been received for user amaltaro in /data/certs/mynewproxy.pem.
Contacting xxx.app.cern.ch:yyy [/DC=ch/DC=cern/OU=computers/CN=xxx.web.cern.ch] "cms"...
Remote VOMS server contacted succesfully.


WARNING: VOMS AC validation for VO cms failed for the following reasons:
         LSC validation failed: LSC file matching VOMS attributes not found in store.
         AC signature verification failure: no valid VOMS server credential found.
WARNING: proxy lifetime limited to issuing credential lifetime.

Created proxy in /data/certs/myproxy.pem.

Your proxy is valid until Fri Jul 05 15:41:58 UTC 2024
ERROR: _renew_proxy
Start sleeping now ...zzz...
```
Even if the proxy is created, there is a warning that reports a signature verification failure, and the proxy is reported to last 7 days.
From within the container, this is the information I can get about the voms proxy:
```
cmst1@vocms0262:wmagent $ docker exec -it wmagent bash
(WMAgent-2.3.4rc12) [xxx@vocms0***:current]$ ls /etc/vomses/
cms-voms-cms-auth.app.cern.ch
(WMAgent-2.3.4rc12) [xxx@vocms0***:current]$ voms-proxy-info
subject   : /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues/CN=1093104579/CN=614076789/CN=995549063/CN=169979281
issuer    : /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues/CN=1093104579/CN=614076789/CN=995549063
identity  : /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=amaltaro/CN=718748/CN=Alan Malta Rodrigues
type      : RFC3820 compliant impersonation proxy
strength  : 2048
path      : /data/certs/myproxy.pem
timeleft  : 167:44:01
key usage : Digital Signature, Key Encipherment
```

It seems the proxy is valid, as WMStats doesn't report any warning about expiration of the proxy.

@amaltaro what do you think?