### PR TITLE
Changing MariaDB server default character set and collation.

### DIFF
--- a/docker/pypi/wmagent-mariadb/my.cnf
+++ b/docker/pypi/wmagent-mariadb/my.cnf
@@ -5,6 +5,11 @@ sql_mode="NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES"
 transaction-isolation=READ-COMMITTED
 bind-address = 127.0.0.1
 
+# Setting default collation and charracter set
+collation-server = latin1_swedish_ci
+init-connect='SET NAMES latin1'
+character-set-server = latin1
+
 max_heap_table_size=2048M
 max_allowed_packet=128M
 max_connections = 200


### PR DESCRIPTION
fixes: https://github.com/dmwm/WMCore/issues/12007 

Due to a change in the default character set from `latin1` to `utf8mb4` through an extremely convoluted path, all MariaDB  tables in our databases  using `Unique` indexes and index keys of large size were broken. The cause was the difference in the encoding size - `latin1 == 2 bytes/char` vs. `utf8mb4 == 4 bytes/char`. Due to the so mentioned difference, the tables which were using for index keys fields longer than `767` chars, were crossing a threshold boundary of 3072 bytes for storing the index defined at the `InnoDB` engine. This was causing an automated switch of the index type by MariaDB server from `BTREE` to `HASH`. Unfortunately the `HASH` index is not working with the storage engine we use - `InnoDB`, which was causing a full table scan on every `select` query over a key from those indexes. 


With the current change, we revert back the server default character set and collation to the old default value: 
```
character-set-server = latin1
collation-server = latin1_swedish_ci
```

Here are few links from the official documentation: 
* InnoDB prefix size: https://mariadb.com/kb/en/innodb-limitations/#large-prefix-size
* InnoDB configuration parameters:  https://mariadb.com/kb/en/innodb-system-variables
* MariaDB index to storage engine compatibility: https://mariadb.com/kb/en/storage-engine-index-types/
* MariaDB Unique index types: https://mariadb.com/kb/en/getting-started-with-indexes/#unique-index
* MariaDB index switch threshold: https://dev.mysql.com/doc/refman/8.4/en/innodb-limits.html