### PR TITLE
Update wmagent to Debian trixie

### DIFF
--- a/docker/pypi/dmwm-base/Dockerfile
+++ b/docker/pypi/dmwm-base/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.cern.ch/cmsweb/exporters:20250519-stable as exporters
-FROM python:3.12-slim-bookworm
+FROM python:3.12-trixie
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 
 # see https://docs.docker.com/build/building/best-practices/#apt-get

--- a/docker/pypi/msmonitor/Dockerfile
+++ b/docker/pypi/msmonitor/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250716-stable
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250905-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/msoutput/Dockerfile
+++ b/docker/pypi/msoutput/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250716-stable
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250905-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/mspileup/Dockerfile
+++ b/docker/pypi/mspileup/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250716-stable
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250905-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/msrulecleaner/Dockerfile
+++ b/docker/pypi/msrulecleaner/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250716-stable
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250905-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/mstransferor/Dockerfile
+++ b/docker/pypi/mstransferor/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250716-stable
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250905-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/msunmerged/Dockerfile
+++ b/docker/pypi/msunmerged/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.cern.ch/cmsweb/gfal:deb-py312-113-stable as gfal
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250716-stable
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250905-stable
 ENV WDIR=/data
 WORKDIR $WDIR
 

--- a/docker/pypi/reqmgr2/Dockerfile
+++ b/docker/pypi/reqmgr2/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250716-stable
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250905-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/reqmon/Dockerfile
+++ b/docker/pypi/reqmon/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250716-stable
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250905-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/t0reqmon/Dockerfile
+++ b/docker/pypi/t0reqmon/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250716-stable
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250905-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None

--- a/docker/pypi/wmagent-base/Dockerfile
+++ b/docker/pypi/wmagent-base/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.cern.ch/cmsweb/oracle:21_5-stable as oracle
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250716-stable
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250905-stable
 
 # see https://docs.docker.com/build/building/best-practices/#apt-get
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     cron \
     mariadb-server libmariadb-dev-compat libmariadb-dev \
     myproxy voms-clients voms-clients-java \
-    rlwrap libaio1 \
+    rlwrap libaio1t64 \
     # required for cx_oracle
     build-essential \
     # required for yui 

--- a/docker/pypi/wmagent/Dockerfile
+++ b/docker/pypi/wmagent/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile-upstream:master
-FROM registry.cern.ch/cmsweb/wmagent-base:pypi-20250611-stable
+FROM registry.cern.ch/cmsweb/wmagent-base:pypi-20250905-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 
 # TAG to be passed at build time through `--build-arg TAG=<WMA_TAG>`. Default: None

--- a/docker/pypi/wmglobalqueue/Dockerfile
+++ b/docker/pypi/wmglobalqueue/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250716-stable
+FROM registry.cern.ch/cmsweb/dmwm-base:pypi-20250905-stable
 MAINTAINER Valentin Kuznetsov vkuznet@gmail.com
 # TAG to be passed at build time through `--build-arg TAG=<PYPI_TAG>`. Default: None
 ARG TAG=None


### PR DESCRIPTION
Fixes issue https://github.com/dmwm/WMCore/issues/12401

See comment:
https://github.com/dmwm/WMCore/issues/12401#issuecomment-3156782414

This fixes the renewal of proxies:

```
(WMAgent-2.4.3) [cmsdataops@cmsgwms-submit13:current]$ manage renew-proxy
MyProxy v6.2 Jan 2024 PAM SASL KRB5 LDAP VOMS OCSP
Attempting to connect to 2001:1458:d00:4a::100:480:7512
Successfully connected to myproxy.cern.ch:7512
using trusted certificates directory /etc/grid-security/certificates
Using Host cert file (/data/certs/servicecert.pem), key file (/data/certs/servicekey.pem)
server name: /DC=ch/DC=cern/OU=computers/CN=px501.cern.ch
checking that server name is acceptable...
server name matches "myproxy.cern.ch"
authenticated server name is acceptable
A credential has been received for user amaltaro in /data/certs/mynewproxy.pem.
Contacting voms-cms-auth.cern.ch:443 [/DC=ch/DC=cern/OU=computers/CN=cms-auth.cern.ch] "cms"...
Remote VOMS server contacted succesfully.

WARNING: proxy lifetime limited to issuing credential lifetime.

Created proxy in /data/certs/myproxy.pem.

Your proxy is valid until Mon Sep 01 21:16:16 UTC 2025
(WMAgent-2.4.3) [cmsdataops@cmsgwms-submit13:current]$ cat /etc/issue
Debian GNU/Linux 13 \n \l
```

The following stable images were uploaded to the CERN registry by hand:

```
# docker image ls
REPOSITORY                             TAG                    IMAGE ID       CREATED              SIZE
registry.cern.ch/cmsweb/wmagent-base   pypi-20250905          e3814fa47fbe   About a minute ago   2.05GB
registry.cern.ch/cmsweb/wmagent-base   pypi-20250905-stable   e3814fa47fbe   About a minute ago   2.05GB
registry.cern.ch/cmsweb/dmwm-base      pypi-20250905          63d3bdf9e7d2   5 minutes ago        1.19GB
registry.cern.ch/cmsweb/dmwm-base      pypi-20250905-stable   63d3bdf9e7d2   5 minutes ago        1.19GB
```

This PR also updates the Dockerfile of other Dockerfile components depending on dmwm-base or wmagent-base.