### PR TITLE
wmagent - mariadb upgrade to 11.8.2

### DIFF
--- a/docker/pypi/wmagent-mariadb/Dockerfile
+++ b/docker/pypi/wmagent-mariadb/Dockerfile
@@ -1,4 +1,4 @@
-ARG MDB_TAG=10.6.19
+ARG MDB_TAG=11.8.2
 FROM mariadb:$MDB_TAG
 MAINTAINER Todor Ivanov todor.ivanov@cern.ch
 


### PR DESCRIPTION
mariadb upgrade to version 11.8.2

I uploaded this new image to `registry.cern.ch/cmsweb/mariadb:11.8.2` and it is currently running smoothly in vocms0262

fyi: @amaltaro @todor-ivanov 