### PR TITLE
Remove rotatelogs (apache2-utils)

### DIFF
--- a/docker/pypi/dmwm-base/Dockerfile
+++ b/docker/pypi/dmwm-base/Dockerfile
@@ -3,7 +3,7 @@ FROM registry.cern.ch/cmsweb/exporters as exporters
 FROM python:3.8-bullseye
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 RUN apt-get update && \
-    apt-get install -y curl vim libcurl4 libcurl4-openssl-dev python3-pycurl pip apache2-utils sudo less && \
+    apt-get install -y curl vim libcurl4 libcurl4-openssl-dev python3-pycurl pip sudo less && \
     apt-get clean
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN mkdir /etc/grid-security


### PR DESCRIPTION
Extends https://github.com/dmwm/WMCore/pull/11955

Removes rotatelogs (apache2-utils)
Related to changes made in dmwm/WMCore to use python native log rotation

This is needed after the above PR is merged, since we won't be using `rotatelogs` and instead be using Python's native log rotation mechanisms