### PR TITLE
wmcore - build on top of (dmwm-base|wmagent-base):pypi-20250611-stable

### DIFF
--- a/docker/pypi/msmonitor/Dockerfile
+++ b/docker/pypi/msmonitor/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250523-stable
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250611-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/msoutput/Dockerfile
+++ b/docker/pypi/msoutput/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250523-stable
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250611-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/mspileup/Dockerfile
+++ b/docker/pypi/mspileup/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250523-stable
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250611-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/msrulecleaner/Dockerfile
+++ b/docker/pypi/msrulecleaner/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250523-stable
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250611-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/mstransferor/Dockerfile
+++ b/docker/pypi/mstransferor/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250523-stable
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250611-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/reqmgr2/Dockerfile
+++ b/docker/pypi/reqmgr2/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250523-stable
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250611-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/reqmon/Dockerfile
+++ b/docker/pypi/reqmon/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250523-stable
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250611-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/t0reqmon/Dockerfile
+++ b/docker/pypi/t0reqmon/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250523-stable
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250611-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/wmagent-base/Dockerfile
+++ b/docker/pypi/wmagent-base/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.cern.ch/cmsweb/oracle:21_5-stable as oracle
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250523-stable
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250611-stable
 
 # see https://docs.docker.com/build/building/best-practices/#apt-get
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docker/pypi/wmagent/Dockerfile
+++ b/docker/pypi/wmagent/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile-upstream:master
-FROM registry.cern.ch/cmsweb/wmagent-base:pypi-20250523-stable
+FROM registry.cern.ch/cmsweb/wmagent-base:pypi-20250611-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 
 # TAG to be passed at build time through `--build-arg TAG=<WMA_TAG>`. Default: None

--- a/docker/pypi/wmglobalqueue/Dockerfile
+++ b/docker/pypi/wmglobalqueue/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250523-stable
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250611-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None


### PR DESCRIPTION
followup of https://github.com/dmwm/CMSKubernetes/pull/1621