### PR TITLE
wmcore - load all CAs from k8s host

### DIFF
--- a/helm/reqmgr2-tasks/templates/configMap.yaml
+++ b/helm/reqmgr2-tasks/templates/configMap.yaml
@@ -34,8 +34,6 @@ metadata:
 data:
   setup-certs-and-run.sh: |
     #!/bin/bash
-
-    sudo cp /host/etc/grid-security/* /etc/grid-security
     echo 'INFO Files in /etc/grid-security'
     ls -lahZ /etc/grid-security
     #su  -c "cd /data && /data/run.sh" --preserve-environment _reqmgr2

--- a/helm/reqmgr2-tasks/templates/deployment.yaml
+++ b/helm/reqmgr2-tasks/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
         - name: hmac-secrets
           mountPath: /etc/hmac
           readOnly: true
-        - mountPath: /host/etc/grid-security
+        - mountPath: /etc/grid-security
           name: etc-grid-security
           readOnly: true
         - name: setup-certs-and-run

--- a/helm/reqmgr2/templates/configMap.yaml
+++ b/helm/reqmgr2/templates/configMap.yaml
@@ -34,8 +34,6 @@ metadata:
 data:
   setup-certs-and-run.sh: |
     #!/bin/bash
-
-    sudo cp /host/etc/grid-security/* /etc/grid-security
     echo 'INFO Files in /etc/grid-security'
     ls -lahZ /etc/grid-security
     #su  -c "cd /data && /data/run.sh" --preserve-environment _reqmgr2

--- a/helm/reqmgr2/templates/deployment.yaml
+++ b/helm/reqmgr2/templates/deployment.yaml
@@ -61,7 +61,7 @@ spec:
         - name: hmac-secrets
           mountPath: /etc/hmac
           readOnly: true
-        - mountPath: /host/etc/grid-security
+        - mountPath: /etc/grid-security
           name: etc-grid-security
           readOnly: true
         - name: setup-certs-and-run

--- a/helm/reqmgr2ms-monitor/templates/configMap.yaml
+++ b/helm/reqmgr2ms-monitor/templates/configMap.yaml
@@ -34,7 +34,6 @@ metadata:
 data:
   setup-certs-and-run.sh: |
     #!/bin/bash
-    sudo cp /host/etc/grid-security/* /etc/grid-security
     echo 'INFO Files in /etc/grid-security'
     ls -lahZ /etc/grid-security
     #su  -c "cd /data && /data/run.sh" --preserve-environment _reqmgr2ms

--- a/helm/reqmgr2ms-monitor/templates/deployment.yaml
+++ b/helm/reqmgr2ms-monitor/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
         - name: hmac-secrets
           mountPath: /etc/hmac
           readOnly: true
-        - mountPath: /host/etc/grid-security
+        - mountPath: /etc/grid-security
           name: etc-grid-security
           readOnly: true
         - name: setup-certs-and-run

--- a/helm/reqmgr2ms-output/templates/configMap.yaml
+++ b/helm/reqmgr2ms-output/templates/configMap.yaml
@@ -34,7 +34,6 @@ metadata:
 data:
   setup-certs-and-run.sh: |
     #!/bin/bash
-    sudo cp /host/etc/grid-security/* /etc/grid-security
     echo 'INFO Files in /etc/grid-security'
     ls -lahZ /etc/grid-security
     #su  -c "cd /data && /data/run.sh" --preserve-environment _reqmgr2ms

--- a/helm/reqmgr2ms-output/templates/deployment.yaml
+++ b/helm/reqmgr2ms-output/templates/deployment.yaml
@@ -58,7 +58,7 @@ spec:
         - name: hmac-secrets
           mountPath: /etc/hmac
           readOnly: true
-        - mountPath: /host/etc/grid-security
+        - mountPath: /etc/grid-security
           name: etc-grid-security
           readOnly: true
         - name: setup-certs-and-run

--- a/helm/reqmgr2ms-pileup-tasks/templates/configMap.yaml
+++ b/helm/reqmgr2ms-pileup-tasks/templates/configMap.yaml
@@ -35,7 +35,6 @@ metadata:
 data:
   setup-certs-and-run.sh: |
     #!/bin/bash
-    sudo cp /host/etc/grid-security/* /etc/grid-security
     echo 'INFO Files in /etc/grid-security'
     ls -lahZ /etc/grid-security
     mkdir -p /data/srv/logs/reqmgr2ms

--- a/helm/reqmgr2ms-pileup-tasks/templates/deployment.yaml
+++ b/helm/reqmgr2ms-pileup-tasks/templates/deployment.yaml
@@ -60,7 +60,7 @@ spec:
           - name: hmac-secrets
             mountPath: /etc/hmac
             readOnly: true
-          - mountPath: /host/etc/grid-security
+          - mountPath: /etc/grid-security
             name: etc-grid-security
             readOnly: true
           - name: setup-certs-and-run

--- a/helm/reqmgr2ms-pileup/templates/configMap.yaml
+++ b/helm/reqmgr2ms-pileup/templates/configMap.yaml
@@ -35,7 +35,6 @@ metadata:
 data:
   setup-certs-and-run.sh: |
     #!/bin/bash
-    sudo cp /host/etc/grid-security/* /etc/grid-security
     echo 'INFO Files in /etc/grid-security'
     ls -lahZ /etc/grid-security
     mkdir -p /data/srv/logs/reqmgr2ms

--- a/helm/reqmgr2ms-pileup/templates/deployment.yaml
+++ b/helm/reqmgr2ms-pileup/templates/deployment.yaml
@@ -60,7 +60,7 @@ spec:
           - name: hmac-secrets
             mountPath: /etc/hmac
             readOnly: true
-          - mountPath: /host/etc/grid-security
+          - mountPath: /etc/grid-security
             name: etc-grid-security
             readOnly: true
           - name: setup-certs-and-run

--- a/helm/reqmgr2ms-rulecleaner/templates/configMap.yaml
+++ b/helm/reqmgr2ms-rulecleaner/templates/configMap.yaml
@@ -34,7 +34,6 @@ metadata:
 data:
   setup-certs-and-run.sh: |
     #!/bin/bash
-    sudo cp /host/etc/grid-security/* /etc/grid-security
     echo 'INFO Files in /etc/grid-security'
     ls -lahZ /etc/grid-security
     #su  -c "cd /data && /data/run.sh" --preserve-environment _reqmgr2ms

--- a/helm/reqmgr2ms-rulecleaner/templates/deployment.yaml
+++ b/helm/reqmgr2ms-rulecleaner/templates/deployment.yaml
@@ -58,7 +58,7 @@ spec:
         - name: hmac-secrets
           mountPath: /etc/hmac
           readOnly: true
-        - mountPath: /host/etc/grid-security
+        - mountPath: /etc/grid-security
           name: etc-grid-security
           readOnly: true
         - name: setup-certs-and-run

--- a/helm/reqmgr2ms-transferor/templates/configMap.yaml
+++ b/helm/reqmgr2ms-transferor/templates/configMap.yaml
@@ -34,7 +34,6 @@ metadata:
 data:
   setup-certs-and-run.sh: |
     #!/bin/bash
-    sudo cp /host/etc/grid-security/* /etc/grid-security
     echo 'INFO Files in /etc/grid-security'
     ls -lahZ /etc/grid-security
     #su  -c "cd /data && /data/run.sh" --preserve-environment _reqmgr2ms

--- a/helm/reqmgr2ms-transferor/templates/deployment.yaml
+++ b/helm/reqmgr2ms-transferor/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
         - name: hmac-secrets
           mountPath: /etc/hmac
           readOnly: true
-        - mountPath: /host/etc/grid-security
+        - mountPath: /etc/grid-security
           name: etc-grid-security
           readOnly: true
         - name: setup-certs-and-run

--- a/helm/reqmgr2ms-unmerged-t1/templates/configMap.yaml
+++ b/helm/reqmgr2ms-unmerged-t1/templates/configMap.yaml
@@ -34,7 +34,6 @@ metadata:
 data:
   setup-certs-and-run.sh: |
     #!/bin/bash
-    sudo cp /host/etc/grid-security/* /etc/grid-security
     echo 'INFO Files in /etc/grid-security'
     ls -lahZ /etc/grid-security
     #su  -c "cd /data && /data/run.sh -e '(cms_type=real|cms_type=int)&rse_type=DISK&tier=1' " --preserve-environment _reqmgr2ms

--- a/helm/reqmgr2ms-unmerged-t1/templates/deployment.yaml
+++ b/helm/reqmgr2ms-unmerged-t1/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
         - name: hmac-secrets
           mountPath: /etc/hmac
           readOnly: true
-        - mountPath: /host/etc/grid-security
+        - mountPath: /etc/grid-security
           name: etc-grid-security
           readOnly: true
         - name: setup-certs-and-run

--- a/helm/reqmgr2ms-unmerged-t2t3/templates/configMap.yaml
+++ b/helm/reqmgr2ms-unmerged-t2t3/templates/configMap.yaml
@@ -34,7 +34,6 @@ metadata:
 data:
   setup-certs-and-run.sh: |
     #!/bin/bash
-    sudo cp /host/etc/grid-security/* /etc/grid-security
     echo 'INFO Files in /etc/grid-security'
     ls -lahZ /etc/grid-security
     # su  -c "cd /data && /data/run.sh -e '(((cms_type=real|cms_type=int)&rse_type=DISK&(tier=2|tier=3))\country=US)' " --preserve-environment _reqmgr2ms

--- a/helm/reqmgr2ms-unmerged-t2t3/templates/deployment.yaml
+++ b/helm/reqmgr2ms-unmerged-t2t3/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
         - name: hmac-secrets
           mountPath: /etc/hmac
           readOnly: true
-        - mountPath: /host/etc/grid-security
+        - mountPath: /etc/grid-security
           name: etc-grid-security
           readOnly: true
         - name: setup-certs-and-run

--- a/helm/reqmgr2ms-unmerged-t2t3us/templates/configMap.yaml
+++ b/helm/reqmgr2ms-unmerged-t2t3us/templates/configMap.yaml
@@ -34,7 +34,6 @@ metadata:
 data:
   setup-certs-and-run.sh: |
     #!/bin/bash
-    sudo cp /host/etc/grid-security/* /etc/grid-security
     echo 'INFO Files in /etc/grid-security'
     ls -lahZ /etc/grid-security
     #su  -c "cd /data && /data/run.sh -e '(((cms_type=real|cms_type=int)&rse_type=DISK&(tier=2|tier=3))&country=US)' " --preserve-environment _reqmgr2ms

--- a/helm/reqmgr2ms-unmerged-t2t3us/templates/deployment.yaml
+++ b/helm/reqmgr2ms-unmerged-t2t3us/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
         - name: hmac-secrets
           mountPath: /etc/hmac
           readOnly: true
-        - mountPath: /host/etc/grid-security
+        - mountPath: /etc/grid-security
           name: etc-grid-security
           readOnly: true
         - name: setup-certs-and-run

--- a/helm/reqmon-tasks/templates/configMap.yaml
+++ b/helm/reqmon-tasks/templates/configMap.yaml
@@ -34,8 +34,6 @@ metadata:
 data:
   setup-certs-and-run.sh: |
     #!/bin/bash
-
-    sudo cp /host/etc/grid-security/* /etc/grid-security
     echo 'INFO Files in /etc/grid-security'
     ls -lahZ /etc/grid-security
     #su  -c "cd /data && /data/run.sh" --preserve-environment _reqmon-tasks

--- a/helm/reqmon-tasks/templates/deployment.yaml
+++ b/helm/reqmon-tasks/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
         - name: hmac-secrets
           mountPath: /etc/hmac
           readOnly: true
-        - mountPath: /host/etc/grid-security
+        - mountPath: /etc/grid-security
           name: etc-grid-security
           readOnly: true
         - name: setup-certs-and-run

--- a/helm/reqmon/templates/configMap.yaml
+++ b/helm/reqmon/templates/configMap.yaml
@@ -34,8 +34,6 @@ metadata:
 data:
   setup-certs-and-run.sh: |
     #!/bin/bash
-
-    sudo cp /host/etc/grid-security/* /etc/grid-security
     echo 'INFO Files in /etc/grid-security'
     ls -lahZ /etc/grid-security
     #su  -c "cd /data && /data/run.sh" --preserve-environment _reqmon

--- a/helm/reqmon/templates/deployment.yaml
+++ b/helm/reqmon/templates/deployment.yaml
@@ -59,7 +59,7 @@ spec:
         - name: hmac-secrets
           mountPath: /etc/hmac
           readOnly: true
-        - mountPath: /host/etc/grid-security
+        - mountPath: /etc/grid-security
           name: etc-grid-security
           readOnly: true
         - name: setup-certs-and-run

--- a/helm/t0reqmon-tasks/templates/configMap.yaml
+++ b/helm/t0reqmon-tasks/templates/configMap.yaml
@@ -34,8 +34,6 @@ metadata:
 data:
   setup-certs-and-run.sh: |
     #!/bin/bash
-
-    sudo cp /host/etc/grid-security/* /etc/grid-security
     echo 'INFO Files in /etc/grid-security'
     ls -lahZ /etc/grid-security
     #su  -c "cd /data && /data/run.sh" --preserve-environment _t0_reqmon

--- a/helm/t0reqmon-tasks/templates/deployment.yaml
+++ b/helm/t0reqmon-tasks/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
         - name: hmac-secrets
           mountPath: /etc/hmac
           readOnly: true
-        - mountPath: /host/etc/grid-security
+        - mountPath: /etc/grid-security
           name: etc-grid-security
           readOnly: true
         - name: setup-certs-and-run

--- a/helm/t0reqmon/templates/configMap.yaml
+++ b/helm/t0reqmon/templates/configMap.yaml
@@ -34,8 +34,6 @@ metadata:
 data:
   setup-certs-and-run.sh: |
     #!/bin/bash
-
-    sudo cp /host/etc/grid-security/* /etc/grid-security
     echo 'INFO Files in /etc/grid-security'
     ls -lahZ /etc/grid-security
     #su  -c "cd /data && /data/run.sh" --preserve-environment _t0_reqmon

--- a/helm/t0reqmon/templates/deployment.yaml
+++ b/helm/t0reqmon/templates/deployment.yaml
@@ -61,7 +61,7 @@ spec:
         - name: hmac-secrets
           mountPath: /etc/hmac
           readOnly: true
-        - mountPath: /host/etc/grid-security
+        - mountPath: /etc/grid-security
           name: etc-grid-security
           readOnly: true
         - name: setup-certs-and-run

--- a/helm/workqueue/templates/configMap.yaml
+++ b/helm/workqueue/templates/configMap.yaml
@@ -34,7 +34,6 @@ metadata:
 data:
   setup-certs-and-run.sh: |
     #!/bin/bash
-    sudo cp /host/etc/grid-security/* /etc/grid-security
     echo 'INFO Files in /etc/grid-security'
     ls -lahZ /etc/grid-security
     #su  -c "cd /data && /data/run.sh" --preserve-environment _workqueue

--- a/helm/workqueue/templates/deployment.yaml
+++ b/helm/workqueue/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
         - name: hmac-secrets
           mountPath: /etc/hmac
           readOnly: true
-        - mountPath: /host/etc/grid-security
+        - mountPath: /etc/grid-security
           name: etc-grid-security
           readOnly: true
         - name: setup-certs-and-run

--- a/kubernetes/cmsweb/services/reqmgr2-tasks.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2-tasks.yaml
@@ -35,7 +35,6 @@ metadata:
 data:
   setup-certs-and-run.sh: |
     #!/bin/bash
-    sudo cp /host/etc/grid-security/* /etc/grid-security
     echo 'INFO Files in /etc/grid-security'
     ls -lahZ /etc/grid-security
     #su  -c "cd /data && /data/run.sh" --preserve-environment _reqmgr2
@@ -105,7 +104,7 @@ spec:
         - name: hmac-secrets
           mountPath: /etc/hmac
           readOnly: true
-        - mountPath: /host/etc/grid-security
+        - mountPath: /etc/grid-security
           name: etc-grid-security
           readOnly: true
         - name: setup-certs-and-run

--- a/kubernetes/cmsweb/services/reqmgr2.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2.yaml
@@ -49,7 +49,6 @@ data:
   setup-certs-and-run.sh: |
     #!/bin/bash
 
-    sudo cp /host/etc/grid-security/* /etc/grid-security
     echo 'INFO Files in /etc/grid-security'
     ls -lahZ /etc/grid-security
     #su  -c "cd /data && /data/run.sh" --preserve-environment _reqmgr2
@@ -135,7 +134,7 @@ spec:
         - name: hmac-secrets
           mountPath: /etc/hmac
           readOnly: true
-        - mountPath: /host/etc/grid-security
+        - mountPath: /etc/grid-security
           name: etc-grid-security
           readOnly: true
         - name: setup-certs-and-run

--- a/kubernetes/cmsweb/services/reqmgr2ms-monitor.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-monitor.yaml
@@ -48,7 +48,6 @@ metadata:
 data:
   setup-certs-and-run.sh: |
     #!/bin/bash
-    sudo cp /host/etc/grid-security/* /etc/grid-security
     echo 'INFO Files in /etc/grid-security'
     ls -lahZ /etc/grid-security
     #su  -c "cd /data && /data/run.sh" --preserve-environment _reqmgr2ms
@@ -136,7 +135,7 @@ spec:
         - name: hmac-secrets
           mountPath: /etc/hmac
           readOnly: true
-        - mountPath: /host/etc/grid-security
+        - mountPath: /etc/grid-security
           name: etc-grid-security
           readOnly: true
         - name: setup-certs-and-run

--- a/kubernetes/cmsweb/services/reqmgr2ms-output.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-output.yaml
@@ -48,7 +48,6 @@ metadata:
 data:
   setup-certs-and-run.sh: |
     #!/bin/bash
-    sudo cp /host/etc/grid-security/* /etc/grid-security
     echo 'INFO Files in /etc/grid-security'
     ls -lahZ /etc/grid-security
     #su  -c "cd /data && /data/run.sh" --preserve-environment _reqmgr2ms
@@ -136,7 +135,7 @@ spec:
         - name: hmac-secrets
           mountPath: /etc/hmac
           readOnly: true
-        - mountPath: /host/etc/grid-security
+        - mountPath: /etc/grid-security
           name: etc-grid-security
           readOnly: true
         - name: setup-certs-and-run

--- a/kubernetes/cmsweb/services/reqmgr2ms-pileup-tasks.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-pileup-tasks.yaml
@@ -48,7 +48,6 @@ metadata:
 data:
   setup-certs-and-run.sh: |
     #!/bin/bash
-    sudo cp /host/etc/grid-security/* /etc/grid-security
     echo 'INFO Files in /etc/grid-security'
     ls -lahZ /etc/grid-security
     mkdir -p /data/srv/logs/reqmgr2ms
@@ -137,7 +136,7 @@ spec:
         - name: hmac-secrets
           mountPath: /etc/hmac
           readOnly: true
-        - mountPath: /host/etc/grid-security
+        - mountPath: /etc/grid-security
           name: etc-grid-security
           readOnly: true
         - name: setup-certs-and-run

--- a/kubernetes/cmsweb/services/reqmgr2ms-pileup.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-pileup.yaml
@@ -48,7 +48,6 @@ metadata:
 data:
   setup-certs-and-run.sh: |
     #!/bin/bash
-    sudo cp /host/etc/grid-security/* /etc/grid-security
     echo 'INFO Files in /etc/grid-security'
     ls -lahZ /etc/grid-security
     mkdir -p /data/srv/logs/reqmgr2ms
@@ -137,7 +136,7 @@ spec:
         - name: hmac-secrets
           mountPath: /etc/hmac
           readOnly: true
-        - mountPath: /host/etc/grid-security
+        - mountPath: /etc/grid-security
           name: etc-grid-security
           readOnly: true
         - name: setup-certs-and-run

--- a/kubernetes/cmsweb/services/reqmgr2ms-rulecleaner.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-rulecleaner.yaml
@@ -48,7 +48,6 @@ metadata:
 data:
   setup-certs-and-run.sh: |
     #!/bin/bash
-    sudo cp /host/etc/grid-security/* /etc/grid-security
     echo 'INFO Files in /etc/grid-security'
     ls -lahZ /etc/grid-security
     #su  -c "cd /data && /data/run.sh" --preserve-environment _reqmgr2ms
@@ -136,7 +135,7 @@ spec:
         - name: hmac-secrets
           mountPath: /etc/hmac
           readOnly: true
-        - mountPath: /host/etc/grid-security
+        - mountPath: /etc/grid-security
           name: etc-grid-security
           readOnly: true
         - name: setup-certs-and-run

--- a/kubernetes/cmsweb/services/reqmgr2ms-transferor.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-transferor.yaml
@@ -48,7 +48,6 @@ metadata:
 data:
   setup-certs-and-run.sh: |
     #!/bin/bash
-    sudo cp /host/etc/grid-security/* /etc/grid-security
     echo 'INFO Files in /etc/grid-security'
     ls -lahZ /etc/grid-security
     #su  -c "cd /data && /data/run.sh" --preserve-environment _reqmgr2ms
@@ -136,7 +135,7 @@ spec:
         - name: hmac-secrets
           mountPath: /etc/hmac
           readOnly: true
-        - mountPath: /host/etc/grid-security
+        - mountPath: /etc/grid-security
           name: etc-grid-security
           readOnly: true
         - name: setup-certs-and-run

--- a/kubernetes/cmsweb/services/reqmgr2ms-unmerged-t1.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-unmerged-t1.yaml
@@ -48,7 +48,6 @@ metadata:
 data:
   setup-certs-and-run.sh: |
     #!/bin/bash
-    sudo cp /host/etc/grid-security/* /etc/grid-security
     echo 'INFO Files in /etc/grid-security'
     ls -lahZ /etc/grid-security
     #su  -c "cd /data && /data/run.sh -e '(cms_type=real|cms_type=int)&rse_type=DISK&tier=1' " --preserve-environment _reqmgr2ms
@@ -136,7 +135,7 @@ spec:
         - name: hmac-secrets
           mountPath: /etc/hmac
           readOnly: true
-        - mountPath: /host/etc/grid-security
+        - mountPath: /etc/grid-security
           name: etc-grid-security
           readOnly: true
         - name: setup-certs-and-run

--- a/kubernetes/cmsweb/services/reqmgr2ms-unmerged-t2t3.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-unmerged-t2t3.yaml
@@ -48,7 +48,6 @@ metadata:
 data:
   setup-certs-and-run.sh: |
     #!/bin/bash
-    sudo cp /host/etc/grid-security/* /etc/grid-security
     echo 'INFO Files in /etc/grid-security'
     ls -lahZ /etc/grid-security
     # su  -c "cd /data && /data/run.sh -e '(((cms_type=real|cms_type=int)&rse_type=DISK&(tier=2|tier=3))\country=US)' " --preserve-environment _reqmgr2ms
@@ -136,7 +135,7 @@ spec:
         - name: hmac-secrets
           mountPath: /etc/hmac
           readOnly: true
-        - mountPath: /host/etc/grid-security
+        - mountPath: /etc/grid-security
           name: etc-grid-security
           readOnly: true
         - name: setup-certs-and-run

--- a/kubernetes/cmsweb/services/reqmgr2ms-unmerged-t2t3us.yaml
+++ b/kubernetes/cmsweb/services/reqmgr2ms-unmerged-t2t3us.yaml
@@ -48,7 +48,6 @@ metadata:
 data:
   setup-certs-and-run.sh: |
     #!/bin/bash
-    sudo cp /host/etc/grid-security/* /etc/grid-security
     echo 'INFO Files in /etc/grid-security'
     ls -lahZ /etc/grid-security
     #su  -c "cd /data && /data/run.sh -e '(((cms_type=real|cms_type=int)&rse_type=DISK&(tier=2|tier=3))&country=US)' " --preserve-environment _reqmgr2ms
@@ -136,7 +135,7 @@ spec:
         - name: hmac-secrets
           mountPath: /etc/hmac
           readOnly: true
-        - mountPath: /host/etc/grid-security
+        - mountPath: /etc/grid-security
           name: etc-grid-security
           readOnly: true
         - name: setup-certs-and-run

--- a/kubernetes/cmsweb/services/reqmon-tasks.yaml
+++ b/kubernetes/cmsweb/services/reqmon-tasks.yaml
@@ -35,7 +35,6 @@ metadata:
 data:
   setup-certs-and-run.sh: |
     #!/bin/bash
-    sudo cp /host/etc/grid-security/* /etc/grid-security
     echo 'INFO Files in /etc/grid-security'
     ls -lahZ /etc/grid-security
     #su  -c "cd /data && /data/run.sh" --preserve-environment _reqmon
@@ -99,7 +98,7 @@ spec:
         - name: hmac-secrets
           mountPath: /etc/hmac
           readOnly: true
-        - mountPath: /host/etc/grid-security
+        - mountPath: /etc/grid-security
           name: etc-grid-security
           readOnly: true
         - name: setup-certs-and-run

--- a/kubernetes/cmsweb/services/reqmon.yaml
+++ b/kubernetes/cmsweb/services/reqmon.yaml
@@ -48,8 +48,6 @@ metadata:
 data:
   setup-certs-and-run.sh: |
     #!/bin/bash
-
-    sudo cp /host/etc/grid-security/* /etc/grid-security
     echo 'INFO Files in /etc/grid-security'
     ls -lahZ /etc/grid-security
     #su  -c "cd /data && /data/run.sh" --preserve-environment _reqmon
@@ -127,7 +125,7 @@ spec:
         - name: hmac-secrets
           mountPath: /etc/hmac
           readOnly: true
-        - mountPath: /host/etc/grid-security
+        - mountPath: /etc/grid-security
           name: etc-grid-security
           readOnly: true
         - name: setup-certs-and-run

--- a/kubernetes/cmsweb/services/t0_reqmon-tasks.yaml
+++ b/kubernetes/cmsweb/services/t0_reqmon-tasks.yaml
@@ -35,8 +35,6 @@ metadata:
 data:
   setup-certs-and-run.sh: |
     #!/bin/bash
-
-    sudo cp /host/etc/grid-security/* /etc/grid-security
     echo 'INFO Files in /etc/grid-security'
     ls -lahZ /etc/grid-security
     #su  -c "cd /data && /data/run.sh" --preserve-environment _t0_reqmon
@@ -108,7 +106,7 @@ spec:
         - name: hmac-secrets
           mountPath: /etc/hmac
           readOnly: true
-        - mountPath: /host/etc/grid-security
+        - mountPath: /etc/grid-security
           name: etc-grid-security
           readOnly: true
         - name: setup-certs-and-run

--- a/kubernetes/cmsweb/services/t0_reqmon.yaml
+++ b/kubernetes/cmsweb/services/t0_reqmon.yaml
@@ -48,8 +48,6 @@ metadata:
 data:
   setup-certs-and-run.sh: |
     #!/bin/bash
-
-    sudo cp /host/etc/grid-security/* /etc/grid-security
     echo 'INFO Files in /etc/grid-security'
     ls -lahZ /etc/grid-security
     #su  -c "cd /data && /data/run.sh" --preserve-environment _t0_reqmon
@@ -127,7 +125,7 @@ spec:
         - name: hmac-secrets
           mountPath: /etc/hmac
           readOnly: true
-        - mountPath: /host/etc/grid-security
+        - mountPath: /etc/grid-security
           name: etc-grid-security
           readOnly: true
         - name: setup-certs-and-run

--- a/kubernetes/cmsweb/services/workqueue.yaml
+++ b/kubernetes/cmsweb/services/workqueue.yaml
@@ -48,7 +48,6 @@ metadata:
 data:
   setup-certs-and-run.sh: |
     #!/bin/bash
-    sudo cp /host/etc/grid-security/* /etc/grid-security
     echo 'INFO Files in /etc/grid-security'
     ls -lahZ /etc/grid-security
     #su  -c "cd /data && /data/run.sh" --preserve-environment _workqueue
@@ -129,7 +128,7 @@ spec:
         - name: hmac-secrets
           mountPath: /etc/hmac
           readOnly: true
-        - mountPath: /host/etc/grid-security
+        - mountPath: /etc/grid-security
           name: etc-grid-security
           readOnly: true
         - name: setup-certs-and-run


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/12208
### status

- [x] tested with python3.12 docker images
- [ ] not tested yet with python3.8 docker images, but it should be safe enough that i do not need to

### problem

wmcore pypi python3.12 docker image does not load anything from the cmsweb docker image, so CAs are not present and the services crash to make requests to external services (for example reqmgr2 can not talk to DBS and workflows can not be injected)

we never noticed because wmcore pypi python3.8 docker image load CAs from the underlying cmsweb base image, not from the host [1]. This means that we have been using outdated CAs so far, and apparently it has not been a problem.

### proposed solution

this PR is a quickfix that works both for wmcore python3.8 and python3.12 pypi docker images. other solutions may be preferred but likely require more changes. i am open to suggestions, especially from @vkuznet and/or @arooshap 

fyi: @amaltaro @anpicci 

---

[1]

look at the last modifies dates

```plaintext
_reqmgr2@reqmgr2-6985654bf9-bmpb4:/data$ ls -l /host/etc/grid-security/
total 84
drwxr-xr-x. 2 root root 36864 Jun  4 13:55 certificates
-rw-r--r--. 1 root root  2221 May  9 12:56 cmsweb-k8s-prodsrv-v-workers-b3x5lfucvbyx-node-3.cern.ch.grid.crt
-rw-------. 1 root root  1070 May  9 13:40 cmsweb-k8s-prodsrv-v-workers-b3x5lfucvbyx-node-3.cern.ch.grid.csr._tmp_
-rw-------. 1 root root  1708 May  9 12:56 cmsweb-k8s-prodsrv-v-workers-b3x5lfucvbyx-node-3.cern.ch.grid.key
-rw-------. 1 root root  1708 May  9 13:40 cmsweb-k8s-prodsrv-v-workers-b3x5lfucvbyx-node-3.cern.ch.grid.key._tmp_
-rw-r--r--. 1 root root  3065 May  9 12:56 cmsweb-k8s-prodsrv-v-workers-b3x5lfucvbyx-node-3.cern.ch.grid.pem
-rw-r--r--. 1 root root  3065 May  9 13:40 hostcert.pem
-rw-------. 1 root root  1708 May  9 13:40 hostkey.pem
_reqmgr2@reqmgr2-6985654bf9-bmpb4:/data$ ls -l /etc/grid-security/
total 84
drwxr-xr-x. 2 root root 36864 Jun 13  2024 certificates
-rw-r--r--. 1 root root  2221 Jun  3 22:26 cmsweb-k8s-prodsrv-v-workers-b3x5lfucvbyx-node-3.cern.ch.grid.crt
-rw-------. 1 root root  1070 Jun  3 22:26 cmsweb-k8s-prodsrv-v-workers-b3x5lfucvbyx-node-3.cern.ch.grid.csr._tmp_
-rw-------. 1 root root  1708 Jun  3 22:26 cmsweb-k8s-prodsrv-v-workers-b3x5lfucvbyx-node-3.cern.ch.grid.key
-rw-------. 1 root root  1708 Jun  3 22:26 cmsweb-k8s-prodsrv-v-workers-b3x5lfucvbyx-node-3.cern.ch.grid.key._tmp_
-rw-r--r--. 1 root root  3065 Jun  3 22:26 cmsweb-k8s-prodsrv-v-workers-b3x5lfucvbyx-node-3.cern.ch.grid.pem
-rw-r--r--. 1 root root  3065 Jun  3 22:26 hostcert.pem
-rw-------. 1 root root  1708 Jun  3 22:26 hostkey.pem
drwxr-xr-x. 3 root root    17 Jun 13  2024 vomsdir
_reqmgr2@reqmgr2-6985654bf9-bmpb4:/data$ ls -l /host/etc/grid-security/certificates/ | wc -l
982
_reqmgr2@reqmgr2-6985654bf9-bmpb4:/data$ ls -l /etc/grid-security/certificates/ | wc -l
985
```