### PR TITLE
Fix broken cron jobs redirect

### DIFF
--- a/docker/pypi/wmagent/init.sh
+++ b/docker/pypi/wmagent/init.sh
@@ -339,7 +339,7 @@ set_cronjob() {
     crontab $crontabParams - <<EOF
 55 */12 * * * $crontabEnvStr date -Im >> $WMA_LOG_DIR/renew-proxy.log && $WMA_MANAGE_DIR/manage renew-proxy >> $WMA_LOG_DIR/renew-proxy.log 2>&1
 58 */12 * * * $crontabEnvStr python $WMA_DEPLOY_DIR/deploy/checkProxy.py --proxy $X509_USER_PROXY --time 120 --send-mail True --mail alan.malta@cern.ch
-*/15 * * * *  $crontabEnvStr source $WMA_DEPLOY_DIR/deploy/restartComponent.sh >> $WMA_LOG_DIR/component-restart.log 2>&1
+*/15 * * * *  $crontabEnvStr $WMA_DEPLOY_DIR/deploy/restartComponent.sh >> $WMA_LOG_DIR/component-restart.log 2>&1
 EOF
     let errVal+=$?
 

--- a/docker/pypi/wmagent/init.sh
+++ b/docker/pypi/wmagent/init.sh
@@ -337,9 +337,9 @@ set_cronjob() {
 
     # Populating proxy related cronjobs
     crontab $crontabParams - <<EOF
-55 */12 * * * $crontabEnvStr date -Im >> $WMA_LOG_DIR/renew-proxy.log && $WMA_MANAGE_DIR/manage renew-proxy 2>&1 >> $WMA_LOG_DIR/renew-proxy.log
+55 */12 * * * $crontabEnvStr date -Im >> $WMA_LOG_DIR/renew-proxy.log && $WMA_MANAGE_DIR/manage renew-proxy >> $WMA_LOG_DIR/renew-proxy.log 2>&1
 58 */12 * * * $crontabEnvStr python $WMA_DEPLOY_DIR/deploy/checkProxy.py --proxy $X509_USER_PROXY --time 120 --send-mail True --mail alan.malta@cern.ch
-*/15 * * * *  $crontabEnvStr source $WMA_DEPLOY_DIR/deploy/restartComponent.sh 2>&1 >> $WMA_LOG_DIR/component-restart.log
+*/15 * * * *  $crontabEnvStr source $WMA_DEPLOY_DIR/deploy/restartComponent.sh >> $WMA_LOG_DIR/component-restart.log 2>&1
 EOF
     let errVal+=$?
 


### PR DESCRIPTION
Fixes: https://github.com/dmwm/WMCore/issues/12184

With the current PR we fix the broken order of `stdError` to  `stdOut` redirect in the WMAgent's cronjobs in order to stop the eventual spam which would have been generated, once we fix the e-mailing mechanism in our Docker containers.