### PR TITLE
with new CRABServer code can remove data.mode

### DIFF
--- a/helm/crabserver/config/preprod/config.py
+++ b/helm/crabserver/config/preprod/config.py
@@ -39,7 +39,6 @@ data.extconfigurl = 'http://gitlab.cern.ch/crab3/CRAB3ServerConfig/raw/master/cm
 data.loggingLevel = 10
 data.loggingFile = '%s/logs/crabserver/CRAB-%s.log' % (__file__.rsplit('/', 4)[0], myhost)
 data.keptLogDays = 7
-data.mode = "cmsweb-preprod"
 
 data.delegateDN = "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=cmscrab/CN=(817881|373708)/CN=Robot: cms crab|/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=crabint1/CN=373708/CN=Robot: CMS CRAB Integration 1"
 data.compatibleClientVersions = ["v3", "development"]

--- a/helm/crabserver/config/prod/config.py
+++ b/helm/crabserver/config/prod/config.py
@@ -44,6 +44,5 @@ data.extconfigurl = 'http://gitlab.cern.ch/crab3/CRAB3ServerConfig/raw/master/cm
 data.loggingLevel = 10
 data.loggingFile = '%s/logs/crabserver/CRAB-%s.log' % (__file__.rsplit('/', 4)[0], myhost)
 data.keptLogDays = 7
-data.mode = "cmsweb-prod"
 
 data.delegateDN = "/DC=ch/DC=cern/OU=computers/CN=crab-(preprod|prod)-tw(01|02).cern.ch|/DC=ch/DC=cern/OU=computers/CN=crab-dev-tw(01|02|03|04).cern.ch|/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=cmscrab/CN=(817881|373708)/CN=Robot: cms crab|/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=crabint1/CN=373708/CN=Robot: CMS CRAB Integration 1"

--- a/helm/crabserver/config/test/config.py
+++ b/helm/crabserver/config/test/config.py
@@ -39,7 +39,6 @@ data.extconfigurl = 'http://gitlab.cern.ch/crab3/CRAB3ServerConfig/raw/master/cm
 data.loggingLevel = 10
 data.loggingFile = '%s/logs/crabserver/CRAB-%s.log' % (__file__.rsplit('/', 4)[0], myhost)
 data.keptLogDays = 7
-data.mode = "cmsweb-test"
 
 data.enableQueryLoadAllRows = os.getenv('CRABSERVER_ENABLE_QUERY_LOAD_ALL_ROWS', 'True').lower() in ('true', '1', 't')
 


### PR DESCRIPTION
already tested on cmsweb-test2.
Will roll-out incrementally: preprod before prod
FYI: @nausikt @aspiringmind-code feel free to update your test clusters at any time,
 