### PR TITLE
Update preprod con-mon image to 2.1.2

### DIFF
--- a/helm/rucio-con-mon/values-preprod.yaml
+++ b/helm/rucio-con-mon/values-preprod.yaml
@@ -3,4 +3,4 @@ image:
   repository: registry.cern.ch/cmsrucio/rucio-con-mon
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "2.1.1"
+  tag: "2.1.2"


### PR DESCRIPTION
The new image fixes a bug in the RSE summary page, which was causing the charts to crash and not be displayed.
