### PR TITLE
Update logstash config for auth-proxy-server.yaml

### DIFF
--- a/kubernetes/cmsweb/daemonset/auth-proxy-server.yaml
+++ b/kubernetes/cmsweb/daemonset/auth-proxy-server.yaml
@@ -18,10 +18,12 @@ data:
       backoff: 5s
       max_backoff: 10s
       tags: ["aps"]
-    output.console:
-      codec.format:
-        string: '%{[message]} - Podname=${MY_POD_NAME}'
-        pretty: false
+    output.logstash:
+      hosts: ["logstash.monitoring:5044"]
+      compression_level: 3
+      worker: 4
+      bulk_max_size: 4096
+      pipelining: 2
     queue.mem:
       events: 65536
     logging.metrics.enabled: false


### PR DESCRIPTION
Output of the APS logstash should be switched to `logstash` instead of `console`, so that it can properly logstash and OpenSearch afterwards.