### PR TITLE
Adding cron cric that check runs every hour to fetch data from cric.

### DIFF
--- a/kubernetes/cmsweb/crons/cron-cric.yaml
+++ b/kubernetes/cmsweb/crons/cron-cric.yaml
@@ -34,7 +34,7 @@ data:
         cat ${temp_output}
     fi
 
-    echo "Script completed."
+    echo "\nScript completed."
 ---
 apiVersion: v1
 kind: PersistentVolume

--- a/kubernetes/cmsweb/crons/cron-cric.yaml
+++ b/kubernetes/cmsweb/crons/cron-cric.yaml
@@ -39,7 +39,7 @@ spec:
             fsGroup: 0
           containers:
           - name: cric-fetch
-            image: curlimages/curl:latest
+            image: registry.cern.ch/cmsweb/curl:latest-stable
             args:
             - /bin/sh
             - -c

--- a/kubernetes/cmsweb/crons/cron-cric.yaml
+++ b/kubernetes/cmsweb/crons/cron-cric.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: cric-pv
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteMany
+  hostPath:
+    path: "/etc/cric"  
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cric-pvc
+  namespace: auth
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cron-cric
+  namespace: auth
+spec:
+  schedule: "0 * * * *"  # Runs every hour
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+            fsGroup: 0
+          containers:
+          - name: cric-fetch
+            image: curlimages/curl:latest
+            args:
+            - /bin/sh
+            - -c
+            - >
+              curl --cert /etc/robots/robotcert.pem --key /etc/robots/robotkey.pem -k -L -s "https://cms-cric.cern.ch/api/accounts/user/query/?json&preset=roles" -o /etc/cric/cric.json
+            volumeMounts:
+            - name: cric-volume
+              mountPath: /etc/cric
+            - name: robot-secrets
+              mountPath: /etc/robots
+          restartPolicy: Never
+          volumes:
+          - name: cric-volume
+            persistentVolumeClaim:
+              claimName: cric-pvc
+          - name: robot-secrets
+            secret:
+              secretName: robot-secrets

--- a/kubernetes/cmsweb/crons/cron-cric.yaml
+++ b/kubernetes/cmsweb/crons/cron-cric.yaml
@@ -14,7 +14,7 @@ data:
     # Run curl command and capture the HTTP status code
     response_code=$(curl --cert /etc/robots/robotcert.pem --key /etc/robots/robotkey.pem \
         -k -L -s -w "%{http_code}" \
-        -o ${temp_output} "https://cms-cric.cern.ch/api/accounts/user/query/?json&preset=roles123")
+        -o ${temp_output} "https://cms-cric.cern.ch/api/accounts/user/query/?json&preset=roles")
     
     curl_exit_code=$?
 

--- a/kubernetes/cmsweb/crons/cron-cric.yaml
+++ b/kubernetes/cmsweb/crons/cron-cric.yaml
@@ -1,4 +1,34 @@
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cric-fetch-script
+  namespace: auth
+data:
+  fetch-cric.sh: |
+    #!/bin/sh
+    echo "Starting CRIC fetch script..."
+    odir=/etc/cric/cric.json
+    tstamp=`date "+%Y%m%d_%H%M%S"`
+    response_code=$(curl --cert /etc/robots/robotcert.pem --key /etc/robots/robotkey.pem \
+        -k -L -s -w "%{response_code}" \
+        "https://cms-cric.cern.ch/api/accounts/user/query/?json&preset=roles123" -o ${odir}.${tstamp})
+    echo "Curl command executed with response code: $response_code"
+
+    if [ "$?" == "0" ] && [ "$response_code" == "200" ]; then
+        mv ${odir}.${tstamp} ${odir}
+        echo "CRIC data fetched successfully and moved to ${odir}."
+    else
+        echo "Failed to fetch CRIC data or invalid response code: $response_code"
+    fi
+
+    echo "=== Head of ${odir} ==="
+    head -n 10 ${odir}
+
+    echo "=== Tail of ${odir} ==="
+    tail -n 10 ${odir}
+    echo "Script completed."
+---
+apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: cric-pv
@@ -39,17 +69,15 @@ spec:
             fsGroup: 0
           containers:
           - name: cric-fetch
-            image: registry.cern.ch/cmsweb/curl:latest-stable
-            args:
-            - /bin/sh
-            - -c
-            - >
-              curl --cert /etc/robots/robotcert.pem --key /etc/robots/robotkey.pem -k -L -s "https://cms-cric.cern.ch/api/accounts/user/query/?json&preset=roles" -o /etc/cric/cric.json
+            image: curlimages/curl:latest
+            command: ["/bin/sh", "/script/fetch-cric.sh"]
             volumeMounts:
             - name: cric-volume
               mountPath: /etc/cric
             - name: robot-secrets
               mountPath: /etc/robots
+            - name: script-volume
+              mountPath: "/script"
           restartPolicy: Never
           volumes:
           - name: cric-volume
@@ -58,3 +86,7 @@ spec:
           - name: robot-secrets
             secret:
               secretName: robot-secrets
+          - name: script-volume
+            configMap:
+              name: cric-fetch-script
+              defaultMode: 0777

--- a/kubernetes/cmsweb/crons/cron-cric.yaml
+++ b/kubernetes/cmsweb/crons/cron-cric.yaml
@@ -9,23 +9,31 @@ data:
     echo "Starting CRIC fetch script..."
     odir=/etc/cric/cric.json
     tstamp=`date "+%Y%m%d_%H%M%S"`
+    temp_output=/tmp/cric_output_${tstamp}.json
+    
+    # Run curl command and capture the HTTP status code
     response_code=$(curl --cert /etc/robots/robotcert.pem --key /etc/robots/robotkey.pem \
-        -k -L -s -w "%{response_code}" \
-        "https://cms-cric.cern.ch/api/accounts/user/query/?json&preset=roles123" -o ${odir}.${tstamp})
-    echo "Curl command executed with response code: $response_code"
+        -k -L -s -w "%{http_code}" \
+        -o ${temp_output} "https://cms-cric.cern.ch/api/accounts/user/query/?json&preset=roles123")
+    
+    curl_exit_code=$?
 
-    if [ "$?" == "0" ] && [ "$response_code" == "200" ]; then
-        mv ${odir}.${tstamp} ${odir}
+    if [ "$curl_exit_code" -eq 0 ] && [ "$response_code" -eq 200 ]; then
+        mv ${temp_output} ${odir}
         echo "CRIC data fetched successfully and moved to ${odir}."
+        
+        # Show the head and tail of the file
+        echo "=== First 10 lines of ${odir} ==="
+        head -n 10 ${odir}
+        
+        echo "=== Last 10 lines of ${odir} ==="
+        tail -n 10 ${odir}
     else
-        echo "Failed to fetch CRIC data or invalid response code: $response_code"
+        echo "Failed to fetch CRIC data. Curl exit code: $curl_exit_code, Response code: $response_code"
+        echo "Partial or error output:"
+        cat ${temp_output}
     fi
 
-    echo "=== Head of ${odir} ==="
-    head -n 10 ${odir}
-
-    echo "=== Tail of ${odir} ==="
-    tail -n 10 ${odir}
     echo "Script completed."
 ---
 apiVersion: v1

--- a/kubernetes/cmsweb/daemonset/auth-proxy-server.yaml
+++ b/kubernetes/cmsweb/daemonset/auth-proxy-server.yaml
@@ -93,6 +93,8 @@ spec:
         - containerPort: 9091
           name: metrics
         volumeMounts:
+        - mountPath: /etc/cric
+          name: cric-volume
         - name: auth-proxy-server-secrets
           mountPath: /etc/secrets
           #defaultMode: 256
@@ -154,6 +156,9 @@ spec:
         - name: www-htdocs
           mountPath: /tmp/htdocs
       volumes:
+      - name: cric-volume
+        persistentVolumeClaim:
+          claimName: cric-pvc
       - name: auth-proxy-server-secrets
         secret:
           secretName: auth-proxy-server-secrets

--- a/kubernetes/cmsweb/daemonset/x509-proxy-server.yaml
+++ b/kubernetes/cmsweb/daemonset/x509-proxy-server.yaml
@@ -64,7 +64,6 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}
-
       containers:
       - image: registry.cern.ch/cmsweb/auth-proxy-server #imagetag
         name: x509-proxy-server
@@ -99,6 +98,8 @@ spec:
         - containerPort: 9092
           name: metrics
         volumeMounts:
+        - mountPath: /etc/cric
+          name: cric-volume
         - name: auth-proxy-server-secrets # use the same secrets as APS
           mountPath: /etc/secrets
           #defaultMode: 256
@@ -160,6 +161,9 @@ spec:
         - name: www-htdocs
           mountPath: /tmp/htdocs
       volumes:
+      - name: cric-volume
+        persistentVolumeClaim:
+          claimName: cric-pvc
       - name: auth-proxy-server-secrets # use the same secrets as APS
         secret:
           secretName: auth-proxy-server-secrets # use the same secrets as APS


### PR DESCRIPTION
Hi @vkuznet,

As you requested, I created a cron that fetches the data from cric url every hour. Then I created a temporary nginx pod to check if the directory is properly mounted and the contents of the file:

```
root@nginx-check-cric:/# cat /etc/cric/cric.json | head -n 100
[
  {
    "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=xge/CN=874768/CN=Xian Ge",
    "EMAIL": "07220231@njnu.edu.cn",
    "ID": 874768,
    "LOGIN": "xge",
    "NAME": "Xian Ge",
    "ROLES": {
      "user": [
        "group:users"
      ]
    }
  },
  {
    "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=zyuhe/CN=874870/CN=Zhao Yuhe",
    "EMAIL": "07220530@njnu.edu.cn",
    "ID": 874870,
    "LOGIN": "zyuhe",
    "NAME": "Zhao Yuhe",
    "ROLES": {
      "user": [
        "group:users"
      ]
    }
  },
  {
    "DN": "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=fangw/CN=757743/CN=Wenxing Fang",
    "EMAIL": "1473717798@qq.com",
    "ID": 757743,
    "LOGIN": "fangw",
    "NAME": "Wenxing Fang",
    "ROLES": {
      "user": [
        "group:users"
      ]
    }
  },

```


Then, I edited the daemonsets in test7 to use cric_file instead of cric_url, and tested it out:
```
[apervaiz@lxplus974 cmsweb]$ curl -s -L -k --key ~/.globus/userkey.pem --cert ~/.globus/usercert.pem https://cmsweb-test7.cern.ch/httpgo
GET /httpgo HTTP/1.1
Header field "User-Agent", Value ["curl/7.76.1"]
Header field "Cms-Auth-Status", Value ["ok"]
Header field "Cms-Authn-Method", Value ["X509Cert"]
Header field "Cms-Dns", Value ["/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=apervaiz/CN=852819/CN=Aroosha Pervaiz"]
Header field "Cms-Session", Value ["<nil>"]
Header field "Accept", Value ["*/*"]
Header field "Cms-Authz-Production-Operator", Value ["group:dataops"]
Header field "Name", Value ["Aroosha Pervaiz"]
Header field "Sorted-Dn", Value ["/CN=852819/CN=Aroosha Pervaiz/CN=apervaiz/DC=cern/DC=ch/OU=Organic Units/OU=Users"]
Header field "Accept-Encoding", Value ["gzip"]
Header field "Cms-Auth-Cert", Value ["/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=apervaiz/CN=852819/CN=Aroosha Pervaiz"]
Header field "Cms-Authn-Sorted-Dn", Value ["/CN=852819/CN=Aroosha Pervaiz/CN=apervaiz/DC=cern/DC=ch/OU=Organic Units/OU=Users"]
Header field "Cms-Authz-Operator", Value ["group:dbs"]
Header field "Cms-Authz-User", Value ["group:users"]
Header field "Login", Value ["apervaiz"]
Header field "Cms-Auth-Expire", Value ["1731492767"]
Header field "Cms-Authn-Name", Value ["Aroosha Pervaiz"]
Header field "Referrer", Value ["https://cmsweb-test7.cern.ch"]
Header field "Dn", Value ["/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=apervaiz/CN=852819/CN=Aroosha Pervaiz"]
Header field "Cms-Authn-Dn", Value ["/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=apervaiz/CN=852819/CN=Aroosha Pervaiz"]
Header field "Cms-Email", Value ["[aroosha.pervaiz@cern.ch]"]
Header field "Cms-Request-Uri", Value ["/httpgo"]
Header field "X-Forwarded-For", Value ["188.185.37.215:43690, 188.185.37.215"]
Header field "Cms-Auth-Time", Value ["1724767232"]
Header field "Referer", Value ["https://cmsweb-test7.cern.ch"]
Header field "Method", Value ["X509Cert"]
Header field "Cms-Authn-Login", Value ["apervaiz"]
Header field "Cms-Authz-Admin", Value ["group:phedex group:reqmgr"]
Header field "Cms-Authz-Dbsexpert", Value ["group:dbs"]
Header field "Cms-Cern-Id", Value ["852819"]
Header field "X-Forwarded-Host", Value ["cmsweb-test7.cern.ch"]
Host = "httpgo.http.svc.cluster.local:8888"
RemoteAddr= "188.185.120.149:44269"


Finding value of "Accept" ["*/*"]
Hello from Go
```

I also checked the above results against testbed:
```
[apervaiz@lxplus974 cmsweb]$ curl -s -L -k --key ~/.globus/userkey.pem --cert ~/.globus/usercert.pem https://cmsweb-testbed.cern.ch/httpgo
GET /httpgo HTTP/1.1
Header field "Accept", Value ["*/*"]
Header field "Cms-Authz-Production-Operator", Value ["group:dataops"]
Header field "Referrer", Value ["https://cmsweb-testbed.cern.ch"]
Header field "Dn", Value ["/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=apervaiz/CN=852819/CN=Aroosha Pervaiz"]
Header field "Cms-Authn-Dn", Value ["/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=apervaiz/CN=852819/CN=Aroosha Pervaiz"]
Header field "User-Agent", Value ["curl/7.76.1"]
Header field "Cms-Authn-Login", Value ["apervaiz"]
Header field "Cms-Authz-User", Value ["group:users"]
Header field "Cms-Auth-Cert", Value ["/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=apervaiz/CN=852819/CN=Aroosha Pervaiz"]
Header field "Cms-Auth-Expire", Value ["1731492767"]
Header field "Cms-Request-Uri", Value ["/httpgo"]
Header field "Accept-Encoding", Value ["gzip"]
Header field "Cms-Auth-Time", Value ["1724767237"]
Header field "Cms-Authn-Sorted-Dn", Value ["/CN=852819/CN=Aroosha Pervaiz/CN=apervaiz/DC=cern/DC=ch/OU=Organic Units/OU=Users"]
Header field "Login", Value ["apervaiz"]
Header field "Cms-Authz-Admin", Value ["group:phedex group:reqmgr"]
Header field "Cms-Email", Value ["[aroosha.pervaiz@cern.ch]"]
Header field "Cms-Session", Value ["<nil>"]
Header field "Method", Value ["X509Cert"]
Header field "Sorted-Dn", Value ["/CN=852819/CN=Aroosha Pervaiz/CN=apervaiz/DC=cern/DC=ch/OU=Organic Units/OU=Users"]
Header field "Cms-Authn-Method", Value ["X509Cert"]
Header field "Cms-Authn-Name", Value ["Aroosha Pervaiz"]
Header field "Cms-Authz-Dbsexpert", Value ["group:dbs"]
Header field "Cms-Cern-Id", Value ["852819"]
Header field "X-Forwarded-For", Value ["188.185.37.215:51408, 188.185.37.215"]
Header field "X-Forwarded-Host", Value ["cmsweb-testbed.cern.ch"]
Header field "Name", Value ["Aroosha Pervaiz"]
Header field "Cms-Auth-Status", Value ["ok"]
Header field "Cms-Authz-Operator", Value ["group:dbs"]
Header field "Cms-Dns", Value ["/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=apervaiz/CN=852819/CN=Aroosha Pervaiz"]
Header field "Referer", Value ["https://cmsweb-testbed.cern.ch"]
Host = "httpgo.http.svc.cluster.local:8888"
RemoteAddr= "10.100.19.128:45815"


Finding value of "Accept" ["*/*"]
Hello from Go
[apervaiz@lxplus974 cmsweb]$
```
