### PR TITLE
Add Oracle libraries to wmcore-dev images && Ramp up WMCore tag to 2.4.4.rc5

### DIFF
--- a/docker/pypi/wmcore-dev/Dockerfile
+++ b/docker/pypi/wmcore-dev/Dockerfile
@@ -1,6 +1,5 @@
 ARG PYTHON_VERSION=3.12
 
-FROM --platform=linux/amd64 registry.cern.ch/cmsweb/oracle:21_5-stable as oracle
 FROM --platform=linux/amd64 registry.cern.ch/cmsweb/gfal:alma9-py${PYTHON_VERSION}-gfal-1.13.0-stable as gfal2
 FROM --platform=linux/amd64 registry.cern.ch/cmsweb/dmwm-base:alma9-py3.12-20250728-stable
 
@@ -61,6 +60,12 @@ RUN dnf install -y \
         voms-clients-cpp && \
     dnf clean all
 
+# Install Oracle Instant Client:
+RUN dnf config-manager --add-repo https://linuxsoft.cern.ch/mirror/yum.oracle.com/repo/OracleLinux/OL9/oracle/instantclient/x86_64/ && \
+    rpm --import http://linuxsoft.cern.ch/mirror/yum.oracle.com/RPM-GPG-KEY-oracle-ol9 && \
+    dnf install -y oracle-instantclient19.19-basic && \
+    dnf clean all
+
 # Create the working directory
 RUN mkdir -p ${WDIR}/.local
 WORKDIR $WDIR
@@ -83,9 +88,6 @@ RUN uv pip install --no-cache-dir --upgrade pip setuptools wheel && \
 # copy gfal2 and libboost
 COPY --from=gfal2 /tmp/.venv/lib/python${PYTHON_VERSION}/site-packages/gfal2.so $WDIR/.local/wmcore-venv/lib/python${PYTHON_VERSION}/site-packages/gfal2.so
 COPY --from=gfal2 /usr/local/lib/* /usr/local/lib/.
-
-# copy Oracle libraries:
-COPY --from=oracle /usr/lib/oracle /usr/lib/oracle
 
 ADD entrypoint.sh /entrypoint.sh
 ADD etc ${WDIR}/etc

--- a/docker/pypi/wmcore-dev/Dockerfile
+++ b/docker/pypi/wmcore-dev/Dockerfile
@@ -1,10 +1,11 @@
 ARG PYTHON_VERSION=3.12
 
+FROM --platform=linux/amd64 registry.cern.ch/cmsweb/oracle:21_5-stable as oracle
 FROM --platform=linux/amd64 registry.cern.ch/cmsweb/gfal:alma9-py${PYTHON_VERSION}-gfal-1.13.0-stable as gfal2
 FROM --platform=linux/amd64 registry.cern.ch/cmsweb/dmwm-base:alma9-py3.12-20250728-stable
 
 ARG PYTHON_VERSION
-ARG WMCORE_TAG=2.4.1
+ARG WMCORE_TAG=2.4.4rc5
 
 LABEL org.opencontainers.image.authors="Dennis Lee dylee@fnal.gov"
 
@@ -82,6 +83,9 @@ RUN uv pip install --no-cache-dir --upgrade pip setuptools wheel && \
 # copy gfal2 and libboost
 COPY --from=gfal2 /tmp/.venv/lib/python${PYTHON_VERSION}/site-packages/gfal2.so $WDIR/.local/wmcore-venv/lib/python${PYTHON_VERSION}/site-packages/gfal2.so
 COPY --from=gfal2 /usr/local/lib/* /usr/local/lib/.
+
+# copy Oracle libraries:
+COPY --from=oracle /usr/lib/oracle /usr/lib/oracle
 
 ADD entrypoint.sh /entrypoint.sh
 ADD etc ${WDIR}/etc

--- a/docker/pypi/wmcore-dev/Dockerfile.dev
+++ b/docker/pypi/wmcore-dev/Dockerfile.dev
@@ -1,4 +1,4 @@
-ARG WMCORE_TAG=2.4.2rc8
+ARG WMCORE_TAG=2.4.4rc5
 ARG PYTHON_VERSION=3.12
 FROM --platform=linux/amd64 registry.cern.ch/cmsweb/wmcore-dev:py${PYTHON_VERSION}-${WMCORE_TAG}-stable
 LABEL org.opencontainers.image.authors="Dennis Lee dylee@fnal.gov"

--- a/docker/pypi/wmcore-dev/Makefile
+++ b/docker/pypi/wmcore-dev/Makefile
@@ -1,4 +1,4 @@
-WMCORE_TAG=2.4.2rc8
+WMCORE_TAG=2.4.4rc5
 DATE := $(shell date +%Y%m%d)
 
 build:


### PR DESCRIPTION
With the current PR we intend to fix the missing Oracle libraries which are needed during our  Jenkins runs. The change is driven by the needs which arose during the upgrade of the oracle python driver. The new  package `python-oracledb` brings an extra OS level dependency from the oracle client libraries.    