### PR TITLE
Add s-nail package to base image

### DIFF
--- a/docker/pypi/wmagent-base/Dockerfile
+++ b/docker/pypi/wmagent-base/Dockerfile
@@ -11,6 +11,9 @@ RUN apt-get install -y hostname net-tools iputils-ping procps jq && apt-get clea
 # Install recursive ps utility tool
 RUN apt-get install -y pslist && apt-get clean
 
+# Install s-nail package
+RUN apt-get install -y s-nail && apt-get clean
+
 # copy oracle client:
 COPY --from=oracle /usr/lib/oracle /usr/lib/oracle
 ENV LD_LIBRARY_PATH=/usr/lib/oracle


### PR DESCRIPTION
Related to issue:
https://github.com/dmwm/WMCore/issues/12159

and PR:
https://github.com/dmwm/CMSKubernetes/pull/1566

This install the s-nail package in the base image, rather than at runtime