### PR TITLE
Halt wmagent docker run scripts as soon as a second container is detected at the machine

### DIFF
--- a/docker/pypi/wmagent/wmagent-docker-run.sh
+++ b/docker/pypi/wmagent/wmagent-docker-run.sh
@@ -136,7 +136,10 @@ echo "Checking if there is no other wmagent container running and creating a lin
     ln -s $HOST_MOUNT_DIR/srv/wmagent/$WMA_VER_RELEASE $HOST_MOUNT_DIR/srv/wmagent/current )
 
 echo "Starting $registry/$repository:$WMA_TAG docker container with user: $wmaUser:$wmaGroup"
-docker run $dockerOpts $registry/$repository:$WMA_TAG
+docker run $dockerOpts $registry/$repository:$WMA_TAG || {
+    echo "ERROR: WMAgent already running at this machine. Execution HALTED!"
+    exit 1
+}
 docker exec -u root -it wmagent service cron start
 
 # Workaround su authentication issue (cron uses setuid via su)


### PR DESCRIPTION
Fixes: https://github.com/dmwm/WMCore/issues/12190 

With the current change we  halt the execution of the whole docker run script as soon as we find another wmagent container already running at the machine. During the tests the agent statup sequence was perfect: 

```
cmst1@vocms0290:CMSKubernetes.wmagent $ cd docker/pypi/wmagent
cmst1@vocms0290:wmagent $ ./wmagent-docker-run.sh -t 2.3.8rc5  && docker logs -f wmagent 
Using WMAgent version: 2.3.8rc5 under release: 2.3.8

Checking if there is no other wmagent container running and creating a link to the 2.3.8 in the host mount area.
Starting local/wmagent:2.3.8rc5 docker container with user: cmst1:zh
docker: Error response from daemon: Conflict. The container name "/wmagent" is already in use by container "22835eccc7c65887dd52dce582dfd9cfeb0f05e0e5a919998c2454531297af11". You have to remove (or rename) that container to be able to reuse that name.
See 'docker run --help'.
ERROR: WMAgent already running at this machine. Execution HALTED!

``` 