### PR TITLE
sync CRABServer with live state and bump canary 

### DIFF
--- a/helm/crabserver/templates/configMap.yaml
+++ b/helm/crabserver/templates/configMap.yaml
@@ -1,5 +1,5 @@
 {{- $environment := .Values.environment | default dict }}
-{{- if .Values.enabled -}}
+{{- if .Values.crabserver.configMap.enabled -}}
 kind: ConfigMap
 apiVersion: v1
 metadata:

--- a/helm/crabserver/values-preprod.yaml
+++ b/helm/crabserver/values-preprod.yaml
@@ -1,34 +1,31 @@
-environment: "preprod"
-
+environment: preprod
 image:
-  tag: "v3-251024"
-
+  tag: v3-260514
 ciServiceAccount:
   enabled: false
-
-
 livenessProbe:
   exec:
     command:
-    - /bin/sh
-    - -c
-    - |
-      cmsweb-ping --url=http://localhost:8270/crabserver/preprod/info --authz=/etc/hmac/hmac -verbose 0 | egrep "^[2-4]"
+      - /bin/sh
+      - -c
+      - 'cmsweb-ping --url=http://localhost:8270/crabserver/preprod/info --authz=/etc/hmac/hmac
+        -verbose 0 | egrep "^[2-4]"
+
+        '
   failureThreshold: 3
   initialDelaySeconds: 120
   periodSeconds: 60
   timeoutSeconds: 60
-
 readinessProbe:
   exec:
     command:
-    - /bin/sh
-    - -c
-    - |
-      cmsweb-ping --url=http://localhost:8270/crabserver/preprod/info --authz=/etc/hmac/hmac -verbose 0 | egrep "^[2-4]"
+      - /bin/sh
+      - -c
+      - 'cmsweb-ping --url=http://localhost:8270/crabserver/preprod/info --authz=/etc/hmac/hmac
+        -verbose 0 | egrep "^[2-4]"
+
+        '
   periodSeconds: 60
   timeoutSeconds: 60
-
 logPipeline:
-  enabled: true
-  # logstashNamespace: logging
+  enabled: false

--- a/helm/crabserver/values-prod.yaml
+++ b/helm/crabserver/values-prod.yaml
@@ -3,13 +3,13 @@ environment: "prod"
 replicaCount: 15
 
 image:
-  tag: "v3.251002-stable"
+  tag: v3.251015-stable
   
 canary:
   enabled: true
   replicaCount: 1
   image:
-    tag: "v3.251002-stable"
+    tag: v3.260407-stable
 
 livenessProbe:
   exec:

--- a/helm/crabserver/values-test12.yaml
+++ b/helm/crabserver/values-test12.yaml
@@ -1,5 +1,3 @@
----
-environment: "test"
-
+environment: test
 image:
-  tag: "pypi-test12-290925-4"
+  tag: pypi-test12-180426-1

--- a/helm/crabserver/values-test14.yaml
+++ b/helm/crabserver/values-test14.yaml
@@ -1,5 +1,3 @@
----
-environment: "test"
-
+environment: test
 image:
-  tag: "pypi-test14-1760687168"
+  tag: pypi-test14-1778771618

--- a/helm/crabserver/values-test2.yaml
+++ b/helm/crabserver/values-test2.yaml
@@ -1,5 +1,3 @@
----
-environment: "test"
-
+environment: test
 image:
-  tag: "v3.250929.1-stable"
+  tag: v3.260428-stable

--- a/helm/crabserver/values.yaml
+++ b/helm/crabserver/values.yaml
@@ -6,6 +6,8 @@ enabled: true
 replicaCount: 1
 
 crabserver:
+  configMap:
+    enabled: true
   configPy: null
 
 image:


### PR DESCRIPTION
Sync all non-prod envs with live state before switching from local ArgoCD to centrally managed CMSWEB ArgoCD control plane.