### PR TITLE
dmwm-base - remove pycurl from OS && add procps

### DIFF
--- a/docker/pypi/dmwm-base/Dockerfile
+++ b/docker/pypi/dmwm-base/Dockerfile
@@ -4,9 +4,10 @@ MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 
 # see https://docs.docker.com/build/building/best-practices/#apt-get
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl libcurl4 libcurl4-openssl-dev python3-pycurl \ 
+    curl libcurl4 libcurl4-openssl-dev \ 
     apache2-utils \
     sudo less vim git \
+    procps \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
I want to make two small changes to dmwm-base image:

- I want to remove `python3-pycurl` installed via pip, because it downloads the library for the default python of debain 12 (3.11) which is not necessary [1]
    - keep in mind that we already install pycurl from pip for the python version that we care about [3]
- I want to add `procps`, which provides the command `ps`, needed to start monitoring [2]

fyi: @amaltaro @anpicci 

---

[1]

<details>

if we install `python3-pycurl` from apt, then we also install python 3.11

```plaintext
[2/2] STEP 3/12: RUN apt-get update && apt-get install -y --no-install-recommends     curl libcurl4 libcurl4-openssl-dev python3-pycurl     apache2-utils     sudo less vim git     procps     && apt-get clean     && rm -rf /var/lib/apt/lists/*
[...]
The following NEW packages will be installed:
  apache2-utils curl git git-man less libapr1 libaprutil1 libbrotli1
  libcurl3-gnutls libcurl4 libcurl4-openssl-dev liberror-perl libexpat1
  libgdbm-compat4 libgpm2 libldap-2.5-0 libnghttp2-14 libperl5.36 libproc2-0
  libpsl5 libpython3-stdlib libpython3.11-minimal libpython3.11-stdlib
  librtmp1 libsasl2-2 libsasl2-modules-db libsodium23 libssh2-1 media-types
  perl perl-modules-5.36 procps python3 python3-minimal python3-pycurl
  python3.11 python3.11-minimal sudo vim vim-common vim-runtime
0 upgraded, 41 newly installed, 0 to remove and 0 not upgraded.
Need to get 36.7 MB of archives.
After this operation, 177 MB of additional disk space will be used.
[...]
```

when we do not add `python3-pycurl`, no additional python is added

```plaintext
[2/2] STEP 3/12: RUN apt-get update && apt-get install -y --no-install-recommends     curl libcurl4 libcurl4-openssl-dev     apache2-utils     sudo less vim git     procps     && apt-get clean     && rm -rf /var/lib/apt/lists/*
[...]
The following NEW packages will be installed:
  apache2-utils curl git git-man less libapr1 libaprutil1 libbrotli1
  libcurl3-gnutls libcurl4 libcurl4-openssl-dev liberror-perl libexpat1
  libgdbm-compat4 libgpm2 libldap-2.5-0 libnghttp2-14 libperl5.36 libproc2-0
  libpsl5 librtmp1 libsasl2-2 libsasl2-modules-db libsodium23 libssh2-1 perl
  perl-modules-5.36 procps sudo vim vim-common vim-runtime
0 upgraded, 32 newly installed, 0 to remove and 0 not upgraded.
Need to get 31.3 MB of archives.
After this operation, 155 MB of additional disk space will be used.
```

</details>

[2] https://github.com/dmwm/CMSKubernetes/blob/8ef5e91aee333b703dd6fa71aa394e303ee8ff9b/docker/pypi/dmwm-base/monitor.sh#L10

[3] https://github.com/dmwm/WMCore/blob/fb0ed6a73ef8a6eaf6e5c03e7190407b3a5b066b/requirements.txt#L35

<details>

```plaintext
> podman run -it --rm registry.cern.ch/cmsweb/dmwm-base:$basetag bash
root@e9e1d944af78:/data# python -m pip install pycurl
Collecting pycurl
  Downloading pycurl-7.45.6-cp312-cp312-manylinux_2_28_x86_64.whl.metadata (4.6 kB)
Downloading pycurl-7.45.6-cp312-cp312-manylinux_2_28_x86_64.whl (4.6 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 4.6/4.6 MB 24.5 MB/s eta 0:00:00
Installing collected packages: pycurl
Successfully installed pycurl-7.45.6
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.

[notice] A new release of pip is available: 25.0.1 -> 25.1.1
[notice] To update, run: pip install --upgrade pip
root@e9e1d944af78:/data# python
Python 3.12.11 (main, Jun 10 2025, 23:56:19) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pycurl
>>>
```

</details>