### PR TITLE
Drop distutils for Python 3.12, complete cmswmcore rename

### DIFF
--- a/docker/pypi/wmagent/init.sh
+++ b/docker/pypi/wmagent/init.sh
@@ -7,7 +7,7 @@
 ### * The agent's hostname && HTCondor configuration are taken from the host
 
 WMCoreVersion=$(python -c "from WMCore import __version__ as WMCoreVersion; print(WMCoreVersion)")
-pythonLib=$(python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
+pythonLib=$(python -c "import sysconfig; print(sysconfig.get_paths()['purelib'])")
 
 # Load common definitions and environment:
 source $WMA_DEPLOY_DIR/bin/manage-common.sh

--- a/docker/pypi/wmagent/install.sh
+++ b/docker/pypi/wmagent/install.sh
@@ -8,7 +8,7 @@
 ### It takes a single parameter as first (and only) argument - The WMA_TAG
 ### Example: install.sh -t 2.2.0.2
 
-pythonLib=$(python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
+pythonLib=$(python -c "import sysconfig; print(sysconfig.get_paths()['purelib'])")
 
 help(){
     echo -e $1

--- a/docker/pypi/wmagent/wmagent-docker-run.sh
+++ b/docker/pypi/wmagent/wmagent-docker-run.sh
@@ -143,7 +143,7 @@ registry=local
 repository=wmagent
 $PULL && {
     registry=registry.cern.ch
-    project=cmsweb
+    project=cmswmcore
     echo "Pulling Docker image: registry.cern.ch/cmswmcore/wmagent:$WMA_TAG"
     docker login registry.cern.ch
     docker pull $registry/$project/$repository:$WMA_TAG


### PR DESCRIPTION
## Problem
WMCore CI has failed to build the wmagent docker image on every tagged release since 2.4.5.4 (Mar 2026). The last successful build was 2.4.5.3 (Jan 2026). Failure log excerpt from run [24837315029](https://github.com/dmwm/WMCore/actions/runs/24837315029) (tag 2.4.5.6):
```
#15 [ 7/11] RUN /data/install.sh -t 2.4.5.6
#15 0.111 Traceback (most recent call last):
#15 0.111   File "<string>", line 1, in <module>
#15 0.111 ModuleNotFoundError: No module named 'distutils'
```
## Root cause
Both `install.sh:11` and `init.sh:10` call:
```
pythonLib=$(python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
```
distutils was removed from stdlib in [Python 3.12 (PEP 632, 3.12 What's New)](https://docs.python.org/3.12/whatsnew/3.12.html#removed). The base image registry.cern.ch/cmsweb/wmagent-base:pypi-20251015-stable ships Python 3.12.11 and does not include setuptools (which historically provided a distutils compatibility shim, removed anyway in setuptools 74+). So import distutils fails hard. This was changed already in 2025 [commit](https://github.com/dmwm/CMSKubernetes/commit/2e1a7a87). I'm not fully sure why we haven't seen this error before.

Reproduced inside the actual base image:
```
$ docker run --rm registry.cern.ch/cmsweb/wmagent-base:pypi-20251015-stable \
    python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"
ModuleNotFoundError: No module named 'distutils'
```

```
$ docker run --rm registry.cern.ch/cmsweb/wmagent-base:pypi-20251015-stable \
    python -c "import setuptools; print(setuptools.__version__)"
ModuleNotFoundError: No module named 'setuptools'
```
# Fix

Replaced with the officially recommended stdlib call:
```
pythonLib=$(python -c "import sysconfig; print(sysconfig.get_paths()['purelib'])")
```

sysconfig is stdlib since Python 2.7 and has no third-party dependency. It returns the byte-identical path the old distutils call produced back when the January 2026 build succeeded:

```
$ docker run --rm registry.cern.ch/cmsweb/wmagent-base:pypi-20251015-stable \
    python -c "import sysconfig; print(sysconfig.get_paths()['purelib'])"
/usr/local/lib/python3.12/site-packages
```
Bundled cleanup

Also fixes wmagent-docker-run.sh:146 where the cmsweb → cmswmcore rename was half-done in 19b2fec5: the echo message was updated but project=cmsweb was not, so the -p pull path was still resolving to the old Harbor project despite the log saying otherwise.

Verification

- Failing distutils call reproduced against the actual production base image (above).
- Head of patched install.sh executes cleanly:
```
$ docker run --rm -v $PWD/docker/pypi/wmagent/install.sh:/tmp/install.sh:ro \
    registry.cern.ch/cmsweb/wmagent-base:pypi-20251015-stable \
    bash -c 'head -12 /tmp/install.sh; python -c "import sysconfig; print(sysconfig.get_paths()[\"purelib\"])"'
...
/usr/local/lib/python3.12/site-packages
```

