### PR TITLE
Update Dockerfile-spark3-el9

### DIFF
--- a/docker/cmsmon-hadoop-base/Dockerfile-spark3-el9
+++ b/docker/cmsmon-hadoop-base/Dockerfile-spark3-el9
@@ -70,6 +70,6 @@ RUN dnf update -y && \
     jq trustedbag-client cern-hadoop-xrootd-connector && \
     dnf clean all
 
-RUN hadoop-set-default-conf.sh analytix
+RUN hadoop-set-default-conf.sh hadoop-analytix
 
 COPY --from=builder /data $WDIR


### PR DESCRIPTION
`analytix` has been changed to `hadoop-analytix` with [OTG0155042](https://cern.service-now.com/service-portal?id=outage&n=OTG0155042)

FYI @leggerf 