### PR TITLE
Fix cron2 workaround at CERN production nodes

### DIFF
--- a/docker/pypi/wmagent/wmagent-docker-run.sh
+++ b/docker/pypi/wmagent/wmagent-docker-run.sh
@@ -137,4 +137,7 @@ docker run $dockerOpts $registry/$repository:$WMA_TAG
 docker exec -u root -it wmagent service cron start
 
 # Workaround su authentication issue (cron uses setuid via su)
-docker exec -u root -it wmagent sh -c "echo $wmaUser:$wmaUser | chpasswd"
+userStatus="$(docker exec -u root -it wmagent sh -c "passwd -S $wmaUser" | awk '{print $2}')"
+if [ "${userStatus:0:1}" == "P" ]; then
+    docker exec -u root -it wmagent sh -c "echo $wmaUser:$wmaUser | chpasswd"
+fi

--- a/docker/pypi/wmagent/wmagent-docker-run.sh
+++ b/docker/pypi/wmagent/wmagent-docker-run.sh
@@ -135,3 +135,6 @@ echo "Checking if there is no other wmagent container running and creating a lin
 echo "Starting wmagent:$WMA_TAG docker container with user: $wmaUser:$wmaGroup"
 docker run $dockerOpts $registry/$repository:$WMA_TAG
 docker exec -u root -it wmagent service cron start
+
+# Workaround su authentication issue (cron uses setuid via su)
+docker exec -u root -it wmagent sh -c "echo $wmaUser:$wmaUser | chpasswd"


### PR DESCRIPTION
This solves the following problem with https://github.com/dmwm/CMSKubernetes/pull/1538
on CERN nodes.

```
Starting periodic command scheduler: cron.
chpasswd: (user cmst1) pam_chauthtok() failed, error:
Authentication token manipulation error
chpasswd: (line 1, user cmst1) password not changed
```