### PR TITLE
Update aps logstash for prod

### DIFF
--- a/kubernetes/cmsweb/monitoring/logstash.conf
+++ b/kubernetes/cmsweb/monitoring/logstash.conf
@@ -78,7 +78,7 @@ filter {
   if "aps" in [tags] {
       mutate { replace => { "type" => "aps" } }
       grok {
-        match => { "message" => '\[%{TIMESTAMP_ISO8601:tstamp}\] %{DATA:httpversion} %{NUMBER:code:int} %{WORD:method} %{NOTSPACE:request} \[data: %{NUMBER:bytes_received:int} in %{NUMBER:bytes_sent:int} out\] \[host: %{IPORHOST:frontend}:%{NUMBER:fe_port}\] \[remoteAddr: %{IPORHOST:clientip}:%{NUMBER:clientport:int}\] \[X-Forwarded-For: %{IPORHOST:x_forwarded_ip}:%{NUMBER:x_forwarded_port:int}\] \[X-Forwarded-Host: %{HOSTNAME:x_forwarded_host}\] \[auth: %{DATA:tls} %{DATA:crypto} "%{DATA:dn}" %{DATA:auth_name} %{WORD:auth_protocol}\] \[ref: "%{DATA:cluster}" "%{DATA:client}"\] \[req: %{NUMBER:request_time:float} \(s\) proxy-resp: %{NUMBER:proxy_resp_time:float} \(s\)\]' }
+        match => { "message" => '\[%{TIMESTAMP_ISO8601:tstamp}\] %{DATA:httpversion} %{NUMBER:code:int} %{WORD:method} %{NOTSPACE:request} \[data: %{NUMBER:bytes_received:int} in %{NUMBER:bytes_sent:int} out\] \[host: %{IPORHOST:frontend}(?::%{NUMBER:fe_port})?\] \[remoteAddr: %{IPORHOST:clientip}:%{NUMBER:clientport:int}\] \[X-Forwarded-For: (%{IPORHOST:x_forwarded_ip}:%{NUMBER:x_forwarded_port:int})?\] \[X-Forwarded-Host: (%{HOSTNAME:x_forwarded_host})?\] \[auth: %{DATA:tls} %{DATA:crypto} "%{DATA:dn}" %{DATA:auth_name} %{WORD:auth_protocol}\] \[ref: "%{DATA:cluster}" "%{DATA:client}"\] \[req: %{NUMBER:request_time:float} \(s\) proxy-resp: %{NUMBER:proxy_resp_time:float} \(s\)\]' }
       }
       grok {
         match => {
@@ -124,7 +124,6 @@ filter {
       }
       if ![api] {
           mutate { replace => { "api" => "%{request}" } }
-          mutate { replace => { "system" => "%{request}" } }
       }
       if [client] {
           grok { match => { "client" => '%{DATA:client_name}/%{DATA:client_version}$' } }
@@ -241,7 +240,7 @@ filter {
   # common filters
 
   # drop failed records
-  if "_grokparsefailure" in [tags] { drop { } }
+  # if "_grokparsefailure" in [tags] { drop { } }
   # remove quotes from message entry since it will break the JSON
   mutate { gsub => [ "message", "\n", "", "message", "\"", ""] }
 

--- a/kubernetes/cmsweb/monitoring/logstash.conf
+++ b/kubernetes/cmsweb/monitoring/logstash.conf
@@ -239,8 +239,6 @@ filter {
 
   # common filters
 
-  # drop failed records
-  # if "_grokparsefailure" in [tags] { drop { } }
   # remove quotes from message entry since it will break the JSON
   mutate { gsub => [ "message", "\n", "", "message", "\"", ""] }
 


### PR DESCRIPTION
This should solve the issues reported recently related to the logstash of the APS:
- frontend host in the testbed always had port and in prod it sometimes doesn't, so making it optional
- some logs like the ones from `t0wmadatasvc` don't have `x_forwarded_host` and `x_forwarded_port`, so making them optional as well
- removing `system` replacement in case `api` is empty as it doesn't make sense
- stopping the discard of logs that failed to be properly parsed to catch edge cases, but maybe we can bring back this part after some time when we are sure about the logstash working properly

FYI @arooshap @vkuznet @leggerf 