### PR TITLE
Revert rucio_con_mon server to old image

### DIFF
--- a/helm/rucio-con-mon/values-prod.yaml
+++ b/helm/rucio-con-mon/values-prod.yaml
@@ -1,6 +1,6 @@
 environment: "prod"
 image:
-  repository: registry.cern.ch/cmsrucio/rucio-con-mon
+  repository: ivmfnal/rucio_consistency_monitor
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "2.0.0"
+  tag: "latest"


### PR DESCRIPTION
Reverting to old image is necessary, because all recently built images were missing an important functionality (Javascript-based charting).
