### PR TITLE
WMAgent: define rule lifetime for dev/test agents

### DIFF
--- a/docker/pypi/wmagent/init.sh
+++ b/docker/pypi/wmagent/init.sh
@@ -511,6 +511,9 @@ agent_tweakconfig() {
             rucio_auth=https://cms-rucio-auth.cern.ch
             sed -i "s+WorkQueueManager.rucioUrl = .*+WorkQueueManager.rucioUrl = '$rucio_host'+" $WMA_CONFIG_DIR/config.py
             sed -i "s+WorkQueueManager.rucioAuthUrl = .*+WorkQueueManager.rucioAuthUrl = '$rucio_auth'+" $WMA_CONFIG_DIR/config.py
+            # Tweak rule lifetime, see https://github.com/dmwm/WMCore/issues/12316
+            sed -i "s+RucioInjector.blockRuleParams = {}+RucioInjector.blockRuleParams = {'lifetime': 14 * 24 * 60 * 60}+" $WMA_CONFIG_DIR/config.py
+            sed -i "s+RucioInjector.containerDiskRuleParams = {+RucioInjector.containerDiskRuleParams = {'lifetime': 14 * 24 * 60 * 60, +" $WMA_CONFIG_DIR/config.py
         fi
 
         local forceSiteDown=""


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/12316

For agents connected to Rucio Int (testbed and/or development agents), enrich the RucioInjector component attributes, such that output rules created by the agent carry a lifetime (default of 14 days). Component attributes are:
```
config.RucioInjector.blockRuleParams = {}
config.RucioInjector.containerDiskRuleParams = {'weight': 'dm_weight', 'copies': 2, 'grouping': 'DATASET'}
```

which will be updated with `lifetime=expire_in_secs`.

This is yet to be tested, but I welcome a review. Thanks