### PR TITLE
Avoid -u parameter when using the OS crontab for WMAgent

### DIFF
--- a/docker/pypi/wmagent/init.sh
+++ b/docker/pypi/wmagent/init.sh
@@ -332,11 +332,14 @@ set_cronjob() {
     # Avoid -u parameter when using the OS crontab
     _is_venv && crontabParams="" || crontabParams="-u $WMA_USER"
 
+    # Activate the environment if cronjobs are to run under virtual env
+    _is_venv && crontabEnvStr="source $WMA_ROOT_DIR/bin/activate > /dev/null && " || crontabEnvStr=""
+
     # Populating proxy related cronjobs
     crontab $crontabParams - <<EOF
-55 */12 * * * date -Im >> $WMA_LOG_DIR/renew-proxy.log && $WMA_MANAGE_DIR/manage renew-proxy 2>&1 >> $WMA_LOG_DIR/renew-proxy.log
-58 */12 * * * python $WMA_DEPLOY_DIR/deploy/checkProxy.py --proxy $X509_USER_PROXY --time 120 --send-mail True --mail alan.malta@cern.ch
-*/15 * * * *  source $WMA_DEPLOY_DIR/deploy/restartComponent.sh 2>&1 >> $WMA_LOG_DIR/component-restart.log
+55 */12 * * * $crontabEnvStr date -Im >> $WMA_LOG_DIR/renew-proxy.log && $WMA_MANAGE_DIR/manage renew-proxy 2>&1 >> $WMA_LOG_DIR/renew-proxy.log
+58 */12 * * * $crontabEnvStr python $WMA_DEPLOY_DIR/deploy/checkProxy.py --proxy $X509_USER_PROXY --time 120 --send-mail True --mail alan.malta@cern.ch
+*/15 * * * *  $crontabEnvStr source $WMA_DEPLOY_DIR/deploy/restartComponent.sh 2>&1 >> $WMA_LOG_DIR/component-restart.log
 EOF
     let errVal+=$?
 

--- a/docker/pypi/wmagent/init.sh
+++ b/docker/pypi/wmagent/init.sh
@@ -329,8 +329,11 @@ set_cronjob() {
     echo "Start: $stepMsg"
     local errVal=0
 
+    # Avoid -u parameter when using the OS crontab
+    _is_venv && crontabParams="" || crontabParams="-u $WMA_USER"
+
     # Populating proxy related cronjobs
-    crontab -u $WMA_USER - <<EOF
+    crontab $crontabParams - <<EOF
 55 */12 * * * date -Im >> $WMA_LOG_DIR/renew-proxy.log && $WMA_MANAGE_DIR/manage renew-proxy 2>&1 >> $WMA_LOG_DIR/renew-proxy.log
 58 */12 * * * python $WMA_DEPLOY_DIR/deploy/checkProxy.py --proxy /data/certs/myproxy.pem --time 120 --send-mail True --mail alan.malta@cern.ch
 */15 * * * *  source $WMA_DEPLOY_DIR/deploy/restartComponent.sh 2>&1 >> $WMA_LOG_DIR/component-restart.log

--- a/docker/pypi/wmagent/init.sh
+++ b/docker/pypi/wmagent/init.sh
@@ -335,7 +335,7 @@ set_cronjob() {
     # Populating proxy related cronjobs
     crontab $crontabParams - <<EOF
 55 */12 * * * date -Im >> $WMA_LOG_DIR/renew-proxy.log && $WMA_MANAGE_DIR/manage renew-proxy 2>&1 >> $WMA_LOG_DIR/renew-proxy.log
-58 */12 * * * python $WMA_DEPLOY_DIR/deploy/checkProxy.py --proxy /data/certs/myproxy.pem --time 120 --send-mail True --mail alan.malta@cern.ch
+58 */12 * * * python $WMA_DEPLOY_DIR/deploy/checkProxy.py --proxy $X509_USER_PROXY --time 120 --send-mail True --mail alan.malta@cern.ch
 */15 * * * *  source $WMA_DEPLOY_DIR/deploy/restartComponent.sh 2>&1 >> $WMA_LOG_DIR/component-restart.log
 EOF
     let errVal+=$?


### PR DESCRIPTION
Fixes: https://github.com/dmwm/WMCore/issues/12166

With the current change we no longer  try to use the `-u` parameter when the OS `crontab` is used. This is vital for the virtual environment setups, because it breaks with:
```
must be privileged to use -u
``` 

#### Related PRs
https://github.com/dmwm/WMCore/pull/12167
