### PR TITLE
wmagent - install cronjobs when initializing the agent

### DIFF
--- a/docker/pypi/wmagent/init.sh
+++ b/docker/pypi/wmagent/init.sh
@@ -648,6 +648,7 @@ main(){
         (agent_resource_control) || { err=$?; echo "ERROR: agent_resource_control"; exit $err ;}
         (agent_resource_opp)     || { err=$?; echo "ERROR: agent_resource_opp"; exit $err ;}
         (agent_upload_config)    || { err=$?; echo "ERROR: agent_upload_config"; exit $err ;}
+        (set_cronjob)            || { err=$?; echo "ERROR: set_cronjob"; exit $err ;}
         echo $WMA_BUILD_ID > $wmaInitUsing
         (check_wmagent_init)     || { err=$?; echo "ERROR: Unresolved wmaInitId vs. wmaBuildId mismatch"; exit $err ; }
         echo && echo "Docker container has been initialised! However you still need to:"


### PR DESCRIPTION
It would be nice to install the crontabs inside our wmagent docker container the first time that we initialize an agent, without the need to run the `init.sh` script a second time

changes:

- add `set_cronjobs` to the list of functions that are called when initializing the agent, the first time `init.sh` is called. yes, it was this easy. thanks for having a properly organized set of starting scripts :)

status:

- [x] tested [1]

fyi: @amaltaro 

---

[1]

<details>

Extract of the init.sh script on vocms0262

```plaintext
[...]
-----------------------------------------------------------------------
Start: Populating cronjob with utilitarian scripts for user: cmst1
Setting up cron jobs for the job dump.
Done: Populating cronjob with utilitarian scripts for user: cmst1!

-----------------------------------------------------------------------
-------------------------------------------------------
Start: Performing checks for successful WMAgent initialisation steps...
WMA_BUILD_ID: 0fd7d1833844253d87dd014218f5f0c8cf6f8a2eb9ed9c9eab0d5ebb061e4607
wmaInitId: 0fd7d1833844253d87dd014218f5f0c8cf6f8a2eb9ed9c9eab0d5ebb061e4607
OK

Docker container has been initialised! However you still need to:
  1) Double check agent configuration: less /data/[dockerMount]/srv/wmagent/current/config/config.py
  2) Start the agent by either of the methods bellow:
     a) From inside the already running container
          * Access the running WMAgent container:
            docker exec -it wmagent bash
          * Use the regular manage script inside the container:
            manage start-agent

     b) From the host - by restarting the whole container
          * Kill the currently running container:
            docker stop wmagent -t 30
          * Start a fresh instance of wmagent:
            ./wmagent-docker-run.sh -t <WMA_TAG> && docker logs -f wmagent

     c) If you are deploying inside a virtual environment
          * Activate the environment:
            cd <Deployment_dir> && . bin/activate
          * Use the regular manage script inside the virtual environment:
            manage start-agent

Have a nice day!

Start sleeping now ...zzz...
```

and we can check that the crontab is there even if the agent components are not running yet

```plaintext
cmst1@vocms0262:wmagent $ docker exec -it wmagent crontab -l
55 */12 * * * date -Im >> /data/srv/wmagent/2.3.7/logs/renew-proxy.log && /usr/local/bin/manage renew-proxy 2>&1 >> /data/srv/wmagent/2.3.7/logs/renew-proxy.log
58 */12 * * * python /usr/local/deploy/checkProxy.py --proxy /data/certs/myproxy.pem --time 120 --send-mail True --mail alan.malta@cern.ch
*/15 * * * *  source /usr/local/deploy/restartComponent.sh 2>&1 >> /data/srv/wmagent/2.3.7/logs/component-restart.log
* * * * * echo 'http://cmst1:Someslc7Senha@127.0.0.1:5984/wmagent_jobdump\%2Fjobs/_design/JobDump/_view/statusByWorkflowName?limit=1' | sed -e 's|\\||g' | xargs curl -s -m 1 > /dev/null
* * * * * echo 'http://cmst1:Someslc7Senha@127.0.0.1:5984/wmagent_jobdump\%2Ffwjrs/_design/FWJRDump/_view/outputByJobID?limit=1' | sed -e 's|\\||g' | xargs curl -s -m 1 > /dev/null
cmst1@vocms0262:wmagent $ docker exec -it wmagent manage status
----------------------------------------------------------------------
Status of services:
_status_of_couch:
{"couchdb":"Welcome","version":"3.2.2","git_sha":"d5b746b7c","uuid":"18f53118737ed74893055db0ffa972e2","features":["access-ready","partitioned","pluggable-storage-engines","reshard","scheduler"]}
_status_of_couch: CouchDB connection is OK!


_status_of_mysql:
Uptime: 1502  Threads: 1  Questions: 5230  Slow queries: 0  Opens: 156  Open tables: 63  Queries per second avg: 3.482
_status_of_mysql: MySQL connection is OK!


----------------------------------------------------------------------
Status of WMAgent components:
Status of WMAgent:
Checking default database connection... ok.
Status components: ['WorkQueueManager', 'DBS3Upload', 'JobAccountant', 'JobCreator', 'JobSubmitter', 'JobTracker', 'JobStatusLite', 'JobUpdater', 'ErrorHandler', 'RetryManager', 'JobArchiver', 'TaskArchiver', 'AnalyticsDataCollector', 'ArchiveDataReporter', 'AgentStatusWatcher', 'RucioInjector', 'WorkflowUpdater']
Component:WorkQueueManager Not Running
Component:DBS3Upload Not Running
Component:JobAccountant Not Running
Component:JobCreator Not Running
Component:JobSubmitter Not Running
Component:JobTracker Not Running
Component:JobStatusLite Not Running
Component:JobUpdater Not Running
Component:ErrorHandler Not Running
Component:RetryManager Not Running
Component:JobArchiver Not Running
Component:TaskArchiver Not Running
Component:AnalyticsDataCollector Not Running
Component:ArchiveDataReporter Not Running
Component:AgentStatusWatcher Not Running
Component:RucioInjector Not Running
Component:WorkflowUpdater Not Running
----------------------------------------------------------------------
```

</details>