### PR TITLE
Create DBS dev Environment

### DIFF
--- a/kubernetes/cmsweb/services/dbs2go-global-m-dev.yaml
+++ b/kubernetes/cmsweb/services/dbs2go-global-m-dev.yaml
@@ -1,0 +1,133 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dbs2go-global-m-dev
+  namespace: dbs
+  labels:
+    app: dbs2go-global-m-dev
+spec:
+  selector:
+    app: dbs2go-global-m-dev
+  ports:
+  - port: 9257
+    targetPort: 9257
+    name: dbs
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dbs2go-global-m-dev
+  namespace: dbs
+  labels:
+    app: dbs2go-global-m-dev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dbs2go-global-m-dev
+  template:
+    metadata:
+      labels:
+        app: dbs2go-global-m-dev
+        job: dbs2go-global-m-dev
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /dbs/prod/global/DBSMigrate/metrics
+        prometheus.io/port: "9257"
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 2000
+      containers:
+      - name: dev
+        image: registry.cern.ch/cmsweb/dbs2go:dev
+        imagePullPolicy: Always
+        command:
+        - sleep
+        - infinity
+        env:
+        - name: X509_USER_PROXY
+          value: /etc/proxy/proxy
+        - name: TNS_ADMIN
+          value: /etc/tnsnames.ora
+        ports:
+        - containerPort: 9257
+          protocol: TCP
+          name: dbs
+        resources:
+          requests:
+            memory: 100Mi
+            cpu: 200m
+          limits:
+            memory: 500Mi
+            cpu: 4000m
+        volumeMounts:
+        - name: proxy-secrets
+          mountPath: /etc/proxy
+          readOnly: true
+        - name: secrets
+          mountPath: /etc/secrets
+          readOnly: true
+        - name: robot-secrets
+          mountPath: /etc/robots
+          readOnly: true
+        - name: hmac-secrets
+          mountPath: /etc/hmac
+          readOnly: true
+        - name: token-secrets
+          mountPath: /etc/token
+          readOnly: true
+        - name: tnsnames
+          mountPath: /etc/tnsnames.ora
+          subPath: tnsnames.ora
+        securityContext:
+          allowPrivilegeEscalation: false
+      volumes:
+      - name: proxy-secrets
+        secret:
+          secretName: proxy-secrets
+      - name: robot-secrets
+        secret:
+          secretName: robot-secrets
+      - name: hmac-secrets
+        secret:
+          secretName: hmac-secrets
+      - name: secrets
+        secret:
+          secretName: dbs2go-global-m-secrets
+      - name: tnsnames
+        configMap:
+          name: tnsnames-config
+      - name: token-secrets
+        secret:
+          secretName: token-secrets
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: dbs2go-global-m-dev-network-policy
+  namespace: dbs
+spec:
+  podSelector:
+    matchLabels:
+      app: dbs2go-global-m-dev
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: auth
+      podSelector:
+        matchExpressions:
+        - key: app
+          operator: In
+          values:
+          - frontend
+          - auth-proxy-server
+          - scitokens-proxy-server
+          - x509-proxy-server
+    ports:
+    - protocol: TCP
+      port: 9257

--- a/kubernetes/cmsweb/services/dbs2go-global-migration-dev.yaml
+++ b/kubernetes/cmsweb/services/dbs2go-global-migration-dev.yaml
@@ -1,18 +1,3 @@
-apiVersion: v1
-kind: Service
-metadata:
-  name: dbs2go-global-migration-dev
-  namespace: dbs
-  labels:
-    app: dbs2go-global-migration-dev
-spec:
-  selector:
-    app: dbs2go-global-migration-dev
-  ports:
-  - port: 9251
-    targetPort: 9251
-    name: dbs
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/kubernetes/cmsweb/services/dbs2go-global-migration-dev.yaml
+++ b/kubernetes/cmsweb/services/dbs2go-global-migration-dev.yaml
@@ -1,0 +1,133 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dbs2go-global-migration-dev
+  namespace: dbs
+  labels:
+    app: dbs2go-global-migration-dev
+spec:
+  selector:
+    app: dbs2go-global-migration-dev
+  ports:
+  - port: 9251
+    targetPort: 9251
+    name: dbs
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dbs2go-global-migration-dev
+  namespace: dbs
+  labels:
+    app: dbs2go-global-migration-dev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dbs2go-global-migration-dev
+  template:
+    metadata:
+      labels:
+        app: dbs2go-global-migration-dev
+        job: dbs2go-global-migration-dev
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /dbs/prod/global/DBSMigration/metrics
+        prometheus.io/port: "9251"
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 2000
+      containers:
+      - name: dev
+        image: registry.cern.ch/cmsweb/dbs2go:dev
+        imagePullPolicy: Always
+        command:
+        - sleep
+        - infinity
+        env:
+        - name: X509_USER_PROXY
+          value: /etc/proxy/proxy
+        - name: TNS_ADMIN
+          value: /etc/tnsnames.ora
+        ports:
+        - containerPort: 9251
+          protocol: TCP
+          name: dbs
+        resources:
+          requests:
+            memory: 100Mi
+            cpu: 200m
+          limits:
+            memory: 500Mi
+            cpu: 4000m
+        volumeMounts:
+        - name: proxy-secrets
+          mountPath: /etc/proxy
+          readOnly: true
+        - name: secrets
+          mountPath: /etc/secrets
+          readOnly: true
+        - name: robot-secrets
+          mountPath: /etc/robots
+          readOnly: true
+        - name: hmac-secrets
+          mountPath: /etc/hmac
+          readOnly: true
+        - name: token-secrets
+          mountPath: /etc/token
+          readOnly: true
+        - name: tnsnames
+          mountPath: /etc/tnsnames.ora
+          subPath: tnsnames.ora
+        securityContext:
+          allowPrivilegeEscalation: false
+      volumes:
+      - name: proxy-secrets
+        secret:
+          secretName: proxy-secrets
+      - name: robot-secrets
+        secret:
+          secretName: robot-secrets
+      - name: hmac-secrets
+        secret:
+          secretName: hmac-secrets
+      - name: secrets
+        secret:
+          secretName: dbs2go-global-migration-secrets
+      - name: tnsnames
+        configMap:
+          name: tnsnames-config
+      - name: token-secrets
+        secret:
+          secretName: token-secrets
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: dbs2go-global-migration-dev-network-policy
+  namespace: dbs
+spec:
+  podSelector:
+    matchLabels:
+      app: dbs2go-global-migration-dev
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: auth
+      podSelector:
+        matchExpressions:
+        - key: app
+          operator: In
+          values:
+          - frontend
+          - auth-proxy-server
+          - scitokens-proxy-server
+          - x509-proxy-server
+    ports:
+    - protocol: TCP
+      port: 9251

--- a/kubernetes/cmsweb/services/dbs2go-global-r-dev.yaml
+++ b/kubernetes/cmsweb/services/dbs2go-global-r-dev.yaml
@@ -1,0 +1,133 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dbs2go-global-r-dev
+  namespace: dbs
+  labels:
+    app: dbs2go-global-r-dev
+spec:
+  selector:
+    app: dbs2go-global-r-dev
+  ports:
+  - port: 9252
+    targetPort: 9252
+    name: dbs
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dbs2go-global-r-dev
+  namespace: dbs
+  labels:
+    app: dbs2go-global-r-dev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dbs2go-global-r-dev
+  template:
+    metadata:
+      labels:
+        app: dbs2go-global-r-dev
+        job: dbs2go-global-r-dev
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /dbs/prod/global/DBSReader/metrics
+        prometheus.io/port: "9252"
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 2000
+      containers:
+      - name: dev
+        image: registry.cern.ch/cmsweb/dbs2go:dev
+        imagePullPolicy: Always
+        command:
+        - sleep
+        - infinity
+        env:
+        - name: X509_USER_PROXY
+          value: /etc/proxy/proxy
+        - name: TNS_ADMIN
+          value: /etc/tnsnames.ora
+        ports:
+        - containerPort: 9252
+          protocol: TCP
+          name: dbs
+        resources:
+          requests:
+            memory: 100Mi
+            cpu: 200m
+          limits:
+            memory: 500Mi
+            cpu: 4000m
+        volumeMounts:
+        - name: proxy-secrets
+          mountPath: /etc/proxy
+          readOnly: true
+        - name: secrets
+          mountPath: /etc/secrets
+          readOnly: true
+        - name: robot-secrets
+          mountPath: /etc/robots
+          readOnly: true
+        - name: hmac-secrets
+          mountPath: /etc/hmac
+          readOnly: true
+        - name: token-secrets
+          mountPath: /etc/token
+          readOnly: true
+        - name: tnsnames
+          mountPath: /etc/tnsnames.ora
+          subPath: tnsnames.ora
+        securityContext:
+          allowPrivilegeEscalation: false
+      volumes:
+      - name: proxy-secrets
+        secret:
+          secretName: proxy-secrets
+      - name: robot-secrets
+        secret:
+          secretName: robot-secrets
+      - name: hmac-secrets
+        secret:
+          secretName: hmac-secrets
+      - name: secrets
+        secret:
+          secretName: dbs2go-global-r-secrets
+      - name: tnsnames
+        configMap:
+          name: tnsnames-config
+      - name: token-secrets
+        secret:
+          secretName: token-secrets
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: dbs2go-global-r-dev-network-policy
+  namespace: dbs
+spec:
+  podSelector:
+    matchLabels:
+      app: dbs2go-global-r-dev
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: auth
+      podSelector:
+        matchExpressions:
+        - key: app
+          operator: In
+          values:
+          - frontend
+          - auth-proxy-server
+          - scitokens-proxy-server
+          - x509-proxy-server
+    ports:
+    - protocol: TCP
+      port: 9252

--- a/kubernetes/cmsweb/services/dbs2go-global-w-dev.yaml
+++ b/kubernetes/cmsweb/services/dbs2go-global-w-dev.yaml
@@ -1,0 +1,133 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dbs2go-global-w-dev
+  namespace: dbs
+  labels:
+    app: dbs2go-global-w-dev
+spec:
+  selector:
+    app: dbs2go-global-w-dev
+  ports:
+  - port: 9253
+    targetPort: 9253
+    name: dbs
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dbs2go-global-w-dev
+  namespace: dbs
+  labels:
+    app: dbs2go-global-w-dev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dbs2go-global-w-dev
+  template:
+    metadata:
+      labels:
+        app: dbs2go-global-w-dev
+        job: dbs2go-global-w-dev
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /dbs/prod/global/DBSWriter/metrics
+        prometheus.io/port: "9253"
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 2000
+      containers:
+      - name: dev
+        image: registry.cern.ch/cmsweb/dbs2go:dev
+        imagePullPolicy: Always
+        command:
+        - sleep
+        - infinity
+        env:
+        - name: X509_USER_PROXY
+          value: /etc/proxy/proxy
+        - name: TNS_ADMIN
+          value: /etc/tnsnames.ora
+        ports:
+        - containerPort: 9253
+          protocol: TCP
+          name: dbs
+        resources:
+          requests:
+            memory: 100Mi
+            cpu: 200m
+          limits:
+            memory: 500Mi
+            cpu: 4000m
+        volumeMounts:
+        - name: proxy-secrets
+          mountPath: /etc/proxy
+          readOnly: true
+        - name: secrets
+          mountPath: /etc/secrets
+          readOnly: true
+        - name: robot-secrets
+          mountPath: /etc/robots
+          readOnly: true
+        - name: hmac-secrets
+          mountPath: /etc/hmac
+          readOnly: true
+        - name: token-secrets
+          mountPath: /etc/token
+          readOnly: true
+        - name: tnsnames
+          mountPath: /etc/tnsnames.ora
+          subPath: tnsnames.ora
+        securityContext:
+          allowPrivilegeEscalation: false
+      volumes:
+      - name: proxy-secrets
+        secret:
+          secretName: proxy-secrets
+      - name: robot-secrets
+        secret:
+          secretName: robot-secrets
+      - name: hmac-secrets
+        secret:
+          secretName: hmac-secrets
+      - name: secrets
+        secret:
+          secretName: dbs2go-global-w-secrets
+      - name: tnsnames
+        configMap:
+          name: tnsnames-config
+      - name: token-secrets
+        secret:
+          secretName: token-secrets
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: dbs2go-global-w-dev-network-policy
+  namespace: dbs
+spec:
+  podSelector:
+    matchLabels:
+      app: dbs2go-global-w-dev
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: auth
+      podSelector:
+        matchExpressions:
+        - key: app
+          operator: In
+          values:
+          - frontend
+          - auth-proxy-server
+          - scitokens-proxy-server
+          - x509-proxy-server
+    ports:
+    - protocol: TCP
+      port: 9253

--- a/kubernetes/cmsweb/services/dbs2go-phys03-m-dev.yaml
+++ b/kubernetes/cmsweb/services/dbs2go-phys03-m-dev.yaml
@@ -1,0 +1,133 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dbs2go-phys03-m-dev
+  namespace: dbs
+  labels:
+    app: dbs2go-phys03-m-dev
+spec:
+  selector:
+    app: dbs2go-phys03-m-dev
+  ports:
+  - port: 9257
+    targetPort: 9257
+    name: dbs
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dbs2go-phys03-m-dev
+  namespace: dbs
+  labels:
+    app: dbs2go-phys03-m-dev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dbs2go-phys03-m-dev
+  template:
+    metadata:
+      labels:
+        app: dbs2go-phys03-m-dev
+        job: dbs2go-phys03-m-dev
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /dbs/prod/phys03/DBSMigrate/metrics
+        prometheus.io/port: "9257"
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 2000
+      containers:
+      - name: dev
+        image: registry.cern.ch/cmsweb/dbs2go:dev
+        imagePullPolicy: Always
+        command:
+        - sleep
+        - infinity
+        env:
+        - name: X509_USER_PROXY
+          value: /etc/proxy/proxy
+        - name: TNS_ADMIN
+          value: /etc/tnsnames.ora
+        ports:
+        - containerPort: 9257
+          protocol: TCP
+          name: dbs
+        resources:
+          requests:
+            memory: 100Mi
+            cpu: 200m
+          limits:
+            memory: 500Mi
+            cpu: 4000m
+        volumeMounts:
+        - name: proxy-secrets
+          mountPath: /etc/proxy
+          readOnly: true
+        - name: secrets
+          mountPath: /etc/secrets
+          readOnly: true
+        - name: robot-secrets
+          mountPath: /etc/robots
+          readOnly: true
+        - name: hmac-secrets
+          mountPath: /etc/hmac
+          readOnly: true
+        - name: token-secrets
+          mountPath: /etc/token
+          readOnly: true
+        - name: tnsnames
+          mountPath: /etc/tnsnames.ora
+          subPath: tnsnames.ora
+        securityContext:
+          allowPrivilegeEscalation: false
+      volumes:
+      - name: proxy-secrets
+        secret:
+          secretName: proxy-secrets
+      - name: robot-secrets
+        secret:
+          secretName: robot-secrets
+      - name: hmac-secrets
+        secret:
+          secretName: hmac-secrets
+      - name: secrets
+        secret:
+          secretName: dbs2go-phys03-m-secrets
+      - name: tnsnames
+        configMap:
+          name: tnsnames-config
+      - name: token-secrets
+        secret:
+          secretName: token-secrets
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: dbs2go-phys03-m-dev-network-policy
+  namespace: dbs
+spec:
+  podSelector:
+    matchLabels:
+      app: dbs2go-phys03-m-dev
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: auth
+      podSelector:
+        matchExpressions:
+        - key: app
+          operator: In
+          values:
+          - frontend
+          - auth-proxy-server
+          - scitokens-proxy-server
+          - x509-proxy-server
+    ports:
+    - protocol: TCP
+      port: 9257

--- a/kubernetes/cmsweb/services/dbs2go-phys03-migration-dev.yaml
+++ b/kubernetes/cmsweb/services/dbs2go-phys03-migration-dev.yaml
@@ -1,18 +1,3 @@
-apiVersion: v1
-kind: Service
-metadata:
-  name: dbs2go-phys03-migration-dev
-  namespace: dbs
-  labels:
-    app: dbs2go-phys03-migration-dev
-spec:
-  selector:
-    app: dbs2go-phys03-migration-dev
-  ports:
-  - port: 9251
-    targetPort: 9251
-    name: dbs
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/kubernetes/cmsweb/services/dbs2go-phys03-migration-dev.yaml
+++ b/kubernetes/cmsweb/services/dbs2go-phys03-migration-dev.yaml
@@ -1,0 +1,133 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dbs2go-phys03-migration-dev
+  namespace: dbs
+  labels:
+    app: dbs2go-phys03-migration-dev
+spec:
+  selector:
+    app: dbs2go-phys03-migration-dev
+  ports:
+  - port: 9251
+    targetPort: 9251
+    name: dbs
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dbs2go-phys03-migration-dev
+  namespace: dbs
+  labels:
+    app: dbs2go-phys03-migration-dev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dbs2go-phys03-migration-dev
+  template:
+    metadata:
+      labels:
+        app: dbs2go-phys03-migration-dev
+        job: dbs2go-phys03-migration-dev
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /dbs/prod/phys03/DBSMigration/metrics
+        prometheus.io/port: "9251"
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 2000
+      containers:
+      - name: dev
+        image: registry.cern.ch/cmsweb/dbs2go:dev
+        imagePullPolicy: Always
+        command:
+        - sleep
+        - infinity
+        env:
+        - name: X509_USER_PROXY
+          value: /etc/proxy/proxy
+        - name: TNS_ADMIN
+          value: /etc/tnsnames.ora
+        ports:
+        - containerPort: 9251
+          protocol: TCP
+          name: dbs
+        resources:
+          requests:
+            memory: 100Mi
+            cpu: 200m
+          limits:
+            memory: 500Mi
+            cpu: 4000m
+        volumeMounts:
+        - name: proxy-secrets
+          mountPath: /etc/proxy
+          readOnly: true
+        - name: secrets
+          mountPath: /etc/secrets
+          readOnly: true
+        - name: robot-secrets
+          mountPath: /etc/robots
+          readOnly: true
+        - name: hmac-secrets
+          mountPath: /etc/hmac
+          readOnly: true
+        - name: token-secrets
+          mountPath: /etc/token
+          readOnly: true
+        - name: tnsnames
+          mountPath: /etc/tnsnames.ora
+          subPath: tnsnames.ora
+        securityContext:
+          allowPrivilegeEscalation: false
+      volumes:
+      - name: proxy-secrets
+        secret:
+          secretName: proxy-secrets
+      - name: robot-secrets
+        secret:
+          secretName: robot-secrets
+      - name: hmac-secrets
+        secret:
+          secretName: hmac-secrets
+      - name: secrets
+        secret:
+          secretName: dbs2go-phys03-migration-secrets
+      - name: tnsnames
+        configMap:
+          name: tnsnames-config
+      - name: token-secrets
+        secret:
+          secretName: token-secrets
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: dbs2go-phys03-migration-dev-network-policy
+  namespace: dbs
+spec:
+  podSelector:
+    matchLabels:
+      app: dbs2go-phys03-migration-dev
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: auth
+      podSelector:
+        matchExpressions:
+        - key: app
+          operator: In
+          values:
+          - frontend
+          - auth-proxy-server
+          - scitokens-proxy-server
+          - x509-proxy-server
+    ports:
+    - protocol: TCP
+      port: 9251

--- a/kubernetes/cmsweb/services/dbs2go-phys03-r-dev.yaml
+++ b/kubernetes/cmsweb/services/dbs2go-phys03-r-dev.yaml
@@ -1,0 +1,133 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dbs2go-phys03-r-dev
+  namespace: dbs
+  labels:
+    app: dbs2go-phys03-r-dev
+spec:
+  selector:
+    app: dbs2go-phys03-r-dev
+  ports:
+  - port: 9254
+    targetPort: 9254
+    name: dbs
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dbs2go-phys03-r-dev
+  namespace: dbs
+  labels:
+    app: dbs2go-phys03-r-dev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dbs2go-phys03-r-dev
+  template:
+    metadata:
+      labels:
+        app: dbs2go-phys03-r-dev
+        job: dbs2go-phys03-r-dev
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /dbs/prod/phys03/DBSReader/metrics
+        prometheus.io/port: "9254"
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 2000
+      containers:
+      - name: dev
+        image: registry.cern.ch/cmsweb/dbs2go:dev
+        imagePullPolicy: Always
+        command:
+        - sleep
+        - infinity
+        env:
+        - name: X509_USER_PROXY
+          value: /etc/proxy/proxy
+        - name: TNS_ADMIN
+          value: /etc/tnsnames.ora
+        ports:
+        - containerPort: 9254
+          protocol: TCP
+          name: dbs
+        resources:
+          requests:
+            memory: 100Mi
+            cpu: 200m
+          limits:
+            memory: 500Mi
+            cpu: 4000m
+        volumeMounts:
+        - name: proxy-secrets
+          mountPath: /etc/proxy
+          readOnly: true
+        - name: secrets
+          mountPath: /etc/secrets
+          readOnly: true
+        - name: robot-secrets
+          mountPath: /etc/robots
+          readOnly: true
+        - name: hmac-secrets
+          mountPath: /etc/hmac
+          readOnly: true
+        - name: token-secrets
+          mountPath: /etc/token
+          readOnly: true
+        - name: tnsnames
+          mountPath: /etc/tnsnames.ora
+          subPath: tnsnames.ora
+        securityContext:
+          allowPrivilegeEscalation: false
+      volumes:
+      - name: proxy-secrets
+        secret:
+          secretName: proxy-secrets
+      - name: robot-secrets
+        secret:
+          secretName: robot-secrets
+      - name: hmac-secrets
+        secret:
+          secretName: hmac-secrets
+      - name: secrets
+        secret:
+          secretName: dbs2go-phys03-r-secrets
+      - name: tnsnames
+        configMap:
+          name: tnsnames-config
+      - name: token-secrets
+        secret:
+          secretName: token-secrets
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: dbs2go-phys03-r-dev-network-policy
+  namespace: dbs
+spec:
+  podSelector:
+    matchLabels:
+      app: dbs2go-phys03-r-dev
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: auth
+      podSelector:
+        matchExpressions:
+        - key: app
+          operator: In
+          values:
+          - frontend
+          - auth-proxy-server
+          - scitokens-proxy-server
+          - x509-proxy-server
+    ports:
+    - protocol: TCP
+      port: 9254

--- a/kubernetes/cmsweb/services/dbs2go-phys03-w-dev.yaml
+++ b/kubernetes/cmsweb/services/dbs2go-phys03-w-dev.yaml
@@ -1,0 +1,133 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dbs2go-phys03-w-dev
+  namespace: dbs
+  labels:
+    app: dbs2go-phys03-w-dev
+spec:
+  selector:
+    app: dbs2go-phys03-w-dev
+  ports:
+  - port: 9255
+    targetPort: 9255
+    name: dbs
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dbs2go-phys03-w-dev
+  namespace: dbs
+  labels:
+    app: dbs2go-phys03-w-dev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dbs2go-phys03-w-dev
+  template:
+    metadata:
+      labels:
+        app: dbs2go-phys03-w-dev
+        job: dbs2go-phys03-w-dev
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /dbs/prod/phys03/DBSWriter/metrics
+        prometheus.io/port: "9255"
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 2000
+      containers:
+      - name: dev
+        image: registry.cern.ch/cmsweb/dbs2go:dev
+        imagePullPolicy: Always
+        command:
+        - sleep
+        - infinity
+        env:
+        - name: X509_USER_PROXY
+          value: /etc/proxy/proxy
+        - name: TNS_ADMIN
+          value: /etc/tnsnames.ora
+        ports:
+        - containerPort: 9255
+          protocol: TCP
+          name: dbs
+        resources:
+          requests:
+            memory: 100Mi
+            cpu: 200m
+          limits:
+            memory: 500Mi
+            cpu: 4000m
+        volumeMounts:
+        - name: proxy-secrets
+          mountPath: /etc/proxy
+          readOnly: true
+        - name: secrets
+          mountPath: /etc/secrets
+          readOnly: true
+        - name: robot-secrets
+          mountPath: /etc/robots
+          readOnly: true
+        - name: hmac-secrets
+          mountPath: /etc/hmac
+          readOnly: true
+        - name: token-secrets
+          mountPath: /etc/token
+          readOnly: true
+        - name: tnsnames
+          mountPath: /etc/tnsnames.ora
+          subPath: tnsnames.ora
+        securityContext:
+          allowPrivilegeEscalation: false
+      volumes:
+      - name: proxy-secrets
+        secret:
+          secretName: proxy-secrets
+      - name: robot-secrets
+        secret:
+          secretName: robot-secrets
+      - name: hmac-secrets
+        secret:
+          secretName: hmac-secrets
+      - name: secrets
+        secret:
+          secretName: dbs2go-phys03-w-secrets
+      - name: tnsnames
+        configMap:
+          name: tnsnames-config
+      - name: token-secrets
+        secret:
+          secretName: token-secrets
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: dbs2go-phys03-w-dev-network-policy
+  namespace: dbs
+spec:
+  podSelector:
+    matchLabels:
+      app: dbs2go-phys03-w-dev
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: auth
+      podSelector:
+        matchExpressions:
+        - key: app
+          operator: In
+          values:
+          - frontend
+          - auth-proxy-server
+          - scitokens-proxy-server
+          - x509-proxy-server
+    ports:
+    - protocol: TCP
+      port: 9255


### PR DESCRIPTION
## Summary

  Add a dedicated dbs2go-global-r-dev Kubernetes Service and Deployment to support the fast development workflow proposed in dbs2go issue : https://github.com/dmwm/dbs2go/issues/160.

  The development pod:

  - uses registry.cern.ch/cmsweb/dbs2go:dev;
  - provides the standard DBS Oracle runtime and mounted configuration/Secrets;
  - remains idle until a locally developed payload is copied and started;
  - can receive traffic by redirecting the regular dbs2go-global-r Service selector;
  - includes the corresponding development NetworkPolicy.

  This is initially a Reader pilot and does not change the normal release or production deployment workflow.
