### PR TITLE
Set 2 replicas instead of 5 for WM testbed services

### DIFF
--- a/kubernetes/cmsweb/scripts/deploy-srv.sh
+++ b/kubernetes/cmsweb/scripts/deploy-srv.sh
@@ -203,9 +203,9 @@ elif  [ "$cmsweb_env" == "k8s-preprod" ] ; then
             cat $srv.yaml | sed -e "s,1 #PROD#,,g" | sed -e "s,#PROD#,      ,g" |  sed -e "s,logs-cephfs-claim,$cmsweb_log,g" | sed -e "s, #imagetag,$cmsweb_image_tag,g" | sed -e "s,k8s #k8s#,$cmsweb_env,g" | sed -e 's+dbs/prod+dbs/int+g' |  kubectl apply -f -
 	
 	else
-            cat $srv.yaml | sed -e "s,1 #PROD#,,g" | sed -e "s,#PROD#,      ,g" |  sed -e "s,logs-cephfs-claim,$cmsweb_log,g" | sed -e "s, #imagetag,$cmsweb_image_tag,g" | sed -e "s,k8s #k8s#,$cmsweb_env,g" >  $srv.yaml.new
+            cat $srv.yaml | sed -e "s,1 #PROD# 5,2,g" | sed -e "s,#PROD#,      ,g" |  sed -e "s,logs-cephfs-claim,$cmsweb_log,g" | sed -e "s, #imagetag,$cmsweb_image_tag,g" | sed -e "s,k8s #k8s#,$cmsweb_env,g" >  $srv.yaml.new
 
-            cat $srv.yaml | sed -e "s,1 #PROD#,,g" | sed -e "s,#PROD#,      ,g" |  sed -e "s,logs-cephfs-claim,$cmsweb_log,g" | sed -e "s, #imagetag,$cmsweb_image_tag,g" | sed -e "s,k8s #k8s#,$cmsweb_env,g" | kubectl apply -f -
+            cat $srv.yaml | sed -e "s,1 #PROD# 5,2,g" | sed -e "s,#PROD#,      ,g" |  sed -e "s,logs-cephfs-claim,$cmsweb_log,g" | sed -e "s, #imagetag,$cmsweb_image_tag,g" | sed -e "s,k8s #k8s#,$cmsweb_env,g" | kubectl apply -f -
         fi	
 
 elif [ "$srv" == "crabserver" ]; then


### PR DESCRIPTION
Any WM service that is currently (24/Apr/2025) running with 5 replicas, will start running with 2 replicas - only for cmsweb-testbed environment (defined in the script as `k8s-preprod`).