### PR TITLE
Add workqueue-rulecleaner Helm chart

### DIFF
--- a/helm/workqueue-rulecleaner/Chart.yaml
+++ b/helm/workqueue-rulecleaner/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: workqueue-rulecleaner
+description: A Helm chart for the standalone GlobalWorkQueue InputDataRucioRuleCleaner pod
+
+type: application
+
+version: 0.1.0
+
+appVersion: "2.4.4-stable"

--- a/helm/workqueue-rulecleaner/templates/_helpers.tpl
+++ b/helm/workqueue-rulecleaner/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "workqueue-rulecleaner.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "workqueue-rulecleaner.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "workqueue-rulecleaner.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "workqueue-rulecleaner.labels" -}}
+helm.sh/chart: {{ include "workqueue-rulecleaner.chart" . }}
+{{ include "workqueue-rulecleaner.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "workqueue-rulecleaner.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "workqueue-rulecleaner.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "workqueue-rulecleaner.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "workqueue-rulecleaner.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/workqueue-rulecleaner/templates/configMap.yaml
+++ b/helm/workqueue-rulecleaner/templates/configMap.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: workqueue-rulecleaner-filebeat-config
+  namespace: dmwm
+  labels:
+    k8s-app: filebeat
+data:
+  filebeat.yml: |-
+    filebeat.inputs:
+    - type: log
+      enabled: true
+      paths:
+        - /data/srv/logs/workqueue/*${MY_POD_NAME}*.log
+      ignore_older: 1h
+      scan_frequency: 10s
+      backoff: 5s
+      max_backoff: 10s
+    output.console:
+      codec.format:
+        string: '%{[message]} - Podname=${MY_POD_NAME}'
+        pretty: false
+    queue.mem:
+      events: 65536
+    logging.metrics.enabled: false
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: workqueue-rulecleaner
+  labels:
+    app: workqueue-rulecleaner
+  namespace: dmwm
+data:
+  setup-certs-and-run.sh: |
+    #!/bin/bash
+    echo 'INFO Files in /etc/grid-security'
+    ls -lahZ /etc/grid-security
+    cd /data && /data/run.sh
+---

--- a/helm/workqueue-rulecleaner/templates/deployment.yaml
+++ b/helm/workqueue-rulecleaner/templates/deployment.yaml
@@ -1,0 +1,147 @@
+{{- $environment := .Values.environment | default dict }}
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  labels:
+    app: workqueue-rulecleaner
+  name: {{ .Release.Name }}
+  namespace: dmwm
+spec:
+  selector:
+    matchLabels:
+      app: workqueue-rulecleaner
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: workqueue-rulecleaner
+        env: k8s-{{.Values.environment}}
+      annotations:
+      {{- toYaml .Values.podAnnotations | nindent 8 }}
+    spec:
+      securityContext:
+      {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+      - image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        name: workqueue-rulecleaner
+        {{- if or (eq (toString $environment) "prod") (eq (toString $environment) "preprod") }}
+        resources:
+        {{- toYaml .Values.resources | nindent 12 }}
+        {{- end }}
+        livenessProbe:
+        {{- toYaml .Values.livenessProbe | nindent 12 }}
+        ports:
+        - containerPort: 8241
+          protocol: TCP
+          name: wq-rulecleaner
+        - containerPort: 18241
+          protocol: TCP
+          name: wq-rc-mon
+        command:
+        - /bin/bash
+        - /opt/setup-certs-and-run/setup-certs-and-run.sh
+        volumeMounts:
+        - name: rucio-secrets
+          mountPath: /opt/rucio/etc
+          readOnly: true
+        - name: proxy-secrets
+          mountPath: /etc/proxy
+          readOnly: true
+        - name: secrets
+          mountPath: /etc/secrets
+          readOnly: true
+        - name: robot-secrets
+          mountPath: /etc/robots
+          readOnly: true
+        - name: hmac-secrets
+          mountPath: /etc/hmac
+          readOnly: true
+        - mountPath: /etc/grid-security
+          name: etc-grid-security
+          readOnly: true
+        - name: setup-certs-and-run
+          mountPath: /opt/setup-certs-and-run
+        - name: token-secrets
+          mountPath: /etc/token
+          readOnly: true
+        {{- if or (eq (toString $environment) "prod") (eq (toString $environment) "preprod") }}
+        - name: logs
+          mountPath: /data/srv/logs/workqueue
+        {{- end }}
+        securityContext:
+          privileged: true
+        {{- if or (eq (toString $environment) "prod") (eq (toString $environment) "preprod") }}
+      - name: workqueue-rulecleaner-filebeat
+        image: {{ .Values.imageFilebeat.path}}
+        args: [
+          "-c", "/etc/filebeat.yml",
+          "-e",
+        ]
+        env:
+        {{- toYaml .Values.imageFilebeat.env | nindent 10 }}
+        resources:
+        {{- toYaml .Values.imageFilebeatResources | nindent 12 }}
+        volumeMounts:
+        - name: logs
+          mountPath: /data/srv/logs/workqueue
+        - name: config
+          mountPath: /etc/filebeat.yml
+          readOnly: true
+          subPath: filebeat.yml
+        - name: data
+          mountPath: /usr/share/filebeat/data
+        - name: varlog
+          mountPath: /var/log
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+        securityContext:
+          allowPrivilegeEscalation: false
+        {{- end }}
+      volumes:
+      - name: rucio-secrets
+        secret:
+          secretName: rucio-secrets
+      - name: proxy-secrets
+        secret:
+          secretName: proxy-secrets
+      - name: secrets
+        secret:
+          secretName: workqueue-rulecleaner-secrets
+      - name: robot-secrets
+        secret:
+          secretName: robot-secrets
+      - name: hmac-secrets
+        secret:
+          secretName: hmac-secrets
+      - name: etc-grid-security
+        hostPath:
+            path: /etc/grid-security
+      - name: setup-certs-and-run
+        configMap:
+          name: workqueue-rulecleaner
+      - name: token-secrets
+        secret:
+          secretName: token-secrets
+      {{- if or (eq (toString $environment) "prod") (eq (toString $environment) "preprod") }}
+      - name: logs
+        persistentVolumeClaim:
+        {{- if eq (toString $environment) "preprod" }}
+          claimName: logs-cephfs-claim-preprod-dmwm
+          {{- end }}
+          {{- if eq (toString $environment) "prod" }}
+          claimName: logs-cephfs-claim-prod-dmwm
+        {{- end }}
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+      - name: config
+        configMap:
+          defaultMode: 0640
+          name: workqueue-rulecleaner-filebeat-config
+      - name: data
+        emptyDir: {}
+      {{- end }}

--- a/helm/workqueue-rulecleaner/templates/hpa.yaml
+++ b/helm/workqueue-rulecleaner/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "workqueue-rulecleaner.fullname" . }}
+  labels:
+    {{- include "workqueue-rulecleaner.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "workqueue-rulecleaner.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/helm/workqueue-rulecleaner/templates/ingress.yaml
+++ b/helm/workqueue-rulecleaner/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "workqueue-rulecleaner.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "workqueue-rulecleaner.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+  {{- end }}

--- a/helm/workqueue-rulecleaner/templates/service.yaml
+++ b/helm/workqueue-rulecleaner/templates/service.yaml
@@ -1,0 +1,15 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: workqueue-rulecleaner
+  namespace: dmwm
+spec:
+  selector:
+    app: workqueue-rulecleaner
+  ports:
+    - port: 8241
+      targetPort: 8241
+      name: wq-rulecleaner
+    - port: 18241
+      targetPort: 18241
+      name: wq-rc-mon

--- a/helm/workqueue-rulecleaner/templates/serviceaccount.yaml
+++ b/helm/workqueue-rulecleaner/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "workqueue-rulecleaner.serviceAccountName" . }}
+  labels:
+    {{- include "workqueue-rulecleaner.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/workqueue-rulecleaner/values.yaml
+++ b/helm/workqueue-rulecleaner/values.yaml
@@ -1,0 +1,96 @@
+# Default values for workqueue-rulecleaner.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: registry.cern.ch/cmsweb/wmglobalqueue
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "2.4.4-stable"
+  command:
+  - /bin/bash
+  - /opt/setup-certs-and-run/setup-certs-and-run.sh
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+environment:
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+
+podAnnotations:
+  prometheus.io/scrape: 'true'
+  prometheus.io/port: "18241"
+
+securityContext:
+  privileged: true
+
+podSecurityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 2000
+
+imageFilebeatSecurityContext:
+  allowPrivilegeEscalation: false
+
+
+resources:
+  requests:
+    memory: "256Mi"
+    cpu: "200m"
+  limits:
+    memory: "1Gi"
+    cpu: "500m"
+
+
+imageFilebeat:
+  name: workqueue-rulecleaner-filebeat
+  path: docker.elastic.co/beats/filebeat:7.12.0
+  env:
+  - name: MY_POD_NAME
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: metadata.name
+  args: [
+  "-c", "/etc/filebeat.yml",
+  "-e",
+   ]
+
+imageFilebeatResources:
+  requests:
+    memory: "50Mi"
+    cpu: "50m"
+
+livenessProbe:
+  exec:
+    command:
+    - cmsweb-ping
+    - "--url=http://localhost:8241/workqueue/index.html"
+    - "--authz=/etc/hmac/hmac"
+    - -verbose
+    - "0"
+  initialDelaySeconds: 120
+  periodSeconds: 10
+ingress:
+  enabled: false
+  annotations: {}
+
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
## Summary

Adds a new `workqueue-rulecleaner` Helm chart — a standalone CherryPy pod
running only the `InputDataRucioRuleCleaner` periodic task alongside the
GlobalWorkQueue service.

The task cleans block-level Rucio replication rules for input datasets of
completed GlobalWorkQueue elements, freeing disk storage once
workflows have finished processing their input data.

## Changes

- New Helm chart under `helm/workqueue-rulecleaner/` with:
  - `deployment.yaml` — CherryPy pod mounting workqueue secrets and config
  - `configMap.yaml` — startup script (setup-certs-and-run.sh)
  - `values.yaml` — configurable image, resources, and replica count
  - Standard supporting templates (service, ingress, hpa, serviceaccount)

## Test 

- [x] Deployed and tested on cmsweb-test16
- [x] Pod starts successfully and connects to GlobalWorkQueue CouchDB
- [x] InputDataRucioRuleCleaner runs periodically and cleans Rucio rules for completed elements
- [x] No impact on existing workqueue pod