### PR TITLE
Add path for global DBSMigration service in Ingress

### DIFF
--- a/helm/ingress/templates/ing-dbs.yaml
+++ b/helm/ingress/templates/ing-dbs.yaml
@@ -61,6 +61,13 @@ spec:
             name: dbs2go-global-migration
             port:
               number: 9251
+      - path: /dbs/{{$env}}/phy03/DBSMigration
+        pathType: Prefix
+        backend:
+          service:
+            name: dbs2go-phys03-migration
+            port:
+              number: 9251
       - path: /dbspy/{{$env}}/global/DBSMigrate
         pathType: Prefix
         backend:

--- a/helm/ingress/templates/ing-dbs.yaml
+++ b/helm/ingress/templates/ing-dbs.yaml
@@ -54,7 +54,13 @@ spec:
             name: dbs2go-phys03-m
             port:
               number: 9257
-
+      - path: /dbs/{{$env}}/global/DBSMigration
+        pathType: Prefix
+        backend:
+          service:
+            name: dbs2go-global-migration
+            port:
+              number: 9251
       - path: /dbspy/{{$env}}/global/DBSMigrate
         pathType: Prefix
         backend:


### PR DESCRIPTION
It never existed in our old and new Ingress, but it should be added. I was not communicated to that this service is effective in production.

FYI @uhomsuwa 