### PR TITLE
Update alertmanager version

### DIFF
--- a/docker/sqoop/Dockerfile
+++ b/docker/sqoop/Dockerfile
@@ -26,8 +26,8 @@ RUN CGO_ENABLED=0 go build -ldflags "-s -w -extldflags '-static'" monit.go && \
 WORKDIR $WDIR
 
 # get amtool
-RUN curl -ksLO https://github.com/prometheus/alertmanager/releases/download/v0.24.0/alertmanager-0.24.0.linux-amd64.tar.gz
-RUN tar xfz alertmanager-0.24.0.linux-amd64.tar.gz && mv alertmanager-0.24.0.linux-amd64/amtool $WDIR/ && rm -rf alertmanager-0.24.0.linux-amd64*
+RUN curl -ksLO https://github.com/prometheus/alertmanager/releases/download/v0.28.1/alertmanager-0.28.1.linux-amd64.tar.gz
+RUN tar xfz alertmanager-0.28.1.linux-amd64.tar.gz && mv alertmanager-0.28.1.linux-amd64/amtool $WDIR/ && rm -rf alertmanager-0.28.1.linux-amd64*
 
 
 FROM registry.cern.ch/cmsmonitoring/cmsmon-hadoop-base:spark2-latest

--- a/kubernetes/monitoring/services/alertmanager.yaml
+++ b/kubernetes/monitoring/services/alertmanager.yaml
@@ -39,7 +39,7 @@ spec:
           - --web.external-url=https://cms-monitoring.cern.ch/alertmanager
           - --web.route-prefix=/
           name: alertmanager
-          image: prom/alertmanager
+          image: prom/alertmanager:v0.28.1
           ports:
           - containerPort: 9093
             protocol: TCP

--- a/kubernetes/monitoring/services/ha/alertmanager-ha1.yaml
+++ b/kubernetes/monitoring/services/ha/alertmanager-ha1.yaml
@@ -44,7 +44,7 @@ spec:
           - --web.route-prefix=/
           - --cluster.peer=cms-monitoring-ha2:30094 # to mesh with AM on HA2
           name: alertmanager
-          image: prom/alertmanager
+          image: prom/alertmanager:v0.28.1
           ports:
           - containerPort: 9093
             protocol: TCP

--- a/kubernetes/monitoring/services/ha/alertmanager-ha2.yaml
+++ b/kubernetes/monitoring/services/ha/alertmanager-ha2.yaml
@@ -44,7 +44,7 @@ spec:
           - --web.route-prefix=/
           - --cluster.peer=cms-monitoring-ha1:30094 # to mesh with AM on HA1
           name: alertmanager
-          image: prom/alertmanager
+          image: prom/alertmanager:v0.28.1
           ports:
           - containerPort: 9093
             protocol: TCP


### PR DESCRIPTION
This PR targets https://its.cern.ch/jira/browse/CMSMONIT-631.

Updates AlertManager version to v0.28.1 in both High Availability clusters, as well as in the main cluster