### PR TITLE
Debian trixie renames libaio1 to libaio1t64.

### DIFF
--- a/docker/pypi/wmagent/wmagent-docker-run.sh
+++ b/docker/pypi/wmagent/wmagent-docker-run.sh
@@ -179,3 +179,5 @@ docker exec -u root -it wmagent sh -c "printf 'set v15-compat\nset smtp-auth=non
 # Change mail to use s-nail
 docker exec -u root -it wmagent update-alternatives --install /usr/bin/mailx mailx /usr/bin/s-nail 50 --slave /usr/bin/mail mail /usr/bin/s-nail
 
+# Workaround for libaio1 package renamed in Debian trixie
+docker exec -u root -it wmagent ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64.0.2 /usr/lib/x86_64-linux-gnu/libaio.so.1


### PR DESCRIPTION
 For backwards compatibil…ity, create a symlink to the old name.

The issue is with sqlplus

```
sqlplus sqlplus: error while loading shared libraries: libaio.so.1: cannot open shared object file: No such file or directory
```

The workaournd above fixes it. 