### PR TITLE
Increase memory limit for MSOutput and MSRuleCleaner to 1Gi

### DIFF
--- a/kubernetes/cmsweb/services/reqmgr2ms-output.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-output.yaml
@@ -97,7 +97,7 @@ spec:
 #PROD#      memory: "250Mi"
 #PROD#      cpu: "100m"
 #PROD#    limits:
-#PROD#      memory: "750Mi"
+#PROD#      memory: "1Gi"
 #PROD#      cpu: "1000m"
         livenessProbe:
           exec:

--- a/kubernetes/cmsweb/services/reqmgr2ms-rulecleaner.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-rulecleaner.yaml
@@ -97,7 +97,7 @@ spec:
 #PROD#      memory: "250Mi"
 #PROD#      cpu: "200m"
 #PROD#    limits:
-#PROD#      memory: "750Mi"
+#PROD#      memory: "1Gi"
 #PROD#      cpu: "1000m"
         livenessProbe:
           exec:


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/12042

It is a small memory limit increase, but it should help us to better deal with peak loads in these microservices, especially after outages and/or misbehaviors of the services.