### PR TITLE
Fix crontab issue with cmsdataops at FNAL

### DIFF
--- a/docker/pypi/wmagent/wmagent-docker-run.sh
+++ b/docker/pypi/wmagent/wmagent-docker-run.sh
@@ -135,3 +135,6 @@ echo "Checking if there is no other wmagent container running and creating a lin
 echo "Starting wmagent:$WMA_TAG docker container with user: $wmaUser:$wmaGroup"
 docker run $dockerOpts $registry/$repository:$WMA_TAG
 docker exec -u root -it wmagent service cron start
+
+# Workaround su authentication issue (cron uses setuid via su)
+docker exec -u root -it wmagent sh -c "echo $wmaUser:$wmaUser | chpasswd"


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/12000

The wmagent user inside docker has authentication issues with `su`, which is needed and used by crontab.
This fixes that issue. 