### PR TITLE
Update das-mongo-exporter.yaml

### DIFF
--- a/kubernetes/cmsweb/services/das-mongo-exporter.yaml
+++ b/kubernetes/cmsweb/services/das-mongo-exporter.yaml
@@ -60,5 +60,5 @@ spec:
           name: das-mongo-p
       initContainers:
       - name: checkcouchdb
-        image: busybox:1.28
-        command: ['sh', '-c', 'until nslookup das-mongo.das; do echo "Waiting for das-mongo"; sleep 10; done;']
+        image: busybox:1.36.1 #the stable tag
+        command: ['sh', '-c', 'until nslookup das-mongo.das.svc.cluster.local; do echo "Waiting for das-mongo"; sleep 10; done;']

--- a/kubernetes/cmsweb/services/das-mongo-exporter.yaml
+++ b/kubernetes/cmsweb/services/das-mongo-exporter.yaml
@@ -59,6 +59,6 @@ spec:
           protocol: TCP
           name: das-mongo-p
       initContainers:
-      - name: checkcouchdb
+      - name: checkmongodb
         image: busybox:1.36.1 #the stable tag
         command: ['sh', '-c', 'until nslookup das-mongo.das.svc.cluster.local; do echo "Waiting for das-mongo"; sleep 10; done;']


### PR DESCRIPTION
Update busybox to the stable version(1.36.1), and apply a patch for the newer nslookup command.