### PR TITLE
Update dmwm-base and wmagent-base images tag to 20240912; adopt it across WM images

### DIFF
--- a/docker/pypi/dmwm-base/Dockerfile
+++ b/docker/pypi/dmwm-base/Dockerfile
@@ -8,7 +8,6 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN mkdir /etc/grid-security
 COPY --from=cmsweb-base /etc/grid-security/certificates /etc/grid-security/certificates
 COPY --from=cmsweb-base /etc/grid-security/vomsdir /etc/grid-security/vomsdir
-COPY --from=cmsweb-base /etc/vomses /etc/vomses
 COPY --from=exporters /data/cmsweb-ping /usr/bin/cmsweb-ping
 COPY --from=exporters /data/process_exporter /usr/bin/process_exporter
 COPY --from=exporters /data/cpy_exporter /usr/bin/cpy_exporter

--- a/docker/pypi/global-workqueue/Dockerfile
+++ b/docker/pypi/global-workqueue/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230912
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20240912-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/global-workqueue/Dockerfile
+++ b/docker/pypi/global-workqueue/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230525
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230912
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/reqmgr2/Dockerfile
+++ b/docker/pypi/reqmgr2/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230912
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20240912-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/reqmgr2/Dockerfile
+++ b/docker/pypi/reqmgr2/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230525
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230912
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/reqmgr2ms-monitor/Dockerfile
+++ b/docker/pypi/reqmgr2ms-monitor/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230912
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20240912-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/reqmgr2ms-monitor/Dockerfile
+++ b/docker/pypi/reqmgr2ms-monitor/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230525
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230912
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/reqmgr2ms-output/Dockerfile
+++ b/docker/pypi/reqmgr2ms-output/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230912
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20240912-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/reqmgr2ms-output/Dockerfile
+++ b/docker/pypi/reqmgr2ms-output/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230525
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230912
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/reqmgr2ms-pileup/Dockerfile
+++ b/docker/pypi/reqmgr2ms-pileup/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230912
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20240912-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/reqmgr2ms-pileup/Dockerfile
+++ b/docker/pypi/reqmgr2ms-pileup/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230525
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230912
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/reqmgr2ms-rulecleaner/Dockerfile
+++ b/docker/pypi/reqmgr2ms-rulecleaner/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230912
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20240912-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/reqmgr2ms-rulecleaner/Dockerfile
+++ b/docker/pypi/reqmgr2ms-rulecleaner/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230525
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230912
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/reqmgr2ms-transferor/Dockerfile
+++ b/docker/pypi/reqmgr2ms-transferor/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230912
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20240912-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/reqmgr2ms-transferor/Dockerfile
+++ b/docker/pypi/reqmgr2ms-transferor/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230525
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230912
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/reqmgr2ms-unmerged/Dockerfile
+++ b/docker/pypi/reqmgr2ms-unmerged/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.cern.ch/cmsweb/gfal:latest as gfal
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230912
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20240912-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 COPY --from=gfal /data/miniconda /data/miniconda
 ENV WDIR=/data

--- a/docker/pypi/reqmgr2ms-unmerged/Dockerfile
+++ b/docker/pypi/reqmgr2ms-unmerged/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.cern.ch/cmsweb/gfal:latest as gfal
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230525
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230912
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 COPY --from=gfal /data/miniconda /data/miniconda
 ENV WDIR=/data

--- a/docker/pypi/reqmgr2ms/Dockerfile
+++ b/docker/pypi/reqmgr2ms/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230912
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20240912-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 RUN pip install reqmgr2ms-output
 ENV WDIR=/data

--- a/docker/pypi/reqmgr2ms/Dockerfile
+++ b/docker/pypi/reqmgr2ms/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230525
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230912
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 RUN pip install reqmgr2ms-output
 ENV WDIR=/data

--- a/docker/pypi/reqmon/Dockerfile
+++ b/docker/pypi/reqmon/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230912
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20240912-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/reqmon/Dockerfile
+++ b/docker/pypi/reqmon/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230525
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230912
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/t0_reqmon/Dockerfile
+++ b/docker/pypi/t0_reqmon/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230912
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20240912-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/t0_reqmon/Dockerfile
+++ b/docker/pypi/t0_reqmon/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230525
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230912
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/wmagent-base/Dockerfile
+++ b/docker/pypi/wmagent-base/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.cern.ch/cmsweb/oracle:21_5-stable as oracle
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230912
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20240912-stable
 
 # Install basic OS package dependencies
 RUN apt-get update

--- a/docker/pypi/wmagent-base/Dockerfile
+++ b/docker/pypi/wmagent-base/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.cern.ch/cmsweb/oracle:21_5-stable as oracle
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230525
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20230912
 
 # Install basic OS package dependencies
 RUN apt-get update

--- a/docker/pypi/wmagent/Dockerfile
+++ b/docker/pypi/wmagent/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile-upstream:master
-FROM registry.cern.ch/cmsweb/wmagent-base:pypi-20240604
+FROM registry.cern.ch/cmsweb/wmagent-base:pypi-20240912
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 
 # TAG to be passed at build time through `--build-arg TAG=<WMA_TAG>`. Default: None

--- a/docker/pypi/wmagent/Dockerfile
+++ b/docker/pypi/wmagent/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile-upstream:master
-FROM registry.cern.ch/cmsweb/wmagent-base:pypi-20240912
+FROM registry.cern.ch/cmsweb/wmagent-base:pypi-20240912-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 
 # TAG to be passed at build time through `--build-arg TAG=<WMA_TAG>`. Default: None

--- a/docker/pypi/wmagent/Dockerfile
+++ b/docker/pypi/wmagent/Dockerfile
@@ -62,10 +62,6 @@ EOF
 # allow dynamic users to create homefolders and .bashrc
 RUN chmod 777 /home
 
-# given that we have to mount up-to-date /etc/vomses and we have a different setup for CERN
-# - being a directory - and FNAL being a file; just delete it from the image
-RUN rm -rf /etc/vomses
-
 # preserve the whole env for later use by the cron daemon
 RUN env > /etc/environment
 


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/11997

With this PR, the following changes are provided:
1) update the default `manage` script in the dmwm-base image (see https://github.com/dmwm/CMSKubernetes/pull/1532)
2) pull the latest python3.8-bullseye image (change of python version from `3.8.16` to `3.8.20`
3) stop importing into our images the now obsolete `/etc/vomses` from the old cmsweb-base image.

In addition, I compared the old (20230525) and the new (20230912) dmwm-base images and they come with the same kernel version. Lastly, CERN Harbor reports about 1k less vulnerabilities for wmagent-base, also compared against the previous one.