### PR TITLE
Update x509-proxy-server.yaml

### DIFF
--- a/kubernetes/cmsweb/daemonset/x509-proxy-server.yaml
+++ b/kubernetes/cmsweb/daemonset/x509-proxy-server.yaml
@@ -17,7 +17,7 @@ data:
       scan_frequency: 10s
       backoff: 5s
       max_backoff: 10s
-      tags: ["xps"]
+      tags: ["aps"]
     output.logstash:
       hosts: ["logstash.monitoring:5044"]
       compression_level: 3

--- a/kubernetes/cmsweb/daemonset/x509-proxy-server.yaml
+++ b/kubernetes/cmsweb/daemonset/x509-proxy-server.yaml
@@ -17,10 +17,13 @@ data:
       scan_frequency: 10s
       backoff: 5s
       max_backoff: 10s
-    output.console:
-      codec.format:
-        string: '%{[message]} - Podname=${MY_POD_NAME}'
-        pretty: false
+      tags: ["xps"]
+    output.logstash:
+      hosts: ["logstash.monitoring:5044"]
+      compression_level: 3
+      worker: 4
+      bulk_max_size: 4096
+      pipelining: 2
     queue.mem:
       events: 65536
     logging.metrics.enabled: false

--- a/kubernetes/cmsweb/monitoring/logstash.conf
+++ b/kubernetes/cmsweb/monitoring/logstash.conf
@@ -76,7 +76,7 @@ filter {
       mutate { gsub =>  [ "dn","/CN=\d+","" ] }
   }
 
-  if "aps" in [tags] {
+  if "aps" in [tags] or "xps" in [tags] {
       mutate { replace => { "type" => "aps" } }
       grok {
         match => { "message" => '\[%{TIMESTAMP_ISO8601:tstamp}\] %{DATA:httpversion} %{NUMBER:code:int} %{WORD:method} %{NOTSPACE:request} \[data: %{NUMBER:bytes_received:int} in %{NUMBER:bytes_sent:int} out\] \[host: %{IPORHOST:frontend}:%{NUMBER:fe_port}\] \[remoteAddr: %{IPORHOST:clientip}:%{NUMBER:clientport:int}\] \[X-Forwarded-For: %{IPORHOST:x_forwarded_ip}:%{NUMBER:x_forwarded_port:int}\] \[X-Forwarded-Host: %{HOSTNAME:x_forwarded_host}\] \[auth: %{DATA:tls} %{DATA:crypto} "%{DATA:dn}" %{DATA:auth_name} %{WORD:auth_protocol}\] \[ref: "%{DATA:cluster}" "%{DATA:client}"\] \[req: %{NUMBER:request_time:float} \(s\) proxy-resp: %{NUMBER:proxy_resp_time:float} \(s\)\]' }

--- a/kubernetes/cmsweb/monitoring/logstash.conf
+++ b/kubernetes/cmsweb/monitoring/logstash.conf
@@ -80,10 +80,14 @@ filter {
       grok {
         match => { "message" => '\[%{TIMESTAMP_ISO8601:tstamp}\] %{DATA:httpversion} %{NUMBER:code:int} %{WORD:method} %{NOTSPACE:request} \[data: %{NUMBER:bytes_received:int} in %{NUMBER:bytes_sent:int} out\] \[host: %{IPORHOST:frontend}:%{NUMBER:fe_port}\] \[remoteAddr: %{IPORHOST:clientip}:%{NUMBER:clientport:int}\] \[X-Forwarded-For: %{IPORHOST:x_forwarded_ip}:%{NUMBER:x_forwarded_port:int}\] \[X-Forwarded-Host: %{HOSTNAME:x_forwarded_host}\] \[auth: %{DATA:tls} %{DATA:crypto} "%{DATA:dn}" %{DATA:auth_name} %{WORD:auth_protocol}\] \[ref: "%{DATA:cluster}" "%{DATA:client}"\] \[req: %{NUMBER:request_time:float} \(s\) proxy-resp: %{NUMBER:proxy_resp_time:float} \(s\)\]' }
       }
-
       grok {
-      pattern_definitions => { "WORDHYPHEN" => "\b[\w\-]+\b" }
-      match => { "request" => '/%{WORDHYPHEN:system}%{UNIXPATH:uri_path}%{URIPARAM:uri_params}?' }
+        match => {
+          "cmsweb_log" => "/data/srv/logs/frontend/auth-proxy-server.log_%{GREEDYDATA:proxy_server}-%{DATA}_%{YEAR}%{MONTHNUM}%{MONTHDAY}"
+        }
+      }
+      grok {
+        pattern_definitions => { "WORDHYPHEN" => "\b[\w\-]+\b" }
+        match => { "request" => '/%{WORDHYPHEN:system}%{UNIXPATH:uri_path}%{URIPARAM:uri_params}?' }
       }
       if [system] =~ /^(wmstatsserver|reqmgr2|t0_reqmon|ms-pileup|ms-transferor|ms-monitor|ms-output|ms-unmerged|ms-rulecleaner)$/ {
           grok {

--- a/kubernetes/cmsweb/monitoring/logstash.conf
+++ b/kubernetes/cmsweb/monitoring/logstash.conf
@@ -75,7 +75,7 @@ filter {
       mutate { gsub =>  [ "dn","/CN=\d+","" ] }
   }
 
-  if "aps" in [tags] or "xps" in [tags] {
+  if "aps" in [tags] {
       mutate { replace => { "type" => "aps" } }
       grok {
         match => { "message" => '\[%{TIMESTAMP_ISO8601:tstamp}\] %{DATA:httpversion} %{NUMBER:code:int} %{WORD:method} %{NOTSPACE:request} \[data: %{NUMBER:bytes_received:int} in %{NUMBER:bytes_sent:int} out\] \[host: %{IPORHOST:frontend}:%{NUMBER:fe_port}\] \[remoteAddr: %{IPORHOST:clientip}:%{NUMBER:clientport:int}\] \[X-Forwarded-For: %{IPORHOST:x_forwarded_ip}:%{NUMBER:x_forwarded_port:int}\] \[X-Forwarded-Host: %{HOSTNAME:x_forwarded_host}\] \[auth: %{DATA:tls} %{DATA:crypto} "%{DATA:dn}" %{DATA:auth_name} %{WORD:auth_protocol}\] \[ref: "%{DATA:cluster}" "%{DATA:client}"\] \[req: %{NUMBER:request_time:float} \(s\) proxy-resp: %{NUMBER:proxy_resp_time:float} \(s\)\]' }
@@ -268,7 +268,7 @@ output {
           connect_timeout => 60
       }
   }
-  if [type] == "aps" or [type] == "xps" {
+  if [type] == "aps" {
       http {
           http_method => post
           url => "http://monit-logs.cern.ch:10012/"

--- a/kubernetes/cmsweb/monitoring/logstash.conf
+++ b/kubernetes/cmsweb/monitoring/logstash.conf
@@ -58,7 +58,6 @@ filter {
       }
       if ![api] {
           mutate { replace => { "api" => "%{request}" } }
-          mutate { replace => { "system" => "%{request}" } }
       }
       if [client] {
           grok { match => { "client" => '%{DATA:client_name}/%{DATA:client_version}$' } }

--- a/kubernetes/cmsweb/monitoring/logstash.conf
+++ b/kubernetes/cmsweb/monitoring/logstash.conf
@@ -82,7 +82,7 @@ filter {
       }
       grok {
         match => {
-          "cmsweb_log" => "/data/srv/logs/frontend/auth-proxy-server.log_%{GREEDYDATA:proxy_server}-%{DATA}_%{YEAR}%{MONTHNUM}%{MONTHDAY}"
+          "cmsweb_log" => "/data/srv/logs/frontend/%{DATA:log_prefix}_%{GREEDYDATA:proxy_server}-%{DATA}_%{YEAR}%{MONTHNUM}%{MONTHDAY}"
         }
       }
       grok {

--- a/kubernetes/cmsweb/monitoring/logstash.conf
+++ b/kubernetes/cmsweb/monitoring/logstash.conf
@@ -268,7 +268,7 @@ output {
           connect_timeout => 60
       }
   }
-  if [type] == "aps" {
+  if [type] == "aps" or [type] == "xps" {
       http {
           http_method => post
           url => "http://monit-logs.cern.ch:10012/"


### PR DESCRIPTION
- updated `x509-proxy-server` so that the logs would be sent to same index as APS logs on OpenSearch
- updated logstash config to start extracting deployment name from the log file (e.g `x509-proxy-server` would be extracted from `/data/srv/logs/frontend/auth-proxy-server.log_x509-proxy-server-xxxxx_20240730`)