### PR TITLE
dbs3-client - distribute via dmwm/wmcore/requirements.txt only

### DIFF
--- a/docker/pypi/dmwm-base/Dockerfile
+++ b/docker/pypi/dmwm-base/Dockerfile
@@ -11,7 +11,6 @@ COPY --from=cmsweb-base /etc/grid-security/vomsdir /etc/grid-security/vomsdir
 COPY --from=exporters /data/cmsweb-ping /usr/bin/cmsweb-ping
 COPY --from=exporters /data/process_exporter /usr/bin/process_exporter
 COPY --from=exporters /data/cpy_exporter /usr/bin/cpy_exporter
-RUN pip install dbs3-client
 ADD run.sh /data/run.sh
 ADD monitor.sh /data/monitor.sh
 ADD manage /data/manage

--- a/docker/pypi/reqmgr2ms-unmerged/Dockerfile
+++ b/docker/pypi/reqmgr2ms-unmerged/Dockerfile
@@ -14,7 +14,7 @@ ADD run.sh $WDIR/run.sh
 RUN curl -ksLO https://raw.githubusercontent.com/dmwm/WMCore/$TAG/requirements.txt
 RUN cat requirements.txt | grep -v gfal2 > req.txt
 RUN pip install -r req.txt
-RUN pip install --no-deps reqmgr2ms-unmerged==$TAG dbs3-client
+RUN pip install --no-deps reqmgr2ms-unmerged==$TAG 
 RUN sed -i -e "s,-config.py,-config-unmerged.py,g" /data/run.sh
 RUN sed -i -e "s,config.py,config-unmerged.py,g" /data/manage
 ENV WDIR=/data

--- a/docker/pypi/reqmgr2ms-unmerged/Dockerfile.dist
+++ b/docker/pypi/reqmgr2ms-unmerged/Dockerfile.dist
@@ -15,7 +15,6 @@ WORKDIR reqmgr2ms-unmerged-$TAG
 # add requirements.txt file which should exclude gfal2 package
 RUN cat requirements.txt | grep -v gfal2 > req.txt
 RUN pip install -r req.txt
-RUN pip install dbs3-client
 RUN python3 setup.py develop --no-deps
 RUN sed -i -e "s,-config.py,-config-unmerged.py,g" /data/run.sh
 ENV WDIR=/data


### PR DESCRIPTION
related to https://github.com/dmwm/WMCore/issues/12100 

we want to ship the dbsclient into the wmcore docker images via the file dmwm/wmcore/requirements.txt , where we control the specifc version