### PR TITLE
Push com-mon 2.1.3 tag for production

### DIFF
--- a/helm/rucio-con-mon/values-prod.yaml
+++ b/helm/rucio-con-mon/values-prod.yaml
@@ -1,6 +1,6 @@
 environment: "prod"
 image:
-  repository: ivmfnal/rucio_consistency_monitor
+  repository: registry.cern.ch/cmsrucio/rucio-con-mon
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "latest"
+  tag: "2.1.3"


### PR DESCRIPTION
The new image replaces a quite old image that serves the CMS Rucio consistency monitoring pages.

The main chages are:
- based on Python 3.14
- much smaller number of vulnerabilities (cf. CERN registry)
- pages display information about permanently lost files.

It has been launched into the preprod server, and everything looks good.