### PR TITLE
Update oracle Dockerfile to use go:1.25 running on dev13 (trixie)

### DIFF
--- a/docker/oracle/Dockerfile
+++ b/docker/oracle/Dockerfile
@@ -22,6 +22,7 @@ ADD oci8.pc /usr/lib/oracle/instantclient_21.5/oci8.pc
 FROM debian:stable-slim
 RUN apt-get update && apt-get -y install libaio1t64 procps
 COPY --from=builder /usr/lib/oracle/instantclient_21_5 /usr/lib/oracle/
+RUN ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64.0.2 /usr/lib/x86_64-linux-gnu/libaio.so.1
 ENV LD_LIBRARY_PATH=/usr/lib/oracle
 ENV PATH=$PATH:/usr/lib/oracle
 ENV PKG_CONFIG_PATH=/usr/lib/oracle


### PR DESCRIPTION
This PR provides necessary upgrade of oracle image used by WM team for their needs. It includes the following:
- Debian 13 (trixie) OS
- GoLang 1.25 release
- Oracle shared libraries and tools version 21_5

The newly built images uploaded to CERN registry are the following:
- `registry.cern.ch/cmsweb/oracle:21_5-go1.25-deb13-stable`
- `registry.cern.ch/cmsweb/oracle:21_5-deb13-stable`