### PR TITLE
Update GFAL and MSUnmerged images to Debian Bookworm + Miniconda + Py3.12

### DIFF
--- a/docker/pypi/gfal/Dockerfile
+++ b/docker/pypi/gfal/Dockerfile
@@ -1,11 +1,11 @@
-FROM python:3.8-bullseye
+FROM python:3.12-slim-bookworm
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 RUN apt-get update
 RUN apt-get install -y curl libcurl4 libcurl4-openssl-dev
 RUN ln -s /usr/bin/python3 /usr/bin/python
 ENV WDIR=/data
 WORKDIR $WDIR
-RUN curl -ksL https://repo.anaconda.com/miniconda/Miniconda3-py38_4.12.0-Linux-x86_64.sh -o $WDIR/miniconda.sh \
+RUN curl -ksL https://repo.anaconda.com/miniconda/Miniconda3-py312_25.5.1-0-Linux-x86_64.sh -o $WDIR/miniconda.sh \
     && chmod +x $WDIR/miniconda.sh
 RUN $WDIR/miniconda.sh -b -p $WDIR/miniconda
 ENV PATH $WDIR/miniconda/bin:$PATH

--- a/docker/pypi/gfal/Dockerfile
+++ b/docker/pypi/gfal/Dockerfile
@@ -1,13 +1,16 @@
-FROM python:3.12-slim-bookworm
-MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
-RUN apt-get update
-RUN apt-get install -y curl libcurl4 libcurl4-openssl-dev
-RUN ln -s /usr/bin/python3 /usr/bin/python
-ENV WDIR=/data
-WORKDIR $WDIR
-RUN curl -ksL https://repo.anaconda.com/miniconda/Miniconda3-py312_25.5.1-0-Linux-x86_64.sh -o $WDIR/miniconda.sh \
-    && chmod +x $WDIR/miniconda.sh
-RUN $WDIR/miniconda.sh -b -p $WDIR/miniconda
-ENV PATH $WDIR/miniconda/bin:$PATH
-RUN conda install -y -c conda-forge python-gfal2
-RUN conda clean --all -f -y
+FROM continuumio/miniconda3 AS gfal2-base
+
+# Install gfal2 via conda-forge
+RUN conda install -y -c conda-forge \
+      python=3.12 \
+      gfal2 \
+      python-gfal2 \
+      openssl=3.2 \
+      libcurl && \
+    conda clean -afy
+
+ENV PATH=/opt/conda/bin:$PATH \
+    LD_LIBRARY_PATH=/opt/conda/lib:$LD_LIBRARY_PATH
+
+# Optionally test plugin loading
+RUN python -c 'import gfal2; ctx = gfal2.creat_context(); print("gfal2 load OK")'

--- a/docker/pypi/gfal/Dockerfile
+++ b/docker/pypi/gfal/Dockerfile
@@ -5,7 +5,7 @@ RUN conda install -y -c conda-forge \
       python=3.12 \
       gfal2 \
       python-gfal2 \
-      openssl=3.2 \
+      openssl \
       libcurl && \
     conda clean -afy
 

--- a/docker/pypi/msunmerged/Dockerfile
+++ b/docker/pypi/msunmerged/Dockerfile
@@ -1,10 +1,10 @@
-FROM registry.cern.ch/cmsweb/gfal:latest as gfal
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20240923-stable
+FROM registry.cern.ch/cmsweb/gfal:deb-py312-113 as gfal
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250611-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 COPY --from=gfal /data/miniconda /data/miniconda
 ENV WDIR=/data
 ENV PATH $PATH:$WDIR/miniconda/bin
-ENV PYTHONPATH $WDIR/miniconda/lib/python3.8/site-packages/
+ENV PYTHONPATH $WDIR/miniconda/lib/python3.12/site-packages
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None
 WORKDIR $WDIR
@@ -12,7 +12,7 @@ ADD run.sh $WDIR/run.sh
 # since we install gfal via external image we'll skip it for installation
 # of msunmerged, but to satisfy dependencies we'll install them first
 RUN curl -ksLO https://raw.githubusercontent.com/dmwm/WMCore/$TAG/requirements.txt
-RUN cat requirements.txt | grep -v gfal2 > req.txt
+RUN cat requirements.txt | grep msunmerged | grep -v gfal2 > req.txt
 RUN pip install -r req.txt
 RUN pip install --no-deps msunmerged==$TAG 
 RUN sed -i -e "s,-config.py,-config-unmerged.py,g" /data/run.sh

--- a/docker/pypi/msunmerged/Dockerfile
+++ b/docker/pypi/msunmerged/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/gfal:deb-py312-113-v5 as gfal
+FROM registry.cern.ch/cmsweb/gfal:deb-py312-113-v6 as gfal
 FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250611-stable
 ENV WDIR=/data
 WORKDIR $WDIR

--- a/docker/pypi/msunmerged/Dockerfile
+++ b/docker/pypi/msunmerged/Dockerfile
@@ -1,23 +1,34 @@
-FROM registry.cern.ch/cmsweb/gfal:deb-py312-113 as gfal
+FROM registry.cern.ch/cmsweb/gfal:deb-py312-113-v5 as gfal
 FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250611-stable
-MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
-COPY --from=gfal /data/miniconda /data/miniconda
 ENV WDIR=/data
-ENV PATH $PATH:$WDIR/miniconda/bin
-ENV PYTHONPATH $WDIR/miniconda/lib/python3.12/site-packages
+WORKDIR $WDIR
+
+# Copy Miniconda environment from gfal image
+COPY --from=gfal /opt/conda /opt/conda
+
+# Set PATH and LD_LIBRARY_PATH to use gfal2 (Miniconda) environment
+ENV PATH=/opt/conda/bin:$PATH \
+    LD_LIBRARY_PATH=/opt/conda/lib:$LD_LIBRARY_PATH \
+    PYTHONPATH=/opt/conda/lib/python3.12/site-packages:$PYTHONPATH
+
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None
-WORKDIR $WDIR
 ADD run.sh $WDIR/run.sh
 # since we install gfal via external image we'll skip it for installation
 # of msunmerged, but to satisfy dependencies we'll install them first
 RUN curl -ksLO https://raw.githubusercontent.com/dmwm/WMCore/$TAG/requirements.txt
 RUN cat requirements.txt | grep msunmerged | grep -v gfal2 > req.txt
-RUN pip install -r req.txt
+RUN pip install --no-cache-dir -r req.txt
 RUN pip install --no-deps msunmerged==$TAG 
 RUN sed -i -e "s,-config.py,-config-unmerged.py,g" /data/run.sh
 RUN sed -i -e "s,config.py,config-unmerged.py,g" /data/manage
-ENV WDIR=/data
+
+# Optional: sanity check
+RUN echo "Sanity check: Python from $(which python)" && \
+    python -c 'import gfal2; ctx = gfal2.creat_context(); print("gfal2 load OK")'
+# (Optional) Print out library linking as sanity check
+RUN echo "Libssl link check:" && ldd $(python -c "import libssl; print(libssl.__file__)") || true
+
 ENV USER=_reqmgr2ms
 RUN useradd ${USER} && install -o ${USER} -d ${WDIR}
 RUN echo "%$USER ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers

--- a/docker/pypi/msunmerged/Dockerfile
+++ b/docker/pypi/msunmerged/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/gfal:deb-py312-113-v6 as gfal
+FROM registry.cern.ch/cmsweb/gfal:deb-py312-113-stable as gfal
 FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250611-stable
 ENV WDIR=/data
 WORKDIR $WDIR


### PR DESCRIPTION
Fixes https://github.com/dmwm/WMCore/issues/11922

With this PR, we update both the GFAL and the MSUnmerged docker images to:
* base Debian Bookworm OS
* Python 3.12 (3.12.11 at the moment)
* GFAL2 to "GFAL-client-2.23.1"
* python-gfal2 to "python-gfal2-1.13.0-py312" 
* Openssl to "OpenSSL 3.5.1 1"

while we keep relying on conda/miniconda for the GFAL library and the dependencies that need to be installed together to make sure that dynamic libraries are properly linked, including python itself.