### PR TITLE
crabserver - update image path, versions

### DIFF
--- a/helm/crabserver/deploy.sh
+++ b/helm/crabserver/deploy.sh
@@ -1,17 +1,29 @@
 #! /bin/bash
 set -euo pipefail
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+
+# hash table of clusters nickname-name:
+declare -A cluster_map=([prod]=prod)
+cluster_map[prod]=k8s-prodsrv
+cluster_map[preprod]=k8s-prodsrv-v1.22.9
+cluster_map[testbed]=testbed
+cluster_map[test2]=test2
+cluster_map[test11]=test11
+cluster_map[test12]=test12
 if [[ $# -ne 1 ]]; then
     echo "Usage: deploy.sh ENVNAME"
-    echo " ENVNAME=(prod|testbed|test2|test11|test12)"
+    echo " ENVNAME=(prod|preprod|testbed|test2|test11|test12)"
     exit 1
 fi
-desired_cluster=$1
+desired_cluster="${cluster_map[$1]}"
+
 # make sure that your current context points to the desired cluster
 current_cluster=$(kubectl config view -o json | jq '.["current-context"] as $context | .["contexts"][] | select(.name | contains($context))| .context.cluster')
+
 if [[ $current_cluster =~ $desired_cluster ]]; then 
   echo "deploying to $desired_cluster"; 
-  helm template crabserver . -f values.yaml -f values-${desired_cluster}-pypi.yaml | kubectl -n crab apply -f -
+  helm template crabserver . -f values.yaml -f values-${1}-pypi.yaml | kubectl -n crab apply -f -
 else 
   echo "wrong cluster: your are connected to $current_cluster"; 
 fi

--- a/helm/crabserver/deploy.sh
+++ b/helm/crabserver/deploy.sh
@@ -11,7 +11,7 @@ desired_cluster=$1
 current_cluster=$(kubectl config view -o json | jq '.["current-context"] as $context | .["contexts"][] | select(.name | contains($context))| .context.cluster')
 if [[ $current_cluster =~ $desired_cluster ]]; then 
   echo "deploying to $desired_cluster"; 
-  helm template crabserver . -f values.yaml -f values-$desired_cluster.yaml | kubectl -n crab apply -f -
+  helm template crabserver . -f values.yaml -f values-${desired_cluster}-pypi.yaml | kubectl -n crab apply -f -
 else 
   echo "wrong cluster: your are connected to $current_cluster"; 
 fi

--- a/helm/crabserver/values-preprod-pypi.yaml
+++ b/helm/crabserver/values-preprod-pypi.yaml
@@ -1,10 +1,10 @@
 ---
-environment: "test"
+environment: "preprod"
 
 image:
   path: registry.cern.ch/cmscrab/crabserver
   pullPolicy: IfNotPresent
-  tag: "pypi-test2-1716890482"
+  tag: "v3.240731-stable"
   command:
   - /data/entrypoint.sh
   args:
@@ -16,8 +16,3 @@ image:
     && ls -lahZ /etc/grid-security \
     && /data/run.sh
 
-#https://helm.sh/docs/chart_template_guide/values_files/#deleting-a-default-key
-livenessProbePreProd: null
-readinessProbePreProd: null
-readinessProbe: null
-livenessProbe: null

--- a/helm/crabserver/values-prod-pypi.yaml
+++ b/helm/crabserver/values-prod-pypi.yaml
@@ -1,10 +1,10 @@
 ---
-environment: "test"
+environment: "prod"
 
 image:
   path: registry.cern.ch/cmscrab/crabserver
   pullPolicy: IfNotPresent
-  tag: "pypi-test2-1716890482"
+  tag: "v3.240731-stable"
   command:
   - /data/entrypoint.sh
   args:
@@ -16,8 +16,3 @@ image:
     && ls -lahZ /etc/grid-security \
     && /data/run.sh
 
-#https://helm.sh/docs/chart_template_guide/values_files/#deleting-a-default-key
-livenessProbePreProd: null
-readinessProbePreProd: null
-readinessProbe: null
-livenessProbe: null

--- a/helm/crabserver/values-prod.yaml
+++ b/helm/crabserver/values-prod.yaml
@@ -1,5 +1,5 @@
-environment: "prod"
+environment: "preprod"
 
 image:
-  tag: "v3.240508"
+  tag: "v3.240731-stable"
 

--- a/helm/crabserver/values-test1.yaml
+++ b/helm/crabserver/values-test1.yaml
@@ -1,0 +1,4 @@
+environment: "test"
+
+image:
+  tag: "v3.240709"

--- a/helm/crabserver/values-testbed-pypi.yaml
+++ b/helm/crabserver/values-testbed-pypi.yaml
@@ -1,10 +1,10 @@
 ---
-environment: "test"
+environment: "testbed"
 
 image:
   path: registry.cern.ch/cmscrab/crabserver
   pullPolicy: IfNotPresent
-  tag: "pypi-test2-1716890482"
+  tag: "v3.240731-stable"
   command:
   - /data/entrypoint.sh
   args:
@@ -16,8 +16,3 @@ image:
     && ls -lahZ /etc/grid-security \
     && /data/run.sh
 
-#https://helm.sh/docs/chart_template_guide/values_files/#deleting-a-default-key
-livenessProbePreProd: null
-readinessProbePreProd: null
-readinessProbe: null
-livenessProbe: null

--- a/helm/crabserver/values.yaml
+++ b/helm/crabserver/values.yaml
@@ -8,7 +8,7 @@ replicaCount:
   test: 1
 
 image:
-  path: registry.cern.ch/cmsweb/crabserver
+  path: registry.cern.ch/cmscrab/crabserver
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: "v3.231006"


### PR DESCRIPTION
### Status

tested on test11, testbed, preprod, and prod

### description

change the default path from `path: registry.cern.ch/cmsweb/crabserver` to `path: registry.cern.ch/cmscrab/crabserver`, defaulting to the pypi images. added some values files with more recent versions

fyi: @novicecpp 