### PR TITLE
Remove cmsweb-base and /etc/grid-security from APS image

### DIFF
--- a/docker/auth-proxy-server/Dockerfile
+++ b/docker/auth-proxy-server/Dockerfile
@@ -5,7 +5,7 @@ ENV USER=http
 WORKDIR $WDIR
 
 # tag to use
-ENV TAG=0.2.32
+ENV TAG=0.2.81
 
 ARG CGO_ENABLED=0
 RUN mkdir $WDIR/gopath
@@ -14,12 +14,9 @@ RUN git clone https://github.com/vkuznet/auth-proxy-server.git
 WORKDIR $WDIR/auth-proxy-server
 RUN git checkout tags/$TAG -b build && make
 
-FROM cmssw/cmsweb-base:latest as cmsweb-base
-
 # https://blog.baeke.info/2021/03/28/distroless-or-scratch-for-go-apps/
 # FROM alpine
 FROM gcr.io/distroless/static AS final
 #RUN mkdir -p /data/static && mkdir -p /data/srv/logs/frontend
 COPY --from=go-builder /data/auth-proxy-server/auth-proxy-server /data/
 COPY --from=go-builder /data/auth-proxy-server/static/cmsmon/index.html /data/static/
-COPY --from=cmsweb-base /etc/grid-security /etc/grid-security


### PR DESCRIPTION
This PR removes /etc/grid-security/certificates area from APS image as it gets outdated based on state of cmsweb-base image. Instead we should use k8s nodes to mount this area to APS pods and external plugin/cron should update /etc/grid-security/certificates area.