### PR TITLE
Mount /etc/vomses and grid-security in the WMAgent container

### DIFF
--- a/docker/pypi/wmagent/Dockerfile
+++ b/docker/pypi/wmagent/Dockerfile
@@ -62,6 +62,10 @@ EOF
 # allow dynamic users to create homefolders and .bashrc
 RUN chmod 777 /home
 
+# given that we have to mount up-to-date /etc/vomses and we have a different setup for CERN
+# - being a directory - and FNAL being a file; just delete it from the image
+RUN rm -rf /etc/vomses
+
 # preserve the whole env for later use by the cron daemon
 RUN env > /etc/environment
 

--- a/docker/pypi/wmagent/bin/manage-common.sh
+++ b/docker/pypi/wmagent/bin/manage-common.sh
@@ -311,7 +311,7 @@ _renew_proxy(){
 
     # Here to forge the myproxy command string to be used for the operation.
     local myproxyCmd="myproxy-get-delegation \
-                    -v -l amaltaro -t 168 -s myproxy.cern.ch -k $myproxyCredName -n \
+                    -v -l amaltaro -t 169 -s myproxy.cern.ch -k $myproxyCredName -n \
                     -o $WMA_CERTS_DIR/mynewproxy.pem"
     local vomsproxyCmd="voms-proxy-init -rfc \
                     -voms cms:/cms/Role=production -valid 168:00 -bits 2048 -noregen \

--- a/docker/pypi/wmagent/wmagent-docker-run.sh
+++ b/docker/pypi/wmagent/wmagent-docker-run.sh
@@ -110,6 +110,8 @@ $tnsMount \
 --mount type=bind,source=$HOST_MOUNT_DIR/admin/etc/group,target=/etc/group,readonly \
 --mount type=bind,source=/etc/sudoers,target=/etc/sudoers,readonly \
 --mount type=bind,source=/etc/sudoers.d,target=/etc/sudoers.d,readonly \
+--mount type=bind,source=/etc/grid-security,target=/etc/grid-security,readonly \
+--mount type=bind,source=/etc/vomses,target=/etc/vomses,readonly \
 "
 
 registry=local


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/12030
Superseeds https://github.com/dmwm/CMSKubernetes/pull/1517

This PR contains the changes that Andrea provided in his PR, plus an extra tweak for /etc/vomses. In short:
* fix proxy lifetime and voms roles lifetime request to avoid a WARNING message
* remove /etc/vomses directory in the WMAgent docker image
* mount both /etc/vomses and /etc/grid-security at container runtime

This has been tested both at FNAL and CERN and we are now able to renew the user proxy - and against the correct voms server.
FYI @anpicci I am merging it such that we release a new version of WMAgent.