### PR TITLE
wmcore - switch to py3.12 for pypi docker images

### DIFF
--- a/docker/pypi/dmwm-base/Dockerfile
+++ b/docker/pypi/dmwm-base/Dockerfile
@@ -1,14 +1,17 @@
-FROM registry.cern.ch/cmsweb/cmsweb-base as cmsweb-base
-FROM registry.cern.ch/cmsweb/exporters as exporters
-FROM python:3.8-bullseye
+FROM registry.cern.ch/cmsweb/exporters:20250519-stable as exporters
+FROM python:3.12-slim-bookworm
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
-RUN apt-get update && \
-    apt-get install -y curl vim libcurl4 libcurl4-openssl-dev python3-pycurl pip apache2-utils sudo less && \
-    apt-get clean
+
+# see https://docs.docker.com/build/building/best-practices/#apt-get
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl libcurl4 libcurl4-openssl-dev python3-pycurl \ 
+    apache2-utils \
+    sudo less vim git \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN mkdir /etc/grid-security
-COPY --from=cmsweb-base /etc/grid-security/certificates /etc/grid-security/certificates
-COPY --from=cmsweb-base /etc/grid-security/vomsdir /etc/grid-security/vomsdir
 COPY --from=exporters /data/cmsweb-ping /usr/bin/cmsweb-ping
 COPY --from=exporters /data/process_exporter /usr/bin/process_exporter
 COPY --from=exporters /data/cpy_exporter /usr/bin/cpy_exporter

--- a/docker/pypi/msmonitor/Dockerfile
+++ b/docker/pypi/msmonitor/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20240923-stable
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250523-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/msoutput/Dockerfile
+++ b/docker/pypi/msoutput/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20240923-stable
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250523-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/mspileup/Dockerfile
+++ b/docker/pypi/mspileup/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20240923-stable
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250523-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/msrulecleaner/Dockerfile
+++ b/docker/pypi/msrulecleaner/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20240923-stable
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250523-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/mstransferor/Dockerfile
+++ b/docker/pypi/mstransferor/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20240923-stable
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250523-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/reqmgr2/Dockerfile
+++ b/docker/pypi/reqmgr2/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20240923-stable
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250523-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/reqmon/Dockerfile
+++ b/docker/pypi/reqmon/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20240923-stable
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250523-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/t0reqmon/Dockerfile
+++ b/docker/pypi/t0reqmon/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20240923-stable
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250523-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/wmagent-base/Dockerfile
+++ b/docker/pypi/wmagent-base/Dockerfile
@@ -1,18 +1,23 @@
 FROM registry.cern.ch/cmsweb/oracle:21_5-stable as oracle
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20240923-stable
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250523-stable
 
-# Install basic OS package dependencies
-RUN apt-get update
-RUN apt-get install -y libmariadb-dev-compat libmariadb-dev apache2-utils cron mariadb-server myproxy voms-clients voms-clients-java rlwrap libaio1 && apt-get clean
-
-# Install some debugging tools
-RUN apt-get install -y hostname net-tools iputils-ping procps jq && apt-get clean
-
-# Install recursive ps utility tool
-RUN apt-get install -y pslist && apt-get clean
-
-# Install s-nail package
-RUN apt-get install -y s-nail && apt-get clean
+# see https://docs.docker.com/build/building/best-practices/#apt-get
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    # basic OS packages
+    cron \
+    mariadb-server libmariadb-dev-compat libmariadb-dev \
+    myproxy voms-clients voms-clients-java \
+    rlwrap libaio1 \
+    # required for cx_oracle
+    build-essential \
+    # required for yui 
+    wget unzip \
+    # debugging 
+    hostname net-tools iputils-ping procps jq \
+    # Install recursive ps utility tool
+    pslist \
+    s-nail \
+    && rm -rf /var/lib/apt/lists/*
 
 # copy oracle client:
 COPY --from=oracle /usr/lib/oracle /usr/lib/oracle

--- a/docker/pypi/wmagent/Dockerfile
+++ b/docker/pypi/wmagent/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile-upstream:master
-FROM registry.cern.ch/cmsweb/wmagent-base:pypi-20250121-stable
+FROM registry.cern.ch/cmsweb/wmagent-base:pypi-20250523-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 
 # TAG to be passed at build time through `--build-arg TAG=<WMA_TAG>`. Default: None

--- a/docker/pypi/wmagent/install.sh
+++ b/docker/pypi/wmagent/install.sh
@@ -96,7 +96,7 @@ echo "-----------------------------------------------------------------------"
 echo "Start $stepMsg"
 
 # Fix for outdated yui library - A really bad workaround. We should get rid of it ASAP:
-wget -nv -P $WMA_DEPLOY_DIR  https://yui.github.io/yui2/archives/yui_2.9.0.zip || { err=$?; echo "Error downloading yui_2.9.0.zip"; exit $err ; }
+curl  https://yui.github.io/yui2/archives/yui_2.9.0.zip -o $WMA_DEPLOY_DIR/yui_2.9.0.zip || { err=$?; echo "Error downloading yui_2.9.0.zip"; exit $err ; }
 unzip -d $WMA_DEPLOY_DIR $WMA_DEPLOY_DIR/yui_2.9.0.zip yui/build/*
 rm -f $WMA_DEPLOY_DIR/yui_2.9.0.zip
 

--- a/docker/pypi/wmglobalqueue/Dockerfile
+++ b/docker/pypi/wmglobalqueue/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20240923-stable
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250523-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None


### PR DESCRIPTION
### status

tested, if we have consensus on the format of the new tags, it can be merged

warning: do not create a new tag in dmwm/WMCore yet, we (i) need to build and push the new tags for dmwm-base and wmagent-base first

### description

move wmcore images from python:3.8 based on debian 11 (`bullseye`) to python:3.12 based on debian 12 (`bookworm`).

moving from a "full" debian image to a slim one requires adding a few packages manually:
    - `git`, `build-essential` (gcc), `unzip`

~~moreover, i specified the latest available tag for `cmsweb/cmsweb-base` and `cmsweb/exportes`, as i do not like to rely on `latest`.~~

Moreover:

- using the most recent cmsweb-alma9-base image
- using the most recent exporter image

