### PR TITLE
Update hadoop docker image to use pull through cache

### DIFF
--- a/docker/cmsmon-hadoop-base/Dockerfile-spark3
+++ b/docker/cmsmon-hadoop-base/Dockerfile-spark3
@@ -1,5 +1,6 @@
 # Ref: https://gitlab.cern.ch/hadoop/utils/hadoop-conf/-/blob/master/docker/Dockerfile
-FROM python:3.9 AS builder
+FROM registry.cern.ch/docker.io/python:3.9 AS builder
+USER root
 
 ENV WDIR=/data
 WORKDIR $WDIR

--- a/docker/cmsmon-hadoop-base/Dockerfile-spark3
+++ b/docker/cmsmon-hadoop-base/Dockerfile-spark3
@@ -1,5 +1,5 @@
 # Ref: https://gitlab.cern.ch/hadoop/utils/hadoop-conf/-/blob/master/docker/Dockerfile
-FROM registry.cern.ch/docker.io/python:3.9 AS builder
+FROM registry.cern.ch/docker.io/library/python:3.9 AS builder
 USER root
 
 ENV WDIR=/data

--- a/docker/cmsmon-hadoop-base/build-and-push.sh
+++ b/docker/cmsmon-hadoop-base/build-and-push.sh
@@ -19,7 +19,7 @@ DOCKER_REGISTRY=registry.cern.ch/cmsmonitoring
 # Build
 image_tag="spark3-${CURRENT_DATE}"
 echo "Building ${image_tag}"
-docker build -t "${DOCKER_REGISTRY}/cmsmon-hadoop-base:${image_tag}" -t "${DOCKER_REGISTRY}/cmsmon-hadoop-base:latest" -f Dockerfile-spark3 .
+docker build --user root -t "${DOCKER_REGISTRY}/cmsmon-hadoop-base:${image_tag}" -t "${DOCKER_REGISTRY}/cmsmon-hadoop-base:latest" -f Dockerfile-spark3 .
 echo Build finished: "${DOCKER_REGISTRY}/cmsmon-hadoop-base:${image_tag}"
 # Push
 docker push "${DOCKER_REGISTRY}/cmsmon-hadoop-base:${image_tag}"


### PR DESCRIPTION
Changed the FROM statement in the hadoop-base docker image to use CERN's pull through cache (see https://kubernetes.docs.cern.ch/docs/registry/quickstart/#pull-through-caches for more information).

This is part of [CMSMONIT-651](https://its.cern.ch/jira/browse/CMSMONIT-651).