### PR TITLE
wmagent - do not init if couch is not empty

### DIFF
--- a/docker/pypi/wmagent-base/Dockerfile
+++ b/docker/pypi/wmagent-base/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update
 RUN apt-get install -y libmariadb-dev-compat libmariadb-dev apache2-utils cron mariadb-server myproxy voms-clients voms-clients-java rlwrap libaio1 && apt-get clean
 
 # Install some debugging tools
-RUN apt-get install -y hostname net-tools iputils-ping procps && apt-get clean
+RUN apt-get install -y hostname net-tools iputils-ping procps jq && apt-get clean
 
 # Install recursive ps utility tool
 RUN apt-get install -y pslist && apt-get clean

--- a/docker/pypi/wmagent/Dockerfile
+++ b/docker/pypi/wmagent/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile-upstream:master
-FROM registry.cern.ch/cmsweb/wmagent-base:pypi-20240923-stable
+FROM registry.cern.ch/cmsweb/wmagent-base:pypi-20241107-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 
 # TAG to be passed at build time through `--build-arg TAG=<WMA_TAG>`. Default: None

--- a/docker/pypi/wmagent/bin/manage
+++ b/docker/pypi/wmagent/bin/manage
@@ -331,6 +331,10 @@ clean_oracle(){
     return $errVal
 }
 
+clean_couch(){
+  echo "$FUNCNAME: automatic cleaning of local CouchDB is not implemented, yet"
+}
+
 status(){
     echo "----------------------------------------------------------------------"
     echo "Status of services:"

--- a/docker/pypi/wmagent/init.sh
+++ b/docker/pypi/wmagent/init.sh
@@ -284,8 +284,10 @@ _check_couch() {
     echo "$FUNCNAME: Checking whether the CouchDB database is reachable..."
     _status_of_couch || return $(false)
 
-    # echo "$FUNCNAME: Additional checks for CouchDB:"
+    echo "$FUNCNAME: Additional checks for CouchDB:"
+    local cleanMessage="You may consider cleaning local couchdb with 'rm -rf /data/dockerMount/srv/couchdb/'"
     # NOTE: To implement any additional check to the CouchDB similar to the relational databases
+    _couch_db_isclean || { echo "$FUNCNAME: Error: non empty local CouchDB. $cleanMessage"; return $(false); }
 }
 
 check_databases() {
@@ -313,7 +315,10 @@ check_databases() {
     esac
 
     # Checking CouchDB:
-    _check_couch
+    [[ -n $COUCH_HOST ]] && [[ -n $COUCH_PORT ]] && [[ -n $COUCH_USER ]] && [[ -n $COUCH_PASS ]] &&
+      couchdbCred=true
+    $couchdbCred || { echo "$FUNCNAME: ERROR: No local CouchDB credentials provided at $WMA_SECRETS_FILE" ; return $(false); }
+    _check_couch 
     echo "-----------------------------------------------------------------------"
 }
 


### PR DESCRIPTION
Following up on an operation mishap where I and @anpicci  deployed a new fnal wmagent with a non empty couchdb and Alan suggested to drain it soon not to encounter performance issues down the line, I decided that it was time to add some checks to our scripts.

I know that these changes are not really "required" but more of a "nice to have" , it was nonetheless a fun exercise to discover how we build our docker images and explore our init scripts.

This PR provides the following changes:

- I added `jq` to wmagent-base. it adds [100kB](https://packages.debian.org/bookworm/jq) to our docker image size, so i do not consider it a problem
- I built and pushed a new version of this image to [harbour](https://registry.cern.ch/harbor/projects/1771/repositories/wmagent-base/artifacts-tab) with tag `registry.cern.ch/cmsweb/wmagent-base:pypi-20241107-stable`
- I added a new `_couch_db_isclean` function to `manage-common.sh` script. after we check the connection to the local couch db, we retrieve some statistics about that instance. if it contains 1 document and 0 deleted documents, then we proceed with agent initialization. otherwise we stop the init.sh script and print how to manually clean the local couchdb.

Status:

- [x] tested that we can start an agent with an empty couch
- [x] tested that the commands used in this PR detect if a couch is not empty
- [ ] not tested yet that the init.sh script exits when couch is not empty, but i have no reason to believe it does not work :) 