### PR TITLE
Bump CRABServer to Alma9 with py3.9 codebase.

### DIFF
--- a/helm/crabserver/values-prod.yaml
+++ b/helm/crabserver/values-prod.yaml
@@ -3,7 +3,7 @@ environment: "prod"
 replicaCount: 15
 
 image:
-  tag: v3.251015-stable
+  tag: v3.260407-stable
   
 canary:
   enabled: true


### PR DESCRIPTION
Hi CMSWeb experts!

let us take this chance to bump to Alma9 image `v3.260407-stable` as a way to test the migration to CMSWEB-managed ArgoCD. 