### PR TITLE
Update dbs2go-*.yaml to chown of the logs directory by using an init …

### DIFF
--- a/kubernetes/cmsweb/services/dbs2go-global-r.yaml
+++ b/kubernetes/cmsweb/services/dbs2go-global-r.yaml
@@ -61,6 +61,25 @@ spec:
         prometheus.io/path: "/dbs/prod/global/DBSReader/metrics"
         prometheus.io/port: "9252"
     spec:
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - |
+          apt-get update && apt-get install -y sudo && apt-get clean && \
+          chmod 0777 /data/srv/logs/dbs && chown 1000:1000 /data/srv/logs/dbs
+        image: ubuntu
+        imagePullPolicy: Always
+        name: init-install-sudo
+        resources: {}
+        securityContext:
+          runAsGroup: 0
+          runAsUser: 0
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /data/srv/logs/dbs
+          name: logs
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000

--- a/kubernetes/cmsweb/services/dbs2go-global-w.yaml
+++ b/kubernetes/cmsweb/services/dbs2go-global-w.yaml
@@ -61,6 +61,25 @@ spec:
         prometheus.io/path: "/dbs/prod/global/DBSWriter/metrics"
         prometheus.io/port: "9253"
     spec:
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - |
+          apt-get update && apt-get install -y sudo && apt-get clean && \
+          chmod 0777 /data/srv/logs/dbs && chown 1000:1000 /data/srv/logs/dbs
+        image: ubuntu
+        imagePullPolicy: Always
+        name: init-install-sudo
+        resources: {}
+        securityContext:
+          runAsGroup: 0
+          runAsUser: 0
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /data/srv/logs/dbs
+          name: logs
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000


### PR DESCRIPTION
…container. This resolves the issue of services not being able to write to the /data/srv/logs/dbs directory.