### PR TITLE
Update MariaDB version from 10.6.5 to 10.6.19

### DIFF
--- a/docker/pypi/wmagent-mariadb/Dockerfile
+++ b/docker/pypi/wmagent-mariadb/Dockerfile
@@ -1,4 +1,4 @@
-ARG MDB_TAG=10.6.5
+ARG MDB_TAG=10.6.19
 FROM mariadb:$MDB_TAG
 MAINTAINER Todor Ivanov todor.ivanov@cern.ch
 


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/12138

I've been running tests with a fresh new agent in vocms0261 and this latest version in the 10.6.x series seems to be running fine without any changes anywhere.