### PR TITLE
Update rucio-con-mon image tag to 2.1.1

### DIFF
--- a/helm/rucio-con-mon/values.yaml
+++ b/helm/rucio-con-mon/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: registry.cern.ch/cmsrucio/rucio-con-mon
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "2.0.1"
+  tag: "2.1.1"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
The new consistency monitoring image:
- fixes a python function that was breaking the display for T1_UK_RAL_Disk and T1_UK_RAL_Tape sites
- upgrades from python 3.9 to python 3.14