### PR TITLE
Use s-nail host mail server (FNAL/CERN)

### DIFF
--- a/docker/pypi/wmagent/Dockerfile
+++ b/docker/pypi/wmagent/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile-upstream:master
-FROM registry.cern.ch/cmsweb/wmagent-base:pypi-20241107-stable
+FROM registry.cern.ch/cmsweb/wmagent-base:pypi-20250121-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 
 # TAG to be passed at build time through `--build-arg TAG=<WMA_TAG>`. Default: None


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/12159

Issue: Both CERN and FNAL already run mail agents at the host-level. Deploying a mail server inside docker (like exim4) conflicts with the host-server, since both would operate on ports 25. Running an independent mail agent on different port can lead to firewall issues as well. 

Solution: Both CERN and FNAL use the same mail agent (s-nail). Therefore, configure the containers to use the host mail agent instead.